### PR TITLE
feat: M3-1 コンテンツ定義の外部化とスケルトン作成

### DIFF
--- a/apps/web/src/content/courseData.ts
+++ b/apps/web/src/content/courseData.ts
@@ -1,0 +1,209 @@
+export type CourseLevel = 'beginner' | 'intermediate' | 'advanced'
+
+export interface StepMeta {
+  id: string
+  order: number
+  title: string
+  description: string
+  isImplemented: boolean
+}
+
+export interface CourseMeta {
+  id: string
+  title: string
+  level: CourseLevel
+  steps: StepMeta[]
+}
+
+export const COURSES: CourseMeta[] = [
+  {
+    id: 'course-1',
+    title: 'React基礎',
+    level: 'beginner',
+    steps: [
+      {
+        id: 'usestate-basic',
+        order: 1,
+        title: 'useState基礎',
+        description: '状態管理の基本を学び、コンポーネントに記憶を持たせる方法を理解します。',
+        isImplemented: true,
+      },
+      {
+        id: 'events',
+        order: 2,
+        title: 'イベント処理',
+        description: 'クリックや入力イベントを扱い、ユーザー操作に反応する実装を行います。',
+        isImplemented: true,
+      },
+      {
+        id: 'conditional',
+        order: 3,
+        title: '条件付きレンダリング',
+        description: '条件に応じた表示切り替えで、UIの分岐を実装します。',
+        isImplemented: true,
+      },
+      {
+        id: 'lists',
+        order: 4,
+        title: 'リスト表示',
+        description: '配列データを効率的に描画し、keyの基本を理解します。',
+        isImplemented: true,
+      },
+    ],
+  },
+  {
+    id: 'course-2',
+    title: 'React応用',
+    level: 'intermediate',
+    steps: [
+      {
+        id: 'useeffect',
+        order: 5,
+        title: 'useEffect',
+        description: '副作用とライフサイクルを理解し、データ取得や購読処理を実装します。',
+        isImplemented: false,
+      },
+      {
+        id: 'forms',
+        order: 6,
+        title: 'フォーム処理',
+        description: '入力値の管理とバリデーションを実装し、実用的なフォームを作ります。',
+        isImplemented: false,
+      },
+      {
+        id: 'usecontext',
+        order: 7,
+        title: 'useContext',
+        description: 'コンテキストAPIでグローバル状態を管理し、prop drillingを解消します。',
+        isImplemented: false,
+      },
+      {
+        id: 'usereducer',
+        order: 8,
+        title: 'useReducer',
+        description: '複雑な状態ロジックをreducerパターンで整理します。',
+        isImplemented: false,
+      },
+    ],
+  },
+  {
+    id: 'course-3',
+    title: 'React実践',
+    level: 'advanced',
+    steps: [
+      {
+        id: 'custom-hooks',
+        order: 9,
+        title: 'カスタムHooks',
+        description: '再利用可能なロジックをカスタムHookとして切り出します。',
+        isImplemented: false,
+      },
+      {
+        id: 'api-fetch',
+        order: 10,
+        title: 'API連携',
+        description: 'データ取得とローディング状態の管理を実践します。',
+        isImplemented: false,
+      },
+      {
+        id: 'performance',
+        order: 11,
+        title: 'パフォーマンス最適化',
+        description: 'useMemo/useCallbackで不要な再レンダリングを防ぎます。',
+        isImplemented: false,
+      },
+      {
+        id: 'testing',
+        order: 12,
+        title: 'テスト入門',
+        description: 'React Testing Libraryでコンポーネントのテストを書きます。',
+        isImplemented: false,
+      },
+    ],
+  },
+  {
+    id: 'course-4',
+    title: 'API連携実践',
+    level: 'intermediate',
+    steps: [
+      {
+        id: 'api-counter-get',
+        order: 13,
+        title: 'カウンターAPI (GET)',
+        description: 'APIからデータを取得し、画面に表示する基本パターンを学びます。',
+        isImplemented: false,
+      },
+      {
+        id: 'api-counter-post',
+        order: 14,
+        title: 'カウンターAPI (POST)',
+        description: 'APIにデータを送信し、サーバーの状態を更新します。',
+        isImplemented: false,
+      },
+      {
+        id: 'api-tasks-list',
+        order: 15,
+        title: 'タスク一覧 (GET)',
+        description: 'リストデータを取得して一覧表示するパターンを実装します。',
+        isImplemented: false,
+      },
+      {
+        id: 'api-tasks-create',
+        order: 16,
+        title: 'タスク追加 (POST)',
+        description: 'フォームからデータを送信し、リストに追加する処理を実装します。',
+        isImplemented: false,
+      },
+      {
+        id: 'api-tasks-update',
+        order: 17,
+        title: 'タスク更新 (PATCH)',
+        description: '完了状態の切り替えなど、既存データの更新処理を実装します。',
+        isImplemented: false,
+      },
+      {
+        id: 'api-tasks-delete',
+        order: 18,
+        title: 'タスク削除 (DELETE)',
+        description: 'APIで削除処理を行い、リストから即時除去するUIを実装します。',
+        isImplemented: false,
+      },
+      {
+        id: 'api-custom-hook',
+        order: 19,
+        title: 'useTasksフック',
+        description: 'API操作をカスタムフックに集約し、コンポーネントをシンプルに保ちます。',
+        isImplemented: false,
+      },
+      {
+        id: 'api-error-loading',
+        order: 20,
+        title: 'エラー/ローディングUI',
+        description: 'APIの通信状態に応じたUI表示を実装し、UXを向上させます。',
+        isImplemented: false,
+      },
+    ],
+  },
+]
+
+export const TOTAL_STEP_COUNT = COURSES.reduce((sum, course) => sum + course.steps.length, 0)
+
+export const IMPLEMENTED_STEP_COUNT = COURSES.reduce(
+  (sum, course) => sum + course.steps.filter((s) => s.isImplemented).length,
+  0,
+)
+
+export function findStepMeta(stepId: string): StepMeta | undefined {
+  for (const course of COURSES) {
+    const step = course.steps.find((s) => s.id === stepId)
+    if (step) return step
+  }
+  return undefined
+}
+
+export function getNextStep(currentStepId: string): StepMeta | undefined {
+  const allSteps = COURSES.flatMap((c) => c.steps)
+  const currentIndex = allSteps.findIndex((s) => s.id === currentStepId)
+  if (currentIndex === -1) return undefined
+  return allSteps[currentIndex + 1]
+}

