### PR TITLE
feat: M2-1 学習画面シェルとコンテンツデータを追加

### DIFF
--- a/apps/web/src/components/LearningSidebar.tsx
+++ b/apps/web/src/components/LearningSidebar.tsx
@@ -1,0 +1,36 @@
+import { Link } from 'react-router-dom'
+import type { LearningStepContent } from '../content/fundamentals/steps'
+
+interface LearningSidebarProps {
+  currentStepId: string
+  steps: LearningStepContent[]
+}
+
+export function LearningSidebar({ currentStepId, steps }: LearningSidebarProps) {
+  return (
+    <aside className="w-full rounded-2xl border border-slate-200 bg-white p-4 shadow-sm lg:w-72">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">React基礎コース</p>
+      <ul className="mt-3 space-y-2">
+        {steps.map((step) => {
+          const isCurrent = step.id === currentStepId
+
+          return (
+            <li key={step.id}>
+              <Link
+                className={`block rounded-lg border px-3 py-2 text-sm transition ${
+                  isCurrent
+                    ? 'border-blue-300 bg-blue-50 text-blue-900'
+                    : 'border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50'
+                }`}
+                to={`/step/${step.id}`}
+              >
+                <p className="text-xs text-slate-500">STEP {step.order}</p>
+                <p className="font-medium">{step.title}</p>
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </aside>
+  )
+}

--- a/apps/web/src/content/fundamentals/steps.ts
+++ b/apps/web/src/content/fundamentals/steps.ts
@@ -1,0 +1,155 @@
+export type LearningMode = 'read' | 'practice' | 'test' | 'challenge'
+
+export interface PracticeQuestion {
+  id: string
+  prompt: string
+  answer: string
+  hint: string
+}
+
+export interface TestTask {
+  instruction: string
+  starterCode: string
+  expectedKeywords: string[]
+}
+
+export interface ChallengeTask {
+  prompt: string
+  requirements: string[]
+  hints: string[]
+}
+
+export interface LearningStepContent {
+  id: string
+  order: number
+  title: string
+  summary: string
+  readMarkdown: string
+  practiceQuestions: PracticeQuestion[]
+  testTask: TestTask
+  challengeTask: ChallengeTask
+}
+
+export const fundamentalsSteps: LearningStepContent[] = [
+  {
+    id: 'usestate-basic',
+    order: 1,
+    title: 'useState基礎',
+    summary: '状態管理の基本を学び、ユーザー操作で値が変わるUIを作る。',
+    readMarkdown: `# useStateの基本
+
+- \`useState\` は関数コンポーネントで状態を持つためのHookです。
+- \`const [count, setCount] = useState(0)\` のように定義します。
+- setterを呼ぶと再レンダリングされ、画面に最新の状態が反映されます。`,
+    practiceQuestions: [
+      {
+        id: 'q1',
+        prompt: 'stateを更新する関数名は何ですか？（countの例）',
+        answer: 'setCount',
+        hint: '`const [count, ???] = useState(0)` の形を思い出してください。',
+      },
+    ],
+    testTask: {
+      instruction: 'ボタンを押すと count が 1 増えるように空欄を埋めてください。',
+      starterCode: `const [count, setCount] = useState(0)
+return <button onClick={() => ____}>+1 ({count})</button>`,
+      expectedKeywords: ['setCount', 'count + 1'],
+    },
+    challengeTask: {
+      prompt: 'いいねボタンを実装し、クリックで数値が増えるコンポーネントを作ってください。',
+      requirements: ['初期値0から開始する', 'クリックで+1される', '現在値を表示する'],
+      hints: ['まず state を 1 つ定義する', 'イベントハンドラで setter を呼ぶ'],
+    },
+  },
+  {
+    id: 'events',
+    order: 2,
+    title: 'イベント処理',
+    summary: 'onClick や onChange を使ってユーザー入力を処理する。',
+    readMarkdown: `# イベント処理
+
+- Reactのイベント名はキャメルケース（例: \`onClick\`）です。
+- イベントハンドラには関数を渡します。
+- フォーム入力では \`event.target.value\` を使います。`,
+    practiceQuestions: [
+      {
+        id: 'q1',
+        prompt: '入力欄の変更イベントで使うプロパティ名は？',
+        answer: 'onChange',
+        hint: '`input` の値変更で発火するイベントです。',
+      },
+    ],
+    testTask: {
+      instruction: 'ボタン押下時に "clicked" をコンソール出力してください。',
+      starterCode: `<button ____={() => console.log('clicked')}>Run</button>`,
+      expectedKeywords: ['onClick'],
+    },
+    challengeTask: {
+      prompt: '入力値をリアルタイム表示するフォームを作成してください。',
+      requirements: ['入力欄を1つ置く', '入力値を下に表示する', '表示は即時反映される'],
+      hints: ['onChange で値を受け取る', 'useStateで保持する'],
+    },
+  },
+  {
+    id: 'conditional',
+    order: 3,
+    title: '条件付きレンダリング',
+    summary: '条件によって表示する要素を切り替える。',
+    readMarkdown: `# 条件付きレンダリング
+
+- \`if\` 文で分岐して JSX を返せます。
+- JSX 内では三項演算子（\`condition ? A : B\`）や \`&&\` が使えます。
+- ログイン状態などの切り替え表現で多用します。`,
+    practiceQuestions: [
+      {
+        id: 'q1',
+        prompt: '条件が真の時だけ表示したい場合によく使う演算子は？',
+        answer: '&&',
+        hint: '短絡評価を使う記法です。',
+      },
+    ],
+    testTask: {
+      instruction: 'isLoggedIn が true の時だけ Welcome を表示してください。',
+      starterCode: `{isLoggedIn ____ <p>Welcome</p>}`,
+      expectedKeywords: ['&&'],
+    },
+    challengeTask: {
+      prompt: '切替ボタンで「表示中/非表示」を切り替えるUIを作ってください。',
+      requirements: ['表示状態をstateで持つ', 'ボタンで反転する', '文言を条件分岐で表示する'],
+      hints: ['booleanのstateを使う', 'setState(prev => !prev) を使う'],
+    },
+  },
+  {
+    id: 'lists',
+    order: 4,
+    title: 'リスト表示',
+    summary: '配列データを map で描画し、key を適切に設定する。',
+    readMarkdown: `# リスト表示
+
+- 配列は \`array.map\` で JSX に変換します。
+- それぞれの要素には安定した \`key\` を渡します。
+- key には index よりも一意なIDを使うのが基本です。`,
+    practiceQuestions: [
+      {
+        id: 'q1',
+        prompt: 'リスト描画で必須になる属性名は？',
+        answer: 'key',
+        hint: 'Reactが差分更新で使う識別子です。',
+      },
+    ],
+    testTask: {
+      instruction: 'items を li で描画し、id を key に指定してください。',
+      starterCode: `{items.map((item) => <li ____>{item.name}</li>)}`,
+      expectedKeywords: ['key={item.id}'],
+    },
+    challengeTask: {
+      prompt: 'Todo配列を受け取り、未完了件数を表示するリストを実装してください。',
+      requirements: ['mapで一覧描画する', 'keyを設定する', '未完了件数を表示する'],
+      hints: ['filter で未完了を抽出', 'lengthで件数を算出'],
+    },
+  },
+]
+
+export function getFundamentalsStep(stepId: string) {
+  return fundamentalsSteps.find((step) => step.id === stepId)
+}

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -1,22 +1,57 @@
+import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
+import { LearningSidebar } from '../components/LearningSidebar'
+import { fundamentalsSteps, getFundamentalsStep, type LearningMode } from '../content/fundamentals/steps'
 import { useAuth } from '../contexts/AuthContext'
 
 export function StepPage() {
-  const { stepId } = useParams()
+  const { stepId = '' } = useParams()
   const { signOut } = useAuth()
   const navigate = useNavigate()
+  const [activeMode, setActiveMode] = useState<LearningMode>('read')
+  const [practiceDraft, setPracticeDraft] = useState('')
+  const [showHint, setShowHint] = useState(false)
+
+  const step = getFundamentalsStep(stepId)
+
+  useEffect(() => {
+    setActiveMode('read')
+    setPracticeDraft('')
+    setShowHint(false)
+  }, [stepId])
 
   async function handleSignOut() {
     await signOut()
     navigate('/login', { replace: true })
   }
 
+  if (!step) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-4xl flex-col gap-6 px-6 py-16">
+        <h1 className="text-3xl font-bold">指定したステップが見つかりません</h1>
+        <p className="text-slate-600">stepId: {stepId}</p>
+        <Link className="text-sm font-medium text-blue-700 underline" to="/step/usestate-basic">
+          最初のステップへ戻る
+        </Link>
+      </main>
+    )
+  }
+
+  const modeButtons: { id: LearningMode; label: string }[] = [
+    { id: 'read', label: 'Read' },
+    { id: 'practice', label: 'Practice' },
+    { id: 'test', label: 'Test' },
+    { id: 'challenge', label: 'Challenge' },
+  ]
+
+  const currentPractice = step.practiceQuestions[0]
+
   return (
-    <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-6 px-6 py-16">
+    <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-6 py-10">
       <header className="flex items-center justify-between gap-4">
         <div className="space-y-2">
-          <h1 className="text-3xl font-bold">学習画面</h1>
-          <p className="text-slate-600">stepId: {stepId}</p>
+          <h1 className="text-3xl font-bold">{step.title}</h1>
+          <p className="text-slate-600">{step.summary}</p>
         </div>
         <button
           className="rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
@@ -27,12 +62,88 @@ export function StepPage() {
         </button>
       </header>
 
-      <section className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-        <p className="text-sm text-slate-700">M2で4タブUI（Read/Practice/Test/Challenge）を実装します。</p>
+      <section className="flex flex-col gap-4 lg:flex-row lg:items-start">
+        <LearningSidebar currentStepId={stepId} steps={fundamentalsSteps} />
+
+        <div className="flex-1 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-500">stepId: {step.id}</p>
+
+          <div className="mt-4 flex flex-wrap gap-2 border-b border-slate-200 pb-4">
+            {modeButtons.map((mode) => {
+              const isActive = activeMode === mode.id
+
+              return (
+                <button
+                  key={mode.id}
+                  className={`rounded-md px-3 py-2 text-sm font-medium transition ${
+                    isActive ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
+                  }`}
+                  type="button"
+                  onClick={() => setActiveMode(mode.id)}
+                >
+                  {mode.label}
+                </button>
+              )
+            })}
+          </div>
+
+          {activeMode === 'read' ? (
+            <section className="mt-4 space-y-3">
+              <h2 className="text-lg font-semibold">Read</h2>
+              <pre className="whitespace-pre-wrap rounded-lg bg-slate-50 p-4 text-sm text-slate-800">
+                {step.readMarkdown}
+              </pre>
+            </section>
+          ) : null}
+
+          {activeMode === 'practice' ? (
+            <section className="mt-4 space-y-3">
+              <h2 className="text-lg font-semibold">Practice</h2>
+              <p className="text-sm text-slate-700">{currentPractice.prompt}</p>
+              <input
+                className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+                placeholder="回答を入力"
+                value={practiceDraft}
+                onChange={(event) => setPracticeDraft(event.target.value)}
+              />
+              <button
+                className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 hover:bg-slate-50"
+                type="button"
+                onClick={() => setShowHint((prev) => !prev)}
+              >
+                ヒントを{showHint ? '隠す' : '表示'}
+              </button>
+              {showHint ? <p className="text-sm text-blue-700">{currentPractice.hint}</p> : null}
+            </section>
+          ) : null}
+
+          {activeMode === 'test' ? (
+            <section className="mt-4 space-y-3">
+              <h2 className="text-lg font-semibold">Test</h2>
+              <p className="text-sm text-slate-700">{step.testTask.instruction}</p>
+              <pre className="rounded-lg bg-slate-50 p-4 text-sm text-slate-800">{step.testTask.starterCode}</pre>
+            </section>
+          ) : null}
+
+          {activeMode === 'challenge' ? (
+            <section className="mt-4 space-y-3">
+              <h2 className="text-lg font-semibold">Challenge</h2>
+              <p className="text-sm text-slate-700">{step.challengeTask.prompt}</p>
+              <ul className="list-inside list-disc space-y-1 text-sm text-slate-700">
+                {step.challengeTask.requirements.map((requirement) => (
+                  <li key={requirement}>{requirement}</li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+        </div>
       </section>
-      <Link className="text-sm font-medium text-blue-700 underline" to="/">
-        ダッシュボードへ戻る
-      </Link>
+
+      <div className="flex gap-4 text-sm">
+        <Link className="font-medium text-blue-700 underline" to="/">
+          ダッシュボードへ戻る
+        </Link>
+      </div>
     </main>
   )
 }


### PR DESCRIPTION
## 概要
- /step/:stepId の学習画面シェルを実装
- ステップサイドバーを追加し、React基礎4ステップへ遷移可能に変更
- fundamentals向けの静的コンテンツデータ（Read/Practice/Test/Challenge）を追加
- stepId 変更時に ctiveMode / 入力値 / ヒント表示を useEffect でリセット

## 変更ファイル
- pps/web/src/pages/StepPage.tsx
- pps/web/src/components/LearningSidebar.tsx
- pps/web/src/content/fundamentals/steps.ts

## 検証
- cmd /c npm run typecheck（apps/web）: pass
- cmd /c npm run build（apps/web）: pass

## Issue要否
- 不要（docs/roadmaps/roadmap01.md のM2-1タスクに含まれるため）