### PR TITLE
docs: M3-2 最終成果物の手順とテスト情報を整備

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,24 +1,75 @@
-# Coden Web (M1-1)
+# Coden Web（MVP）
 
-## セットアップ
+React学習プラットフォーム Coden のMVPフロントエンドです。
+
+## 前提環境
+
+- Node.js 22 系推奨
+- npm
+- Supabase プロジェクト（Auth / DB）
+- Windows PowerShell 5.1 利用時は `cmd /c npm ...` で実行
+
+## ローカル起動手順
 
 ```bash
 cd apps/web
 npm install
-npm run dev
+copy .env.local.example .env.local
 ```
 
-## 必須環境変数
-
-`apps/web/.env.local.example` を `apps/web/.env.local` にコピーして設定:
+`.env.local` に以下を設定してください。
 
 - `VITE_SUPABASE_URL`
 - `VITE_SUPABASE_ANON_KEY`
 - `VITE_API_BASE_URL`
 
-## Supabase SQL
+その後、以下で開発サーバーを起動します。
+
+```bash
+cmd /c npm run dev
+```
+
+## 品質チェック
+
+```bash
+cmd /c npm run typecheck
+cmd /c npm run build
+```
+
+## Supabase SQL 適用順
 
 1. `apps/web/supabase/sql/001_schema_and_rls.sql`
 2. `apps/web/supabase/sql/002_seed_test_users.sql`
 
-の順に実行してください。
+## テストユーザー
+
+`002_seed_test_users.sql` 適用後、以下でログインできます。
+
+- Email: `test01@coden.dev` / Password: `TestPass123!`
+- Email: `test02@coden.dev` / Password: `TestPass123!`
+
+## MVP機能（M1〜M2）
+
+- 認証（ログイン/ログアウト）
+- 保護ルート（`/`、`/step/:stepId`）
+- ダッシュボード（完了ステップ数表示）
+- 学習画面4モード（Read / Practice / Test / Challenge）
+- `step_progress` への進捗保存（UPSERT）
+
+## M3-1 手動テスト結果
+
+詳細は `apps/web/docs/m3-1-manual-test-checklist.md` を参照してください。
+
+- 20項目中: PASS 18 / BLOCKED 2
+- BLOCKED理由:
+  - Supabase接続情報未設定環境では実DBを使った認証導線確認ができない
+  - 複数ユーザーでのRLS分離の実測には実DB接続が必要
+
+## M3-2 ユーザーテスト開始条件
+
+ユーザーテスト開始は以下を満たした時点とします。
+
+1. `apps/web/.env.local` に本番または検証用 Supabase 接続情報が設定済み
+2. SQL 2本の適用が完了している
+3. 上記テストユーザーでログイン可能
+4. `cmd /c npm run typecheck` と `cmd /c npm run build` が成功

--- a/apps/web/docs/m3-1-manual-test-checklist.md
+++ b/apps/web/docs/m3-1-manual-test-checklist.md
@@ -1,40 +1,21 @@
 # M3-1 手動テストチェックリスト（20項目）
 
 実施日: 2026-02-20  
-対象ブランチ: `feat/m3-testing_3-1-manual-test`
+対象: Coden Web MVP
 
-## 実施結果
+## 結果サマリー
 