--- a/apps/web/src/features/dashboard/components/LearningOverviewCard.tsx
+++ b/apps/web/src/features/dashboard/components/LearningOverviewCard.tsx
@@ -1,59 +1,97 @@
 import { Link } from 'react-router-dom'
+import { COURSES, TOTAL_STEP_COUNT, type CourseMeta, type StepMeta } from '../../../content/courseData'
+
+const LEVEL_LABEL: Record<CourseMeta['level'], string> = {
+  beginner: '初級',
+  intermediate: '中級',
+  advanced: '上級',
+}
+
+const LEVEL_COLOR: Record<CourseMeta['level'], string> = {
+  beginner: 'bg-emerald-100 text-emerald-700',
+  intermediate: 'bg-sky-100 text-sky-700',
+  advanced: 'bg-violet-100 text-violet-700',
+}
+
+interface StepRowProps {
+  step: StepMeta
+  isInProgress: boolean
+  isDone: boolean
+}
+
+function StepRow({ step, isInProgress, isDone }: StepRowProps) {
+  const isLocked = !step.isImplemented
+
+  const borderBg = isInProgress
+    ? 'border-primary-mint bg-secondary-bg'
+    : isDone
+      ? 'border-emerald-200 bg-emerald-50/40'
+      : 'border-slate-200 bg-slate-50/60'
+
+  const badge = isInProgress
+    ? { label: '学習中', cls: 'bg-primary-mint text-white' }
+    : isDone
+      ? { label: '完了', cls: 'bg-emerald-100 text-emerald-700' }
+      : { label: isLocked ? '準備中' : 'ロック中', cls: 'bg-slate-200 text-slate-500' }
+
+  const icon = isLocked ? '🔒' : isDone ? '✅' : isInProgress ? '📖' : '📝'
+
+  const inner = (
+    <li className={`rounded-xl border p-4 ${borderBg} ${isLocked ? 'opacity-60' : ''}`}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-2">
+          <span className="mt-0.5 shrink-0 text-base">{icon}</span>
+          <div>
+            <p className={`font-semibold ${isLocked ? 'text-text-light' : 'text-text-dark'}`}>
+              Step {step.order}: {step.title}
+            </p>
+            <p className="mt-1 text-sm text-text-light">{step.description}</p>
+          </div>
+        </div>
+        <span className={`shrink-0 rounded-md px-2 py-1 text-xs font-bold ${badge.cls}`}>
+          {badge.label}
+        </span>
+      </div>
+    </li>
+  )
+
+  if (!isLocked) {
+    return <Link to={`/step/${step.id}`}>{inner}</Link>
+  }
+  return inner
+}
 
 interface LearningOverviewCardProps {
   completedCount: number
-  totalSteps: number
 }
 
