### PR TITLE
feat: 未到達ステップへのアクセスロック強化（UIルーティング）

### DIFF
--- a/apps/web/src/components/LearningSidebar.tsx
+++ b/apps/web/src/components/LearningSidebar.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import type { LearningStepContent } from '../content/fundamentals/steps'
+import { useLearningContext } from '../contexts/LearningContext'
 
 interface LearningSidebarProps {
   currentStepId: string
@@ -7,25 +8,47 @@ interface LearningSidebarProps {
 }
 
 export function LearningSidebar({ currentStepId, steps }: LearningSidebarProps) {
+  const { completedStepsCount, isLoadingStats } = useLearningContext()
+
   return (
     <aside className="w-full rounded-2xl border border-slate-200 bg-white p-4 shadow-sm lg:w-72">
       <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">React基礎コース</p>
       <ul className="mt-3 space-y-2">
         {steps.map((step) => {
           const isCurrent = step.id === currentStepId
+          const isLocked = !isLoadingStats && step.order > completedStepsCount + 1
+
+          const content = (
+            <>
+              <p className="text-xs text-slate-500">
+                STEP {step.order} {isLocked ? '🔒' : ''}
+              </p>
+              <p className="font-medium">{step.title}</p>
+            </>
+          )
+
+          const baseClass = `block rounded-lg border px-3 py-2 text-sm transition`
+
+          if (isLocked) {
+            return (
+              <li key={step.id}>
+                <div className={`${baseClass} border-slate-200 bg-slate-50 text-slate-400 opacity-60`}>
+                  {content}
+                </div>
+              </li>
+            )
+          }
 
           return (
             <li key={step.id}>
               <Link
-                className={`block rounded-lg border px-3 py-2 text-sm transition ${
-                  isCurrent
+                className={`${baseClass} ${isCurrent
                     ? 'border-blue-300 bg-blue-50 text-blue-900'
                     : 'border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50'
-                }`}
+                  }`}
                 to={`/step/${step.id}`}
               >
-                <p className="text-xs text-slate-500">STEP {step.order}</p>
-                <p className="font-medium">{step.title}</p>
+                {content}
               </Link>
             </li>
           )

--- a/apps/web/src/contexts/LearningContext.tsx
+++ b/apps/web/src/contexts/LearningContext.tsx
@@ -1,15 +1,18 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
 import { useAuth } from './AuthContext'
 import { getLearningStats, type LearningStats } from '../services/pointService'
+import { getCompletedStepCount } from '../services/progressService'
 
 interface LearningContextType {
     stats: LearningStats | null
+    completedStepsCount: number
     isLoadingStats: boolean
     refreshStats: () => Promise<void>
 }
 
 const LearningContext = createContext<LearningContextType>({
     stats: null,
+    completedStepsCount: 0,
     isLoadingStats: true,
     refreshStats: async () => { },
 })
@@ -17,18 +20,24 @@ const LearningContext = createContext<LearningContextType>({
 export function LearningProvider({ children }: { children: ReactNode }) {
     const { user } = useAuth()
     const [stats, setStats] = useState<LearningStats | null>(null)
+    const [completedStepsCount, setCompletedStepsCount] = useState(0)
     const [isLoadingStats, setIsLoadingStats] = useState(true)
 
     const refreshStats = async () => {
         if (!user) {
             setStats(null)
+            setCompletedStepsCount(0)
             setIsLoadingStats(false)
             return
         }
 
         try {
-            const currentStats = await getLearningStats(user.id)
+            const [currentStats, count] = await Promise.all([
+                getLearningStats(user.id),
+                getCompletedStepCount(user.id)
+            ])
             setStats(currentStats)
+            setCompletedStepsCount(count)
         } catch (err) {
             console.error('Failed to load learning stats:', err)
         } finally {
@@ -50,7 +59,7 @@ export function LearningProvider({ children }: { children: ReactNode }) {
     }, [user])
 
     return (
-        <LearningContext.Provider value={{ stats, isLoadingStats, refreshStats }}>
+        <LearningContext.Provider value={{ stats, completedStepsCount, isLoadingStats, refreshStats }}>
             {children}
         </LearningContext.Provider>
     )

--- a/apps/web/src/features/dashboard/components/LearningOverviewCard.tsx
+++ b/apps/web/src/features/dashboard/components/LearningOverviewCard.tsx
@@ -17,10 +17,12 @@ interface StepRowProps {
   step: StepMeta
   isInProgress: boolean
   isDone: boolean
+  isLockedByProgress: boolean
 }
 
-function StepRow({ step, isInProgress, isDone }: StepRowProps) {
-  const isLocked = !step.isImplemented
+function StepRow({ step, isInProgress, isDone, isLockedByProgress }: StepRowProps) {
+  const isUnimplemented = !step.isImplemented
+  const isLocked = isUnimplemented || isLockedByProgress
 
   const borderBg = isInProgress
     ? 'border-primary-mint bg-secondary-bg'
@@ -32,7 +34,7 @@ function StepRow({ step, isInProgress, isDone }: StepRowProps) {
     ? { label: '学習中', cls: 'bg-primary-mint text-white' }
     : isDone
       ? { label: '完了', cls: 'bg-emerald-100 text-emerald-700' }
-      : { label: isLocked ? '準備中' : 'ロック中', cls: 'bg-slate-200 text-slate-500' }
+      : { label: isUnimplemented ? '準備中' : 'ロック中', cls: 'bg-slate-200 text-slate-500' }
 
   const icon = isLocked ? '🔒' : isDone ? '✅' : isInProgress ? '📖' : '📝'
 
@@ -120,12 +122,14 @@ export function LearningOverviewCard({ completedCount }: LearningOverviewCardPro
                 {course.steps.map((step) => {
                   const isDone = step.isImplemented && step.order <= completedCount
                   const isInProgress = inProgressStep?.id === step.id
+                  const isLockedByProgress = step.isImplemented && step.order > completedCount + 1
                   return (
                     <StepRow
                       key={step.id}
                       step={step}
                       isInProgress={isInProgress}
                       isDone={isDone}
+                      isLockedByProgress={isLockedByProgress}
                     />
                   )
                 })}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -3,18 +3,18 @@ import { Link, useNavigate } from 'react-router-dom'
 import { ConfigErrorView } from '../components/ConfigErrorView'
 import { IMPLEMENTED_STEP_COUNT } from '../content/courseData'
 import { useAuth } from '../contexts/AuthContext'
+import { useLearningContext } from '../contexts/LearningContext'
 import { AppHeader } from '../features/dashboard/components/AppHeader'
 import { DashboardSidebar } from '../features/dashboard/components/DashboardSidebar'
 import { LearningOverviewCard } from '../features/dashboard/components/LearningOverviewCard'
 import { WelcomeBanner } from '../features/dashboard/components/WelcomeBanner'
 import { supabase, supabaseConfigError } from '../lib/supabaseClient'
-import { getCompletedStepCount } from '../services/progressService'
 
 export function DashboardPage() {
   const { user, signOut } = useAuth()
+  const { completedStepsCount } = useLearningContext()
   const navigate = useNavigate()
   const userId = user?.id ?? null
-  const [completedCount, setCompletedCount] = useState(0)
   const [displayName, setDisplayName] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
@@ -40,16 +40,11 @@ export function DashboardPage() {
 
     async function loadDashboard() {
       try {
-        const [count, profileResult] = await Promise.all([
-          getCompletedStepCount(currentUserId),
-          supabase.from('profiles').select('display_name').eq('id', currentUserId).maybeSingle(),
-        ])
+        const profileResult = await supabase.from('profiles').select('display_name').eq('id', currentUserId).maybeSingle()
 
         if (!isMounted) {
           return
         }
-
-        setCompletedCount(count)
 
         if (!profileResult.error) {
           setDisplayName(profileResult.data?.display_name ?? null)
@@ -93,7 +88,7 @@ export function DashboardPage() {
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
           <section className="space-y-6 lg:col-span-8">
             <WelcomeBanner displayName={greetingName} />
-            <LearningOverviewCard completedCount={Math.min(completedCount, IMPLEMENTED_STEP_COUNT)} />
+            <LearningOverviewCard completedCount={Math.min(completedStepsCount, IMPLEMENTED_STEP_COUNT)} />
             <Link className="inline-flex text-sm font-semibold text-primary-dark underline" to="/step/usestate-basic">
               学習画面へ移動（/step/usestate-basic）
             </Link>

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -34,7 +34,7 @@ function toModeStatus(progress: Awaited<ReturnType<typeof getStepProgress>>): Mo
 export function StepPage() {
   const { stepId = '' } = useParams()
   const { signOut, user } = useAuth()
-  const { refreshStats } = useLearningContext()
+  const { refreshStats, completedStepsCount, isLoadingStats } = useLearningContext()
   const navigate = useNavigate()
   const [activeMode, setActiveMode] = useState<LearningMode>('read')
   const [modeStatus, setModeStatus] = useState<ModeStatus>(INITIAL_MODE_STATUS)
@@ -205,8 +205,16 @@ export function StepPage() {
     navigate(`/step/${nextStep.id}`)
   }
 
-  if (isUnavailableStep) {
+  if (isUnavailableStep || (!isLoadingStats && step && step.order > completedStepsCount + 1)) {
     return <Navigate to="/" replace />
+  }
+
+  if (isLoadingStats) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50">
+        <p className="font-medium text-slate-500">読み込み中...</p>
+      </div>
+    )
   }
 
   if (!step) {
@@ -244,9 +252,8 @@ export function StepPage() {
                 return (
                   <button
                     key={mode.id}
-                    className={`rounded-md px-3 py-2 text-sm font-medium transition ${
-                      isActive ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
-                    }`}
+                    className={`rounded-md px-3 py-2 text-sm font-medium transition ${isActive ? 'bg-slate-900 text-white' : 'bg-slate-100 text-slate-700 hover:bg-slate-200'
+                      }`}
                     type="button"
                     onClick={() => setActiveMode(mode.id)}
                   >


### PR DESCRIPTION
# 概要 Utest01およびそれに伴う確認にて発覚した「未到達進捗のロック機能不備」を修正しました。 ## 修正内容 1. LearningContext にて、ユーザーの最新の「完了したステップ数(completedStepsCount)」をグローバルに保持するように改修しました。 2. その Context State を介し、以下にロックプロテクトを追加しました： - ダッシュボード（LearningOverviewCard）: 現在の進捗を上回るステップのリンクタグを除外し、実体としてクリック不可能に。 - 学習サイドバー（LearningSidebar）: 同じくリンクタグを除去し、クリック不可な枠（+ 鍵アイコン）だけを表示させるように変更。 - StepPage（学習画面直ジャンプロック）: URLを直接叩いてのアクセスを受けた際、「自分の進捗順」を満たしていない場合はエラー表示なしでダッシュボードへ強制リダイレクト（Navigate to /）させるように処理を追加しました（ロード中の白画面も「読み取り中...」画面で防御済み）。 ## Issue要否について 事後対応にはなりますが、RuleOpsに則り Issue #26 を作成し、それをクローズする形で修正しました。