### PR TITLE
fix: roadmap03 M1-2 Read完了保存とステップID整合確認

### DIFF
--- a/apps/web/src/features/learning/ReadMode.tsx
+++ b/apps/web/src/features/learning/ReadMode.tsx
@@ -11,9 +11,10 @@ import 'prismjs/themes/prism.css'
 interface ReadModeProps {
   markdown: string
   onComplete: () => void
+  isCompleted: boolean
 }
 
-export function ReadMode({ markdown, onComplete }: ReadModeProps) {
+export function ReadMode({ markdown, onComplete, isCompleted }: ReadModeProps) {
   const [copyMessage, setCopyMessage] = useState<string | null>(null)
 
   useEffect(() => {
@@ -25,11 +26,14 @@ export function ReadMode({ markdown, onComplete }: ReadModeProps) {
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">Read</h2>
         <button
-          className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-500"
+          className={`rounded-md px-3 py-2 text-sm font-medium text-white ${
+            isCompleted ? 'cursor-not-allowed bg-emerald-300' : 'bg-emerald-600 hover:bg-emerald-500'
+          }`}
           type="button"
           onClick={onComplete}
+          disabled={isCompleted}
         >
-          Readを完了
+          {isCompleted ? 'Read完了済み' : 'Readを完了'}
         </button>
       </div>
 

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -9,7 +9,7 @@ import { ChallengeMode } from '../features/learning/ChallengeMode'
 import { PracticeMode } from '../features/learning/PracticeMode'
 import { ReadMode } from '../features/learning/ReadMode'
 import { TestMode } from '../features/learning/TestMode'
-import { getStepProgress, updateModeCompletion } from '../services/progressService'
+import { getStepProgress, updateModeCompletion, upsertProgress } from '../services/progressService'
 
 type ModeStatus = Record<LearningMode, boolean>
 
@@ -18,6 +18,15 @@ const INITIAL_MODE_STATUS: ModeStatus = {
   practice: false,
   test: false,
   challenge: false,
+}
+
+function toModeStatus(progress: Awaited<ReturnType<typeof getStepProgress>>): ModeStatus {
+  return {
+    read: progress?.read_done ?? false,
+    practice: progress?.practice_done ?? false,
+    test: progress?.test_done ?? false,
+    challenge: progress?.challenge_done ?? false,
+  }
 }
 
 export function StepPage() {
@@ -87,12 +96,7 @@ export function StepPage() {
           return
         }
 
-        setModeStatus({
-          read: progress?.read_done ?? false,
-          practice: progress?.practice_done ?? false,
-          test: progress?.test_done ?? false,
-          challenge: progress?.challenge_done ?? false,
-        })
+        setModeStatus(toModeStatus(progress))
       } catch (error) {
         if (!isMounted) {
           return
@@ -159,7 +163,14 @@ export function StepPage() {
       setSyncMessage(null)
 
       try {
-        await updateModeCompletion(user.id, step.id, mode)
+        if (mode === 'read') {
+          await upsertProgress(user.id, step.id, { read_done: true })
+        } else {
+          await updateModeCompletion(user.id, step.id, mode)
+        }
+
+        const latestProgress = await getStepProgress(user.id, step.id)
+        setModeStatus(toModeStatus(latestProgress))
       } catch (error) {
         setModeStatus((prev) => ({ ...prev, [mode]: false }))
         const message = error instanceof Error ? error.message : '進捗保存に失敗しました。'
@@ -242,7 +253,11 @@ export function StepPage() {
             {syncMessage ? <p className="mt-4 text-sm text-rose-700">{syncMessage}</p> : null}
 
             {activeMode === 'read' ? (
-              <ReadMode markdown={step.readMarkdown} onComplete={() => void handleModeComplete('read')} />
+              <ReadMode
+                markdown={step.readMarkdown}
+                onComplete={() => void handleModeComplete('read')}
+                isCompleted={modeStatus.read}
+              />
             ) : null}
             {activeMode === 'practice' ? (
               <PracticeMode questions={step.practiceQuestions} onComplete={() => void handleModeComplete('practice')} />

--- a/apps/web/src/services/progressService.ts
+++ b/apps/web/src/services/progressService.ts
@@ -13,6 +13,10 @@ interface StepProgressRow {
   completed_at?: string | null
 }
 
+type ProgressPatch = Partial<
+  Pick<StepProgressRow, 'read_done' | 'practice_done' | 'test_done' | 'challenge_done' | 'completed_at'>
+>
+
 export async function getStepProgress(userId: string, stepId: string): Promise<StepProgressRow | null> {
   const { data, error } = await supabase
     .from('step_progress')
@@ -28,12 +32,26 @@ export async function getStepProgress(userId: string, stepId: string): Promise<S
   return data
 }
 
-export async function updateModeCompletion(userId: string, stepId: string, mode: ProgressMode) {
-  const patch: Partial<StepProgressRow> = {
+export async function upsertProgress(userId: string, stepId: string, patch: ProgressPatch) {
+  const payload: Partial<StepProgressRow> = {
     user_id: userId,
     step_id: stepId,
     updated_at: new Date().toISOString(),
+    ...patch,
   }
+
+  const { error } = await supabase.from('step_progress').upsert(payload, {
+    onConflict: 'user_id,step_id',
+    ignoreDuplicates: false,
+  })
+
+  if (error) {
+    throw error
+  }
+}
+
+export async function updateModeCompletion(userId: string, stepId: string, mode: ProgressMode) {
+  const patch: ProgressPatch = {}
 
   if (mode === 'read') {
     patch.read_done = true
@@ -48,14 +66,7 @@ export async function updateModeCompletion(userId: string, stepId: string, mode:
     patch.challenge_done = true
   }
 
-  const { error } = await supabase.from('step_progress').upsert(patch, {
-    onConflict: 'user_id,step_id',
-    ignoreDuplicates: false,
-  })
-
-  if (error) {
-    throw error
-  }
+  await upsertProgress(userId, stepId, patch)
 }
 
 export async function getCompletedStepCount(userId: string) {


### PR DESCRIPTION
## 概要
- Readモード完了時の保存処理を `progressService.upsertProgress()` 経由に統一
- 保存後に `StepPage` のモード状態をDBから再取得して同期
- Read完了ボタンを完了済み状態で無効化し、UI上の反応を明確化

## 変更内容
- `progressService.ts`
  - `upsertProgress(userId, stepId, patch)` を追加
  - `updateModeCompletion()` は `upsertProgress()` を利用する形に整理
- `StepPage.tsx`
  - Read完了時は `upsertProgress(..., { read_done: true })` を実行
  - 保存後に `getStepProgress()` を再取得して `modeStatus` を同期
- `ReadMode.tsx`
  - `isCompleted` props を追加
  - 完了済みならボタンを disabled + ラベルを「Read完了済み」に変更

## ステップID整合確認
- `docs/coden-v1.md` のコース1正式ID（`usestate-basic`, `events`, `conditional`, `lists`）と、
  `apps/web/src/content/courseData.ts` / `apps/web/src/content/fundamentals/steps.ts` の定義が一致していることを確認
- `useState-todo` の参照はコード上に存在しないことを確認

## 検証
- `cmd /c npm --workspace apps/web run typecheck` : 成功
- `cmd /c npm run build` : 成功
- `cmd /c npm --workspace apps/web run test` : 失敗（`@coden/web` に `test` script 未定義）

## Issue要否
- 不要（`docs/roadmaps/roadmap03.md` の M1-2 タスクで管理済みのため二重管理を避ける）