### PR TITLE
fix: roadmap03 M1-1 StepPageヘッダー表示と未解放ステップ保護

### DIFF
--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { Link, Navigate, useNavigate, useParams } from 'react-router-dom'
 import { LearningSidebar } from '../components/LearningSidebar'
+import { findStepMeta } from '../content/courseData'
 import { fundamentalsSteps, getFundamentalsStep, type LearningMode } from '../content/fundamentals/steps'
 import { useAuth } from '../contexts/AuthContext'
+import { AppHeader } from '../features/dashboard/components/AppHeader'
 import { ChallengeMode } from '../features/learning/ChallengeMode'
 import { PracticeMode } from '../features/learning/PracticeMode'
 import { ReadMode } from '../features/learning/ReadMode'
@@ -28,7 +30,22 @@ export function StepPage() {
   const [toastMessage, setToastMessage] = useState<string | null>(null)
   const completedOnceRef = useRef(false)
 
+  const stepMeta = findStepMeta(stepId)
   const step = getFundamentalsStep(stepId)
+  const isUnavailableStep = Boolean(stepMeta && !stepMeta.isImplemented)
+
+  const headerDisplayName = useMemo(() => {
+    const metadataName = user?.user_metadata?.display_name
+    if (typeof metadataName === 'string' && metadataName.length > 0) {
+      return metadataName
+    }
+
+    if (user?.email) {
+      return user.email.split('@')[0]
+    }
+
+    return 'ゲスト'
+  }, [user?.email, user?.user_metadata])
 
   const orderedSteps = useMemo(() => [...fundamentalsSteps].sort((a, b) => a.order - b.order), [])
   const nextStep = useMemo(() => {
@@ -170,6 +187,10 @@ export function StepPage() {
     navigate(`/step/${nextStep.id}`)
   }
 
+  if (isUnavailableStep) {
+    return <Navigate to="/" replace />
+  }
+
   if (!step) {
     return (
       <main className="mx-auto flex min-h-screen max-w-4xl flex-col gap-6 px-6 py-16">
@@ -183,92 +204,88 @@ export function StepPage() {
   }
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-6xl flex-col gap-6 px-6 py-10">
-      <header className="flex items-center justify-between gap-4">
-        <div className="space-y-2">
+    <div className="min-h-screen bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50">
+      <AppHeader displayName={headerDisplayName} onSignOut={() => void handleSignOut()} />
+
+      <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-10">
+        <section className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-primary-mint">Learning Step</p>
           <h1 className="text-3xl font-bold">{step.title}</h1>
           <p className="text-slate-600">{step.summary}</p>
-        </div>
-        <button
-          className="rounded-md border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50"
-          type="button"
-          onClick={handleSignOut}
-        >
-          ログアウト
-        </button>
-      </header>
+        </section>
 
-      <section className="flex flex-col gap-4 lg:flex-row lg:items-start">
-        <LearningSidebar currentStepId={stepId} steps={fundamentalsSteps} />
+        <section className="flex flex-col gap-4 lg:flex-row lg:items-start">
+          <LearningSidebar currentStepId={stepId} steps={fundamentalsSteps} />
 
-        <div className="flex-1 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <p className="text-xs font-medium uppercase tracking-wide text-slate-500">stepId: {step.id}</p>
+          <div className="flex-1 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <p className="text-xs font-medium uppercase tracking-wide text-slate-500">stepId: {step.id}</p>
 
-          <div className="mt-4 flex flex-wrap gap-2 border-b border-slate-200 pb-4">
-            {modeButtons.map((mode) => {
-              const isActive = activeMode === mode.id
-              return (
-                <button
-                  key={mode.id}
-                  className={`rounded-md px-3 py-2 text-sm font-medium transition ${
-                    isActive ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
-                  }`}
-                  type="button"
-                  onClick={() => setActiveMode(mode.id)}
-                >
-                  {mode.label}
-                  {modeStatus[mode.id] ? ' ✓' : ''}
-                </button>
-              )
-            })}
-          </div>
-
-          {syncMessage ? <p className="mt-4 text-sm text-rose-700">{syncMessage}</p> : null}
-
-          {activeMode === 'read' ? (
-            <ReadMode markdown={step.readMarkdown} onComplete={() => void handleModeComplete('read')} />
-          ) : null}
-          {activeMode === 'practice' ? (
-            <PracticeMode questions={step.practiceQuestions} onComplete={() => void handleModeComplete('practice')} />
-          ) : null}
-          {activeMode === 'test' ? (
-            <TestMode stepId={step.id} task={step.testTask} onComplete={() => void handleModeComplete('test')} />
-          ) : null}
-          {activeMode === 'challenge' ? (
-            <ChallengeMode task={step.challengeTask} onComplete={() => void handleModeComplete('challenge')} />
-          ) : null}
-
-          {modeStatus.challenge ? (
-            <div className="mt-6 rounded-xl border border-emerald-200 bg-emerald-50 p-4">
-              <p className="text-sm font-medium text-emerald-800">
-                {nextStep
-                  ? `チャレンジ完了。次は「${nextStep.title}」へ進めます。`
-                  : 'チャレンジ完了。現在の学習フローはすべて完了しています。'}
-              </p>
-              <button
-                className="mt-3 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-700"
-                type="button"
-                onClick={handleNextStep}
-              >
-                {nextStep ? '次のステップへ進む' : 'ダッシュボードへ戻る'}
-              </button>
+            <div className="mt-4 flex flex-wrap gap-2 border-b border-slate-200 pb-4">
+              {modeButtons.map((mode) => {
+                const isActive = activeMode === mode.id
+                return (
+                  <button
+                    key={mode.id}
+                    className={`rounded-md px-3 py-2 text-sm font-medium transition ${
+                      isActive ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
+                    }`}
+                    type="button"
+                    onClick={() => setActiveMode(mode.id)}
+                  >
+                    {mode.label}
+                    {modeStatus[mode.id] ? ' ✓' : ''}
+                  </button>
+                )
+              })}
             </div>
-          ) : null}
-        </div>
-      </section>
 
-      <div className="flex gap-4 text-sm">
-        <Link className="font-medium text-blue-700 underline" to="/">
-          ダッシュボードへ戻る
-        </Link>
-      </div>
+            {syncMessage ? <p className="mt-4 text-sm text-rose-700">{syncMessage}</p> : null}
 
-      {toastMessage ? (
-        <div className="fixed bottom-5 right-5 z-50 max-w-sm rounded-xl border border-emerald-200 bg-white px-4 py-3 text-sm text-emerald-900 shadow-xl">
-          <p className="font-semibold">学習達成</p>
-          <p className="mt-1">{toastMessage}</p>
+            {activeMode === 'read' ? (
+              <ReadMode markdown={step.readMarkdown} onComplete={() => void handleModeComplete('read')} />
+            ) : null}
+            {activeMode === 'practice' ? (
+              <PracticeMode questions={step.practiceQuestions} onComplete={() => void handleModeComplete('practice')} />
+            ) : null}
+            {activeMode === 'test' ? (
+              <TestMode stepId={step.id} task={step.testTask} onComplete={() => void handleModeComplete('test')} />
+            ) : null}
+            {activeMode === 'challenge' ? (
+              <ChallengeMode task={step.challengeTask} onComplete={() => void handleModeComplete('challenge')} />
+            ) : null}
+
+            {modeStatus.challenge ? (
+              <div className="mt-6 rounded-xl border border-emerald-200 bg-emerald-50 p-4">
+                <p className="text-sm font-medium text-emerald-800">
+                  {nextStep
+                    ? `チャレンジ完了。次は「${nextStep.title}」へ進めます。`
+                    : 'チャレンジ完了。現在の学習フローはすべて完了しています。'}
+                </p>
+                <button
+                  className="mt-3 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-emerald-700"
+                  type="button"
+                  onClick={handleNextStep}
+                >
+                  {nextStep ? '次のステップへ進む' : 'ダッシュボードへ戻る'}
+                </button>
+              </div>
+            ) : null}
+          </div>
+        </section>
+
+        <div className="flex gap-4 text-sm">
+          <Link className="font-medium text-blue-700 underline" to="/">
+            ダッシュボードへ戻る
+          </Link>
         </div>
-      ) : null}
-    </main>
+
+        {toastMessage ? (
+          <div className="fixed bottom-5 right-5 z-50 max-w-sm rounded-xl border border-emerald-200 bg-white px-4 py-3 text-sm text-emerald-900 shadow-xl">
+            <p className="font-semibold">学習達成</p>
+            <p className="mt-1">{toastMessage}</p>
+          </div>
+        ) : null}
+      </main>
+    </div>
   )
 }


### PR DESCRIPTION
## 概要
- StepPageにAppHeaderを追加し、学習画面でもPt・ストリーク・ユーザー名を常時表示
- courseDataのisImplementedを参照し、未解放ステップへの直接URLアクセス時は`/`へリダイレクト

## 変更内容
- `StepPage` に `AppHeader` を導入
- `findStepMeta(stepId)` + `Navigate` による未解放ステップ保護ロジックを追加
- 画面レイアウトをダッシュボード側と同系統の背景トーンに統一

## 検証
- `cmd /c npm --workspace apps/web run typecheck` : 成功
- `cmd /c npm run build` : 成功
- `cmd /c npm --workspace apps/web run test` : 失敗（`@coden/web` に `test` script が未定義）

## Issue要否
- 不要（`docs/roadmaps/roadmap03.md` の M1-1 にタスク定義済みで二重管理を避けるため）