### PR TITLE
feat: M4-2 ポイント付与と状態管理基盤を実装

### DIFF
--- a/apps/web/src/contexts/LearningContext.tsx
+++ b/apps/web/src/contexts/LearningContext.tsx
@@ -1,0 +1,65 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
+import { useAuth } from './AuthContext'
+import { getLearningStats, type LearningStats } from '../services/pointService'
+
+interface LearningContextType {
+    stats: LearningStats | null
+    isLoadingStats: boolean
+    refreshStats: () => Promise<void>
+}
+
+const LearningContext = createContext<LearningContextType>({
+    stats: null,
+    isLoadingStats: true,
+    refreshStats: async () => { },
+})
+
+export function LearningProvider({ children }: { children: ReactNode }) {
+    const { user } = useAuth()
+    const [stats, setStats] = useState<LearningStats | null>(null)
+    const [isLoadingStats, setIsLoadingStats] = useState(true)
+
+    const refreshStats = async () => {
+        if (!user) {
+            setStats(null)
+            setIsLoadingStats(false)
+            return
+        }
+
+        try {
+            const currentStats = await getLearningStats(user.id)
+            setStats(currentStats)
+        } catch (err) {
+            console.error('Failed to load learning stats:', err)
+        } finally {
+            setIsLoadingStats(false)
+        }
+    }
+
+    useEffect(() => {
+        let isMounted = true
+
+        setIsLoadingStats(true)
+        refreshStats().finally(() => {
+            if (isMounted) setIsLoadingStats(false)
+        })
+
+        return () => {
+            isMounted = false
+        }
+    }, [user])
+
+    return (
+        <LearningContext.Provider value={{ stats, isLoadingStats, refreshStats }}>
+            {children}
+        </LearningContext.Provider>
+    )
+}
+
+export function useLearningContext() {
+    const context = useContext(LearningContext)
+    if (!context) {
+        throw new Error('useLearningContext must be used within a LearningProvider')
+    }
+    return context
+}

--- a/apps/web/src/features/dashboard/components/AppHeader.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeader.tsx
@@ -1,9 +1,12 @@
+import { useLearningContext } from '../../../contexts/LearningContext'
+
 interface AppHeaderProps {
   displayName: string
   onSignOut: () => void
 }
 
 export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
