### PR TITLE
feat: M2-1 デザインシステム移植とTailwind設定

### DIFF
--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -1,18 +1,46 @@
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;700;900&family=Nunito:wght@600;700;800&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 :root {
-  font-family: 'Noto Sans JP', 'Hiragino Kaku Gothic ProN', Meiryo, sans-serif;
-  color: #0f172a;
-  background: radial-gradient(circle at top left, #e0f2fe 0%, #f8fafc 45%, #ffffff 100%);
+  --primary-mint: #2cc295;
+  --primary-dark: #1e9e78;
+  --secondary-bg: #f0fdf9;
+  --text-dark: #1f2937;
+  --text-light: #6b7280;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
+  font-family: 'Noto Sans JP', sans-serif;
+  color: var(--text-dark);
+  background-color: #f9fafb;
 }
 
 * {
   box-sizing: border-box;
+}
+
+@layer base {
+  html,
+  body,
+  #root {
+    min-height: 100%;
+  }
+}
+
+@layer utilities {
+  .font-display {
+    font-family: 'Nunito', sans-serif;
+  }
+
+  .glass-card {
+    background: rgba(255, 255, 255, 0.95);
+    backdrop-filter: blur(10px);
+    border: 1px solid rgba(255, 255, 255, 0.5);
+    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  }
 }

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -2,7 +2,25 @@
 export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        'primary-mint': '#2CC295',
+        'primary-dark': '#1E9E78',
+        'secondary-bg': '#F0FDF9',
+        'text-dark': '#1F2937',
+        'text-light': '#6B7280',
+      },
+      fontFamily: {
+        sans: ['"Noto Sans JP"', 'sans-serif'],
+        display: ['Nunito', 'sans-serif'],
+      },
+      backgroundImage: {
+        'mint-gradient': 'linear-gradient(135deg, #2CC295 0%, #4FD1C5 100%)',
+      },
+      boxShadow: {
+        glass: '0 10px 30px rgba(15, 23, 42, 0.08)',
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## 概要
- roadmap02 の M2-1（タスク1）として Tailwind テーマ拡張を追加
- primary-mint などのカラートークン、Noto Sans JP / Nunito のフォントトークンを定義
- globals.css に Google Fonts、ベーススタイル、ont-display / glass-card ユーティリティを追加

## 変更ファイル
- apps/web/tailwind.config.js
- apps/web/src/styles/globals.css

## 検証
- cmd /c npm run typecheck : 成功
- cmd /c npm run build : 成功

## Issue要否
- 不要
- 根拠: roadmap02 に M2-1 タスクが既に定義されており、タスク管理の二重化を避けるため