### PR TITLE
feat: M2-2 ダッシュボード共通レイアウトを刷新

### DIFF
--- a/apps/web/src/features/dashboard/components/AppHeader.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeader.tsx
@@ -1,0 +1,41 @@
+interface AppHeaderProps {
+  displayName: string
+  onSignOut: () => void
+}
+
+export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
+  return (
+    <header className="sticky top-0 z-40 border-b border-slate-200/70 bg-white/90 backdrop-blur">
+      <div className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
+        <div className="flex items-center gap-8">
+          <div className="flex items-center gap-2">
+            <div className="grid h-10 w-10 place-items-center rounded-xl bg-mint-gradient text-lg font-black text-white shadow-glass">
+              C
+            </div>
+            <span className="font-display text-2xl font-bold tracking-tight text-primary-mint">Coden</span>
+          </div>
+
+          <nav className="hidden items-center gap-5 text-sm font-medium text-slate-500 md:flex">
+            <span className="border-b-2 border-primary-mint pb-1 text-slate-900">ダッシュボード</span>
+            <span>コース一覧</span>
+            <span>コミュニティ</span>
+          </nav>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <div className="hidden rounded-full border border-primary-mint/30 bg-secondary-bg px-3 py-1 text-xs font-semibold text-primary-dark sm:block">
+            🔥 3日連続
+          </div>
+          <div className="hidden text-sm font-medium text-slate-600 sm:block">{displayName}</div>
+          <button
+            className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-50"
+            type="button"
+            onClick={onSignOut}
+          >
+            ログアウト
+          </button>
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/apps/web/src/features/dashboard/components/DashboardSidebar.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardSidebar.tsx
@@ -1,0 +1,81 @@
+const HEATMAP_LEVELS = [0, 1, 2, 1, 0, 3, 2, 0, 0, 1, 2, 3, 1, 0, 0, 0, 2, 1, 3, 2, 0, 1, 2, 3, 1, 0, 2, 1]
+
+function heatmapColor(level: number) {
+  if (level === 3) return 'bg-primary-dark'
+  if (level === 2) return 'bg-primary-mint'
+  if (level === 1) return 'bg-emerald-200'
+  return 'bg-slate-100'
+}
+
+export function DashboardSidebar() {
+  return (
+    <aside className="space-y-5">
+      <section className="relative overflow-hidden rounded-2xl border border-emerald-100 bg-white shadow-sm">
+        <div className="bg-mint-gradient px-5 py-4">
+          <h3 className="font-bold text-white">学習ステータス</h3>
+        </div>
+        <div className="space-y-4 p-5">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="rounded-xl border border-orange-100 bg-orange-50 p-3 text-center">
+              <p className="text-[10px] font-bold uppercase tracking-wide text-orange-600">連続学習</p>
+              <p className="mt-1 text-2xl font-black text-orange-700">3日</p>
+            </div>
+            <div className="rounded-xl border border-indigo-100 bg-indigo-50 p-3 text-center">
+              <p className="text-[10px] font-bold uppercase tracking-wide text-indigo-600">合計ポイント</p>
+              <p className="mt-1 text-2xl font-black text-indigo-700">450pt</p>
+            </div>
+          </div>
+
+          <div>
+            <div className="mb-1 flex justify-between text-xs font-semibold text-text-light">
+              <span>次のレベルまで</span>
+              <span className="text-primary-mint">50 / 500 pt</span>
+            </div>
+            <div className="h-2 w-full overflow-hidden rounded-full bg-slate-100">
+              <div className="h-full w-[10%] rounded-full bg-mint-gradient" />
+            </div>
+          </div>
+
+          <div>
+            <p className="mb-2 text-xs font-bold uppercase tracking-wide text-text-light">獲得バッジ</p>
+            <div className="flex items-center justify-between text-xl">
+              <span className="grid h-10 w-10 place-items-center rounded-full border border-yellow-200 bg-yellow-100">✅</span>
+              <span className="grid h-10 w-10 place-items-center rounded-full border border-orange-200 bg-orange-100">🔥</span>
+              <span className="grid h-10 w-10 place-items-center rounded-full border border-blue-200 bg-blue-100">💻</span>
+              <span className="grid h-10 w-10 place-items-center rounded-full border border-slate-300 bg-slate-100 text-slate-400">
+                🔒
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="pointer-events-none absolute -bottom-6 -right-6 h-20 w-20 rounded-full bg-yellow-300/20 blur-2xl" />
+      </section>
+
+      <section className="rounded-2xl border border-slate-100 bg-white p-5 shadow-sm">
+        <div className="mb-3 flex items-center justify-between">
+          <h3 className="text-sm font-bold text-text-dark">学習ヒートマップ</h3>
+          <span className="text-xs text-text-light">過去30日</span>
+        </div>
+        <div className="flex flex-wrap gap-1.5">
+          {HEATMAP_LEVELS.map((level, index) => (
+            <span key={`${level}-${index}`} className={`h-3 w-3 rounded-sm ${heatmapColor(level)}`} />
+          ))}
+        </div>
+        <p className="mt-3 text-center text-xs text-text-light">
+          今月は <span className="font-bold text-text-dark">12日</span> 学習しました
+        </p>
+      </section>
+
+      <section className="rounded-2xl bg-gradient-to-br from-indigo-600 to-sky-600 p-5 text-white shadow-sm">
+        <p className="mb-2 inline-block rounded bg-white/20 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide">
+          Daily Challenge
+        </p>
+        <h3 className="font-bold">ボーナス問題を解く</h3>
+        <p className="mt-1 text-sm text-indigo-100">React Hooks クイズに正解して +50pt を獲得しましょう。</p>
+        <button className="mt-4 w-full rounded-lg bg-white py-2 text-sm font-semibold text-indigo-700 transition hover:bg-indigo-50" type="button">
+          チャレンジ開始
+        </button>
+      </section>
+    </aside>
+  )
+}

--- a/apps/web/src/features/dashboard/components/LearningOverviewCard.tsx
+++ b/apps/web/src/features/dashboard/components/LearningOverviewCard.tsx
@@ -1,0 +1,103 @@
+import { Link } from 'react-router-dom'
+
+interface LearningOverviewCardProps {
+  completedCount: number
+  totalSteps: number
+}
+
+const LEARNING_PATH = [
+  {
+    id: 'usestate-basic',
+    title: 'Step 1: useState基礎',
+    status: '完了',
+    description: '状態管理の基本を学び、コンポーネントに記憶を持たせる方法を理解します。',
+  },
+  {
+    id: 'events',
+    title: 'Step 2: イベント処理',
+    status: '学習中',
+    description: 'クリックや入力イベントを扱い、ユーザー操作に反応する実装を行います。',
+  },
+  {
+    id: 'conditional',
+    title: 'Step 3: 条件付きレンダリング',
+    status: 'ロック中',
+    description: '条件に応じた表示切り替えで、UIの分岐を実装します。',
+  },
+  {
+    id: 'lists',
+    title: 'Step 4: リスト表示',
+    status: 'ロック中',
+    description: '配列データを効率的に描画し、keyの基本を理解します。',
+  },
+] as const
+
+export function LearningOverviewCard({ completedCount, totalSteps }: LearningOverviewCardProps) {
+  const progressPercent = Math.max(0, Math.min(100, Math.round((completedCount / totalSteps) * 100)))
+
+  return (
+    <section className="space-y-4 rounded-2xl border border-slate-100 bg-white p-6 shadow-sm sm:p-8">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h2 className="text-xl font-bold text-text-dark">学習コース進捗</h2>
+          <p className="mt-1 text-sm text-text-light">コース全体の進捗を確認できます</p>
+        </div>
+        <Link
+          className="rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-800"
+          to="/step/events"
+        >
+          続きから再開
+        </Link>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between text-sm font-semibold">
+          <span className="text-primary-dark">
+            完了ステップ {completedCount} / {totalSteps}
+          </span>
+          <span className="text-text-light">{progressPercent}%</span>
+        </div>
+        <div className="h-3 w-full overflow-hidden rounded-full bg-slate-100">
+          <div className="h-full rounded-full bg-primary-mint transition-all duration-500" style={{ width: `${progressPercent}%` }} />
+        </div>
+      </div>
+
+      <ul className="space-y-3">
+        {LEARNING_PATH.map((item) => {
+          const isInProgress = item.status === '学習中'
+          const isDone = item.status === '完了'
+          return (
+            <li
+              key={item.id}
+              className={`rounded-xl border p-4 ${
+                isInProgress
+                  ? 'border-primary-mint bg-secondary-bg'
+                  : isDone
+                    ? 'border-emerald-200 bg-emerald-50/40'
+                    : 'border-slate-200 bg-slate-50/60'
+              }`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="font-semibold text-text-dark">{item.title}</p>
+                  <p className="mt-1 text-sm text-text-light">{item.description}</p>
+                </div>
+                <span
+                  className={`shrink-0 rounded-md px-2 py-1 text-xs font-bold ${
+                    isInProgress
+                      ? 'bg-primary-mint text-white'
+                      : isDone
+                        ? 'bg-emerald-100 text-emerald-700'
+                        : 'bg-slate-200 text-slate-600'
+                  }`}
+                >
+                  {item.status}
+                </span>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}

--- a/apps/web/src/features/dashboard/components/WelcomeBanner.tsx
+++ b/apps/web/src/features/dashboard/components/WelcomeBanner.tsx
@@ -1,0 +1,22 @@
+interface WelcomeBannerProps {
+  displayName: string
+}
+
+export function WelcomeBanner({ displayName }: WelcomeBannerProps) {
+  return (
+    <section className="relative overflow-hidden rounded-3xl bg-mint-gradient px-6 py-8 text-white shadow-glass sm:px-8">
+      <div className="relative z-10 flex flex-wrap items-center justify-between gap-4">
+        <div className="space-y-2">
+          <p className="text-sm font-semibold uppercase tracking-wide text-emerald-50">Welcome back</p>
+          <h1 className="font-display text-3xl font-bold leading-tight">こんにちは、{displayName}さん</h1>
+          <p className="text-sm text-emerald-50 sm:text-base">
+            Reactマスターへの道を進めましょう。今日の1ステップが次の実装力につながります。
+          </p>
+        </div>
+        <div className="grid h-20 w-20 place-items-center rounded-full border border-white/30 bg-white/20 text-4xl">🤖</div>
+      </div>
+      <div className="absolute -right-10 -top-10 h-32 w-32 rounded-full bg-white/10 blur-2xl" />
+      <div className="absolute -bottom-10 -left-10 h-32 w-32 rounded-full bg-white/10 blur-2xl" />
+    </section>
+  )
+}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -2,6 +2,10 @@ import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { ConfigErrorView } from '../components/ConfigErrorView'
 import { useAuth } from '../contexts/AuthContext'
+import { AppHeader } from '../features/dashboard/components/AppHeader'
+import { DashboardSidebar } from '../features/dashboard/components/DashboardSidebar'
+import { LearningOverviewCard } from '../features/dashboard/components/LearningOverviewCard'
+import { WelcomeBanner } from '../features/dashboard/components/WelcomeBanner'
 import { supabase, supabaseConfigError } from '../lib/supabaseClient'
 import { getCompletedStepCount } from '../services/progressService'
 
@@ -80,40 +84,27 @@ export function DashboardPage() {
   }
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-4xl flex-col gap-6 px-6 py-16">
-      <header className="flex flex-wrap items-center justify-between gap-4">
-        <div className="space-y-2">
-          <h1 className="text-3xl font-bold">ダッシュボード</h1>
-          <p className="text-slate-600">こんにちは、{greetingName}さん</p>
+    <div className="min-h-screen bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50">
+      <AppHeader displayName={greetingName} onSignOut={() => void handleSignOut()} />
+
+      <main className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
+        {supabaseConfigError ? <ConfigErrorView message={supabaseConfigError} /> : null}
+        {error ? <p className="mb-4 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{error}</p> : null}
+
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
+          <section className="space-y-6 lg:col-span-8">
+            <WelcomeBanner displayName={greetingName} />
+            <LearningOverviewCard completedCount={completedCount} totalSteps={TOTAL_STEPS} />
+            <Link className="inline-flex text-sm font-semibold text-primary-dark underline" to="/step/usestate-basic">
+              学習画面へ移動（/step/usestate-basic）
+            </Link>
+          </section>
+
+          <section className="lg:col-span-4">
+            <DashboardSidebar />
+          </section>
         </div>
-        <button
-          className="rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
-          type="button"
-          onClick={handleSignOut}
-        >
-          ログアウト
-        </button>
-      </header>
-
-      {supabaseConfigError ? <ConfigErrorView message={supabaseConfigError} /> : null}
-      {error ? <p className="text-sm text-red-700">{error}</p> : null}
-
-      <section className="grid gap-4 md:grid-cols-2">
-        <article className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-          <p className="text-sm text-slate-500">学習中コース</p>
-          <p className="mt-2 text-xl font-semibold">React基礎</p>
-        </article>
-        <article className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
-          <p className="text-sm text-slate-500">完了ステップ</p>
-          <p className="mt-2 text-xl font-semibold">
-            {completedCount} / {TOTAL_STEPS}
-          </p>
-        </article>
-      </section>
-
-      <Link className="text-sm font-medium text-blue-700 underline" to="/step/usestate-basic">
-        学習画面へ（/step/usestate-basic）
-      </Link>
-    </main>
+      </main>
+    </div>
   )
 }


### PR DESCRIPTION
## 概要
- roadmap02 の M2-2（タスク2）として、ダッシュボードUIをコンポーネント分割
- ナビゲーションヘッダー (AppHeader) と右カラムのサイドバー (DashboardSidebar) を新規実装
- ウェルカムバナー・進捗カードを WelcomeBanner / LearningOverviewCard へ分離し、DashboardPage は組み立てに専念
- ストリーク・ポイント・バッジ・ヒートマップはモック値で表示（M2要件どおり）

## 変更ファイル
- apps/web/src/pages/DashboardPage.tsx
- apps/web/src/features/dashboard/components/AppHeader.tsx
- apps/web/src/features/dashboard/components/WelcomeBanner.tsx
- apps/web/src/features/dashboard/components/LearningOverviewCard.tsx
- apps/web/src/features/dashboard/components/DashboardSidebar.tsx

## 検証
- cmd /c npm run typecheck : 成功
- cmd /c npm run build : 成功

## Issue要否
- 不要
- 根拠: roadmap02 に M2-2 タスクが既に定義されており、タスク管理の二重化を避けるため