-| No | 観点 | 結果 | 根拠 |
-|---|---|---|---|
-| 1 | `/login` が未認証向けに公開されている | PASS | `apps/web/src/main.tsx` で `GuestRoute` を適用 |
-| 2 | `/` が認証必須で保護されている | PASS | `apps/web/src/main.tsx` で `ProtectedRoute` を適用 |
-| 3 | `/step/:stepId` が認証必須で保護されている | PASS | `apps/web/src/main.tsx` で `ProtectedRoute` を適用 |
-| 4 | Auth初期化時に `getSession()` フォールバックがある | PASS | `apps/web/src/contexts/AuthContext.tsx` |
-| 5 | `onAuthStateChange` が `try-catch-finally` で保護されている | PASS | `apps/web/src/contexts/AuthContext.tsx` |
-| 6 | `finally` で `setIsLoading(false)` が保証される | PASS | `apps/web/src/contexts/AuthContext.tsx` |
-| 7 | ステップ画面で4モードタブが表示される | PASS | `apps/web/src/pages/StepPage.tsx` |
-| 8 | `stepId` 変更時にタブ状態が初期化される | PASS | `apps/web/src/pages/StepPage.tsx` の `setActiveMode('read')` |
-| 9 | 進捗取得 (`getStepProgress`) で初期状態を復元する | PASS | `apps/web/src/pages/StepPage.tsx` |
-| 10 | モード完了時に `updateModeCompletion` でUPSERTする | PASS | `apps/web/src/pages/StepPage.tsx` |
-| 11 | ReadモードでMarkdownを描画できる | PASS | `apps/web/src/features/learning/ReadMode.tsx` |
-| 12 | Readモードでコードコピー失敗時のフォールバックがある | PASS | `apps/web/src/features/learning/ReadMode.tsx` |
-| 13 | Practiceモードで即時正誤判定がある | PASS | `apps/web/src/features/learning/PracticeMode.tsx` |
-| 14 | Practiceモードでヒント表示切替ができる | PASS | `apps/web/src/features/learning/PracticeMode.tsx` |
-| 15 | Testモードでキーワード判定と合格表示がある | PASS | `apps/web/src/features/learning/TestMode.tsx` |
-| 16 | ChallengeモードでMonaco遅延ロードがある | PASS | `apps/web/src/features/learning/ChallengeMode.tsx` |
-| 17 | Challengeモードでキーワードベース判定がある | PASS | `apps/web/src/features/learning/ChallengeMode.tsx` |
-| 18 | `step_progress` にRLSと `auth.uid()=user_id` 制約がある | PASS | `apps/web/supabase/sql/001_schema_and_rls.sql` |
-| 19 | 認証導線のブラウザE2E確認（ログイン/ログアウト遷移） | BLOCKED | ローカル環境で有効な Supabase 接続情報が未設定 |
-| 20 | ユーザー間の進捗分離（RLS実データ確認） | BLOCKED | ローカル環境で複数ユーザーの実DB検証が未実施 |
+- PASS: 18
+- BLOCKED: 2
 
-## 実行コマンド
+## BLOCKED項目
 
-- `cmd /c npm run typecheck` : PASS
-- `cmd /c npm run build` : PASS（chunk size warningあり、ビルド成功）
+1. 認証導線の実DB E2E確認  
+理由: 実行環境に Supabase 接続情報が未設定
+2. 複数ユーザーでのRLS分離確認  
+理由: 実DB接続と複数ユーザーでの実測が必要
 
-## バグ修正（M3-1内で対応）
+## 補足
 
-1. Auth状態変化コールバックを `try-catch-finally` 化し、`isLoading` 永続化リスクを低減。  
-2. Step画面のログアウト失敗時にエラーメッセージを表示するよう修正。  
-3. Readモードのコードコピーで Clipboard API 非対応/失敗時のフォールバック文言を追加。  
+- 静的確認（ルート保護、Authハンドリング、進捗保存導線、RLS SQL定義）は実施済み。
+- `cmd /c npm run typecheck` と `cmd /c npm run build` は成功。


### PR DESCRIPTION
## 概要
- pps/web/README.md をMVP現状に合わせて更新
- ローカル起動手順、必須環境変数、SQL適用順、テストユーザー情報を明記
- M3-1手動テスト結果（PASS/BLOCKED）と、M3-2のユーザーテスト開始条件を追記
- pps/web/docs/m3-1-manual-test-checklist.md を同ブランチで参照可能な内容へ整理

## 変更ファイル
- pps/web/README.md
- pps/web/docs/m3-1-manual-test-checklist.md

## 検証
- cmd /c npm run typecheck（apps/web）: pass
- cmd /c npm run build（apps/web）: pass
  - 備考: Monaco由来のchunk size warningは出るがビルド成功

## Issue要否
- 不要（docs/roadmaps/roadmap01.md の M3-2 タスクで管理済み）