+  const { stats } = useLearningContext()
   return (
     <header className="sticky top-0 z-40 border-b border-slate-200/70 bg-white/90 backdrop-blur">
       <div className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
@@ -23,8 +26,11 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
         </div>
 
         <div className="flex items-center gap-3">
+          <div className="hidden rounded-full border border-amber-300/30 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-700 sm:block">
+            💎 {stats?.total_points ?? 0} Pt
+          </div>
           <div className="hidden rounded-full border border-primary-mint/30 bg-secondary-bg px-3 py-1 text-xs font-semibold text-primary-dark sm:block">
-            🔥 3日連続
+            🔥 {stats?.current_streak ?? 0}日連続
           </div>
           <div className="hidden text-sm font-medium text-slate-600 sm:block">{displayName}</div>
           <button

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client'
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 import { ProtectedRoute, GuestRoute } from './components/ProtectedRoute'
 import { AuthProvider } from './contexts/AuthContext'
+import { LearningProvider } from './contexts/LearningContext'
 import { DashboardPage } from './pages/DashboardPage'
 import { LoginPage } from './pages/LoginPage'
 import { StepPage } from './pages/StepPage'
@@ -53,7 +54,9 @@ if (supabaseConfigError) {
   root.render(
     <React.StrictMode>
       <AuthProvider>
-        <RouterProvider router={router} />
+        <LearningProvider>
+          <RouterProvider router={router} />
+        </LearningProvider>
       </AuthProvider>
     </React.StrictMode>,
   )

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -3,10 +3,12 @@ import { Link, useNavigate, useParams } from 'react-router-dom'
 import { LearningSidebar } from '../components/LearningSidebar'
 import { fundamentalsSteps, getFundamentalsStep, type LearningMode } from '../content/fundamentals/steps'
 import { useAuth } from '../contexts/AuthContext'
+import { useLearningContext } from '../contexts/LearningContext'
 import { ChallengeMode } from '../features/learning/ChallengeMode'
 import { PracticeMode } from '../features/learning/PracticeMode'
 import { ReadMode } from '../features/learning/ReadMode'
 import { TestMode } from '../features/learning/TestMode'
+import { awardPoints } from '../services/pointService'
 import { getStepProgress, updateModeCompletion } from '../services/progressService'
 
 type ModeStatus = Record<LearningMode, boolean>
@@ -21,6 +23,7 @@ const INITIAL_MODE_STATUS: ModeStatus = {
 export function StepPage() {
   const { stepId = '' } = useParams()
   const { signOut, user } = useAuth()
+  const { refreshStats } = useLearningContext()
   const navigate = useNavigate()
   const [activeMode, setActiveMode] = useState<LearningMode>('read')
   const [modeStatus, setModeStatus] = useState<ModeStatus>(INITIAL_MODE_STATUS)
@@ -143,6 +146,9 @@ export function StepPage() {
 
       try {
         await updateModeCompletion(user.id, step.id, mode)
+        const reason = `「${step.title}」の${mode}モード完了`
+        await awardPoints(user.id, 10, reason)
+        await refreshStats()
       } catch (error) {
         setModeStatus((prev) => ({ ...prev, [mode]: false }))
         const message = error instanceof Error ? error.message : '進捗保存に失敗しました。'
@@ -210,9 +216,8 @@ export function StepPage() {
               return (
                 <button
                   key={mode.id}
-                  className={`rounded-md px-3 py-2 text-sm font-medium transition ${
-                    isActive ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
-                  }`}
+                  className={`rounded-md px-3 py-2 text-sm font-medium transition ${isActive ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
+                    }`}
                   type="button"
                   onClick={() => setActiveMode(mode.id)}
                 >

--- a/apps/web/src/services/pointService.ts
+++ b/apps/web/src/services/pointService.ts
@@ -1,0 +1,99 @@
+import { supabase } from '../lib/supabaseClient'
+
+export interface LearningStats {
+    user_id: string
+    total_points: number
+    current_streak: number
+    max_streak: number
+    last_study_date: string | null
+}
+
+export async function getLearningStats(userId: string): Promise<LearningStats> {
+    const { data, error } = await supabase
+        .from('learning_stats')
+        .select('*')
+        .eq('user_id', userId)
+        .maybeSingle()
+
+    if (error) {
+        throw error
+    }
+
+    return (
+        data ?? {
+            user_id: userId,
+            total_points: 0,
+            current_streak: 0,
+            max_streak: 0,
+            last_study_date: null,
+        }
+    )
+}
+
+function calculateStreak(stats: LearningStats, todayDateStr: string, yesterdayDateStr: string): LearningStats {
+    const newStats = { ...stats }
+
+    if (stats.last_study_date === todayDateStr) {
+        // Already studied today
+        return newStats
+    }
+
+    if (stats.last_study_date === yesterdayDateStr) {
+        // Studied yesterday, increment
+        newStats.current_streak += 1
+    } else {
+        // Broken streak or first time
+        newStats.current_streak = 1
+    }
+
+    newStats.last_study_date = todayDateStr
+    if (newStats.current_streak > newStats.max_streak) {
+        newStats.max_streak = newStats.current_streak
+    }
+
+    return newStats
+}
+
+export async function awardPoints(userId: string, amount: number, reason: string): Promise<void> {
+    // 1. Get current stats
+    const stats = await getLearningStats(userId)
+
+    // 2. Calculate new points and streak
+    const now = new Date()
+    const todayDateStr = now.toISOString().split('T')[0]
+
+    const yesterday = new Date(now)
+    yesterday.setDate(now.getDate() - 1)
+    const yesterdayDateStr = yesterday.toISOString().split('T')[0]
+
+    const newStats = calculateStreak(stats, todayDateStr, yesterdayDateStr)
+    newStats.total_points += amount
+
+    // 3. Upsert stats
+    const { error: statsError } = await supabase.from('learning_stats').upsert(
+        {
+            user_id: userId,
+            total_points: newStats.total_points,
+            current_streak: newStats.current_streak,
+            max_streak: newStats.max_streak,
+            last_study_date: newStats.last_study_date,
+            updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id', ignoreDuplicates: false }
+    )
+
+    if (statsError) {
+        throw statsError
+    }
+
+    // 4. Insert history
+    const { error: historyError } = await supabase.from('point_history').insert({
+        user_id: userId,
+        amount,
+        reason,
+    })
+
+    if (historyError) {
+        throw historyError
+    }
+}


### PR DESCRIPTION
## 概要
- M4-2としてポイント付与サービスと状態管理基盤を実装
- pointService.ts を追加し、ポイント加算と学習統計の更新ロジックを実装
- LearningContext / StepPage / AppHeader / main.tsx を更新し、ポイント反映フローを接続

## 変更ファイル
- apps/web/src/services/pointService.ts
- apps/web/src/contexts/LearningContext.tsx
- apps/web/src/pages/StepPage.tsx
- apps/web/src/features/dashboard/components/AppHeader.tsx
- apps/web/src/main.tsx

## 検証
- cmd /c npm --workspace apps/web run typecheck : pass

## Issue要否
- 不要
- 理由: roadmap02のM4-2タスクとして管理済みであり、Issueを分けると管理が二重になるため