### PR TITLE
fix: M3-1 通しテストとバグ修正

### DIFF
--- a/apps/web/docs/m3-1-manual-test-checklist.md
+++ b/apps/web/docs/m3-1-manual-test-checklist.md
@@ -1,0 +1,40 @@
+# M3-1 手動テストチェックリスト（20項目）
+
+実施日: 2026-02-20  
+対象ブランチ: `feat/m3-testing_3-1-manual-test`
+
+## 実施結果
+
+| No | 観点 | 結果 | 根拠 |
+|---|---|---|---|
+| 1 | `/login` が未認証向けに公開されている | PASS | `apps/web/src/main.tsx` で `GuestRoute` を適用 |
+| 2 | `/` が認証必須で保護されている | PASS | `apps/web/src/main.tsx` で `ProtectedRoute` を適用 |
+| 3 | `/step/:stepId` が認証必須で保護されている | PASS | `apps/web/src/main.tsx` で `ProtectedRoute` を適用 |
+| 4 | Auth初期化時に `getSession()` フォールバックがある | PASS | `apps/web/src/contexts/AuthContext.tsx` |
+| 5 | `onAuthStateChange` が `try-catch-finally` で保護されている | PASS | `apps/web/src/contexts/AuthContext.tsx` |
+| 6 | `finally` で `setIsLoading(false)` が保証される | PASS | `apps/web/src/contexts/AuthContext.tsx` |
+| 7 | ステップ画面で4モードタブが表示される | PASS | `apps/web/src/pages/StepPage.tsx` |
+| 8 | `stepId` 変更時にタブ状態が初期化される | PASS | `apps/web/src/pages/StepPage.tsx` の `setActiveMode('read')` |
+| 9 | 進捗取得 (`getStepProgress`) で初期状態を復元する | PASS | `apps/web/src/pages/StepPage.tsx` |
+| 10 | モード完了時に `updateModeCompletion` でUPSERTする | PASS | `apps/web/src/pages/StepPage.tsx` |
+| 11 | ReadモードでMarkdownを描画できる | PASS | `apps/web/src/features/learning/ReadMode.tsx` |
+| 12 | Readモードでコードコピー失敗時のフォールバックがある | PASS | `apps/web/src/features/learning/ReadMode.tsx` |
+| 13 | Practiceモードで即時正誤判定がある | PASS | `apps/web/src/features/learning/PracticeMode.tsx` |
+| 14 | Practiceモードでヒント表示切替ができる | PASS | `apps/web/src/features/learning/PracticeMode.tsx` |
+| 15 | Testモードでキーワード判定と合格表示がある | PASS | `apps/web/src/features/learning/TestMode.tsx` |
+| 16 | ChallengeモードでMonaco遅延ロードがある | PASS | `apps/web/src/features/learning/ChallengeMode.tsx` |
+| 17 | Challengeモードでキーワードベース判定がある | PASS | `apps/web/src/features/learning/ChallengeMode.tsx` |
+| 18 | `step_progress` にRLSと `auth.uid()=user_id` 制約がある | PASS | `apps/web/supabase/sql/001_schema_and_rls.sql` |
+| 19 | 認証導線のブラウザE2E確認（ログイン/ログアウト遷移） | BLOCKED | ローカル環境で有効な Supabase 接続情報が未設定 |
+| 20 | ユーザー間の進捗分離（RLS実データ確認） | BLOCKED | ローカル環境で複数ユーザーの実DB検証が未実施 |
+
+## 実行コマンド
+
+- `cmd /c npm run typecheck` : PASS
+- `cmd /c npm run build` : PASS（chunk size warningあり、ビルド成功）
+
+## バグ修正（M3-1内で対応）
+
+1. Auth状態変化コールバックを `try-catch-finally` 化し、`isLoading` 永続化リスクを低減。  
+2. Step画面のログアウト失敗時にエラーメッセージを表示するよう修正。  
+3. Readモードのコードコピーで Clipboard API 非対応/失敗時のフォールバック文言を追加。  

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -28,20 +28,31 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((event, nextSession) => {
+    } = supabase.auth.onAuthStateChange(async (event, nextSession) => {
       if (!isMounted) {
         return
       }
 
-      if (event === 'SIGNED_OUT' || !nextSession?.user) {
+      try {
+        if (event === 'SIGNED_OUT' || !nextSession?.user) {
+          setSession(null)
+          setUser(null)
+        } else {
+          setSession(nextSession)
+          setUser(nextSession.user)
+        }
+      } catch {
+        if (!isMounted) {
+          return
+        }
+
         setSession(null)
         setUser(null)
-      } else {
-        setSession(nextSession)
-        setUser(nextSession.user)
+      } finally {
+        if (isMounted) {
+          setIsLoading(false)
+        }
       }
-
-      setIsLoading(false)
     })
 
     supabase.auth

--- a/apps/web/src/features/learning/ReadMode.tsx
+++ b/apps/web/src/features/learning/ReadMode.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import Prism from 'prismjs'
@@ -14,6 +14,8 @@ interface ReadModeProps {
 }
 
 export function ReadMode({ markdown, onComplete }: ReadModeProps) {
+  const [copyMessage, setCopyMessage] = useState<string | null>(null)
+
   useEffect(() => {
     Prism.highlightAll()
   }, [markdown])
@@ -49,7 +51,17 @@ export function ReadMode({ markdown, onComplete }: ReadModeProps) {
               }
 
               async function handleCopy() {
-                await navigator.clipboard.writeText(codeText)
+                if (!navigator.clipboard) {
+                  setCopyMessage('この環境ではコピー機能を利用できません。')
+                  return
+                }
+
+                try {
+                  await navigator.clipboard.writeText(codeText)
+                  setCopyMessage('コードをコピーしました。')
+                } catch {
+                  setCopyMessage('コードのコピーに失敗しました。')
+                }
               }
 
               return (
@@ -77,6 +89,7 @@ export function ReadMode({ markdown, onComplete }: ReadModeProps) {
           {markdown}
         </ReactMarkdown>
       </article>
+      {copyMessage ? <p className="text-sm text-slate-600">{copyMessage}</p> : null}
     </section>
   )
 }

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -104,7 +104,11 @@ export function StepPage() {
   )
 
   async function handleSignOut() {
-    await signOut()
+    const errorMessage = await signOut()
+    if (errorMessage) {
+      setSyncMessage(errorMessage)
+      return
+    }
     navigate('/login', { replace: true })
   }
 


### PR DESCRIPTION
## 概要
- M3-1向けに20項目の手動テストチェックリストを追加し、実施結果を記録
- 通しテスト観点で見つかった不具合を修正
  - AuthContext: onAuthStateChange を try-catch-finally で保護
  - StepPage: ログアウト失敗時にエラー表示
  - ReadMode: Clipboard API 非対応/失敗時のフォールバック文言追加

## 変更ファイル
- pps/web/docs/m3-1-manual-test-checklist.md
- pps/web/src/contexts/AuthContext.tsx
- pps/web/src/pages/StepPage.tsx
- pps/web/src/features/learning/ReadMode.tsx

## 検証
- cmd /c npm run typecheck（apps/web）: pass
- cmd /c npm run build（apps/web）: pass
  - 備考: Monaco由来のchunk size warningは出るがビルド成功

## チェックリスト結果
- 20項目中: PASS 18 / BLOCKED 2
- BLOCKED理由: Supabase接続情報未設定のため、実DBでの認証導線・RLS分離の実測は未実施

## Issue要否
- 不要（docs/roadmaps/roadmap01.md のM3-1タスクに含まれるため）