-const LEARNING_PATH = [
-  {
-    id: 'usestate-basic',
-    title: 'Step 1: useState基礎',
-    status: '完了',
-    description: '状態管理の基本を学び、コンポーネントに記憶を持たせる方法を理解します。',
-  },
-  {
-    id: 'events',
-    title: 'Step 2: イベント処理',
-    status: '学習中',
-    description: 'クリックや入力イベントを扱い、ユーザー操作に反応する実装を行います。',
-  },
-  {
-    id: 'conditional',
-    title: 'Step 3: 条件付きレンダリング',
-    status: 'ロック中',
-    description: '条件に応じた表示切り替えで、UIの分岐を実装します。',
-  },
-  {
-    id: 'lists',
-    title: 'Step 4: リスト表示',
-    status: 'ロック中',
-    description: '配列データを効率的に描画し、keyの基本を理解します。',
-  },
-] as const
+export function LearningOverviewCard({ completedCount }: LearningOverviewCardProps) {
+  const progressPercent = Math.max(0, Math.min(100, Math.round((completedCount / TOTAL_STEP_COUNT) * 100)))
 
-export function LearningOverviewCard({ completedCount, totalSteps }: LearningOverviewCardProps) {
-  const progressPercent = Math.max(0, Math.min(100, Math.round((completedCount / totalSteps) * 100)))
+  const implementedSteps = COURSES.flatMap((c) => c.steps.filter((s) => s.isImplemented))
+  const inProgressStep = completedCount < implementedSteps.length ? implementedSteps[completedCount] : null
 
   return (
     <section className="space-y-4 rounded-2xl border border-slate-100 bg-white p-6 shadow-sm sm:p-8">
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <h2 className="text-xl font-bold text-text-dark">学習コース進捗</h2>
-          <p className="mt-1 text-sm text-text-light">コース全体の進捗を確認できます</p>
+          <p className="mt-1 text-sm text-text-light">全{TOTAL_STEP_COUNT}ステップのロードマップ</p>
         </div>
-        <Link
-          className="rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-800"
-          to="/step/events"
-        >
-          続きから再開
-        </Link>
+        {inProgressStep ? (
+          <Link
+            className="rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-800"
+            to={`/step/${inProgressStep.id}`}
+          >
+            続きから再開
+          </Link>
+        ) : null}
       </div>
 
       <div className="space-y-2">
         <div className="flex items-center justify-between text-sm font-semibold">
           <span className="text-primary-dark">
-            完了ステップ {completedCount} / {totalSteps}
+            完了ステップ {completedCount} / {TOTAL_STEP_COUNT}
           </span>
           <span className="text-text-light">{progressPercent}%</span>
         </div>
@@ -62,42 +100,40 @@ export function LearningOverviewCard({ completedCount, totalSteps }: LearningOve
         </div>
       </div>
 
-      <ul className="space-y-3">
-        {LEARNING_PATH.map((item) => {
-          const isInProgress = item.status === '学習中'
-          const isDone = item.status === '完了'
+      <div className="space-y-6">
+        {COURSES.map((course) => {
+          const hasSomeImplemented = course.steps.some((s) => s.isImplemented)
           return (
-            <li
-              key={item.id}
-              className={`rounded-xl border p-4 ${
-                isInProgress
-                  ? 'border-primary-mint bg-secondary-bg'
-                  : isDone
-                    ? 'border-emerald-200 bg-emerald-50/40'
-                    : 'border-slate-200 bg-slate-50/60'
-              }`}
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <p className="font-semibold text-text-dark">{item.title}</p>
-                  <p className="mt-1 text-sm text-text-light">{item.description}</p>
-                </div>
-                <span
-                  className={`shrink-0 rounded-md px-2 py-1 text-xs font-bold ${
-                    isInProgress
-                      ? 'bg-primary-mint text-white'
-                      : isDone
-                        ? 'bg-emerald-100 text-emerald-700'
-                        : 'bg-slate-200 text-slate-600'
-                  }`}
-                >
-                  {item.status}
+            <div key={course.id}>
+              <div className="mb-3 flex items-center gap-2">
+                <h3 className={`text-sm font-bold ${hasSomeImplemented ? 'text-text-dark' : 'text-text-light'}`}>
+                  {course.title}
+                </h3>
+                <span className={`rounded-md px-2 py-0.5 text-xs font-bold ${LEVEL_COLOR[course.level]}`}>
+                  {LEVEL_LABEL[course.level]}
                 </span>
+                {!hasSomeImplemented && (
+                  <span className="ml-auto text-xs text-slate-400">準備中</span>
+                )}
               </div>
-            </li>
+              <ul className="space-y-2">
+                {course.steps.map((step) => {
+                  const isDone = step.isImplemented && step.order <= completedCount
+                  const isInProgress = inProgressStep?.id === step.id
+                  return (
+                    <StepRow
+                      key={step.id}
+                      step={step}
+                      isInProgress={isInProgress}
+                      isDone={isDone}
+                    />
+                  )
+                })}
+              </ul>
+            </div>
           )
         })}
-      </ul>
+      </div>
     </section>
   )
 }

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { ConfigErrorView } from '../components/ConfigErrorView'
+import { IMPLEMENTED_STEP_COUNT } from '../content/courseData'
 import { useAuth } from '../contexts/AuthContext'
 import { AppHeader } from '../features/dashboard/components/AppHeader'
 import { DashboardSidebar } from '../features/dashboard/components/DashboardSidebar'
@@ -8,8 +9,6 @@ import { LearningOverviewCard } from '../features/dashboard/components/LearningO
 import { WelcomeBanner } from '../features/dashboard/components/WelcomeBanner'
 import { supabase, supabaseConfigError } from '../lib/supabaseClient'
 import { getCompletedStepCount } from '../services/progressService'
-
-const TOTAL_STEPS = 4
 
 export function DashboardPage() {
   const { user, signOut } = useAuth()
@@ -94,7 +93,7 @@ export function DashboardPage() {
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
           <section className="space-y-6 lg:col-span-8">
             <WelcomeBanner displayName={greetingName} />
-            <LearningOverviewCard completedCount={completedCount} totalSteps={TOTAL_STEPS} />
+            <LearningOverviewCard completedCount={Math.min(completedCount, IMPLEMENTED_STEP_COUNT)} />
             <Link className="inline-flex text-sm font-semibold text-primary-dark underline" to="/step/usestate-basic">
               学習画面へ移動（/step/usestate-basic）
             </Link>


### PR DESCRIPTION
## 概要

roadmap02 M3-1「コンテンツ定義の外部化とスケルトン作成」を実装する。

## 変更内容

### 新規: `src/content/courseData.ts`
- 全4コース・20ステップのメタデータを一元管理するデータ定義ファイルを作成
- `isImplemented` フラグで実装済みステップ（コース1の4ステップ）と未実装ステップを識別
- `COURSES`, `TOTAL_STEP_COUNT`（20）, `IMPLEMENTED_STEP_COUNT`（4）をエクスポート
- `findStepMeta` / `getNextStep` ユーティリティ関数を追加（後続実装で使用）

### 改修: `LearningOverviewCard.tsx`
- ハードコードされた `LEARNING_PATH` を廃止し、`courseData.ts` から動的描画に変更
- コース単位でグルーピング表示（初級/中級/上級ラベル付き）
- 未実装コース・ステップにロック表示（準備中バッジ・opacity・🔒アイコン）
- 実装済みステップにはリンクを付与、未実装はリンクなし
- `totalSteps` プロップを廃止し、`TOTAL_STEP_COUNT` で内部管理

### 改修: `DashboardPage.tsx`
- `TOTAL_STEPS = 4` を削除し `IMPLEMENTED_STEP_COUNT` に置換

## 検証結果

- `npm run typecheck`: エラーなし（通過）
- `npm run build`: 成功

## Issue要否

不要。roadmap02 M3-1 のスコープ内で完結し、タスク定義がロードマップに記録済みのため。

## マージ可否

マージして問題ない。既存の学習フロー・認証に影響なし。全20ステップのUI全体像を表示しつつ、未実装ステップは明示的にロック済みで誤遷移しない。
→ マージ実行・タスクブランチ削除を実施する。