### PR TITLE
feat: 判定UI刷新（非同期判定方式へ）とTestモード入力改善

### DIFF
--- a/apps/web/src/features/learning/ChallengeMode.tsx
+++ b/apps/web/src/features/learning/ChallengeMode.tsx
@@ -20,9 +20,14 @@ export function ChallengeMode({ task, onComplete }: ChallengeModeProps) {
 
   function handleCheck() {
     setChecked(true)
-    if (missingKeywords.length === 0) {
+    if (isPassed) {
       onComplete()
     }
+  }
+
+  function handleCodeChange(nextValue: string | undefined) {
+    setChecked(false)
+    setCode(nextValue ?? '')
   }
 
   return (
@@ -44,34 +49,36 @@ export function ChallengeMode({ task, onComplete }: ChallengeModeProps) {
             theme="vs-dark"
             value={code}
             options={{ minimap: { enabled: false }, fontSize: 14 }}
-            onChange={(nextValue) => setCode(nextValue ?? '')}
+            onChange={handleCodeChange}
           />
         </Suspense>
       </div>
 
-      <button
-        className="rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-500"
-        type="button"
-        onClick={handleCheck}
-      >
-        キーワードチェック
-      </button>
+      <div className="flex flex-col items-start gap-4 pt-4 sm:flex-row sm:items-center">
+        <button
+          className="rounded-md bg-blue-600 px-6 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-500 active:bg-blue-700"
+          type="button"
+          onClick={handleCheck}
+        >
+          判定する
+        </button>
 
-      {checked ? (
-        <div className={`rounded-lg border p-4 ${isPassed ? 'border-emerald-300 bg-emerald-50' : 'border-rose-300 bg-rose-50'}`}>
-          {isPassed ? (
-            <p className="text-sm font-medium text-emerald-700">Challengeを完了しました。</p>
-          ) : (
-            <>
-              <p className="text-sm font-medium text-rose-700">不足キーワードがあります。</p>
-              <ul className="mt-2 list-inside list-disc text-sm text-rose-700">
-                {missingKeywords.map((keyword) => (
-                  <li key={keyword}>{keyword}</li>
-                ))}
-              </ul>
-              <p className="mt-2 text-sm text-rose-700">ヒント: {task.hints[0]}</p>
-            </>
-          )}
+        {checked && (
+          <p className={`text-sm font-medium ${isPassed ? 'text-emerald-700' : 'text-rose-700'}`}>
+            {isPassed ? '🎉 Challengeを完了しました！' : '❌ 要件を満たしていません。'}
+          </p>
+        )}
+      </div>
+
+      {checked && !isPassed ? (
+        <div className="rounded-lg border border-rose-300 bg-rose-50 p-4">
+          <p className="text-sm font-medium text-rose-700">不足キーワードがあります:</p>
+          <ul className="mt-2 list-inside list-disc text-sm text-rose-700">
+            {missingKeywords.map((keyword) => (
+              <li key={keyword}>{keyword}</li>
+            ))}
+          </ul>
+          {task.hints.length > 0 && <p className="mt-2 text-sm text-rose-700">ヒント: {task.hints[0]}</p>}
         </div>
       ) : null}
     </section>

--- a/apps/web/src/features/learning/PracticeMode.tsx
+++ b/apps/web/src/features/learning/PracticeMode.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { PracticeQuestion } from '../../content/fundamentals/steps'
 
 interface PracticeModeProps {
@@ -13,6 +13,7 @@ function normalize(value: string) {
 export function PracticeMode({ questions, onComplete }: PracticeModeProps) {
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [hints, setHints] = useState<Record<string, boolean>>({})
+  const [isJudged, setIsJudged] = useState(false)
   const [reported, setReported] = useState(false)
 
   const isAllCorrect = useMemo(
@@ -24,12 +25,21 @@ export function PracticeMode({ questions, onComplete }: PracticeModeProps) {
     [answers, questions],
   )
 
-  useEffect(() => {
+  function handleJudge() {
+    setIsJudged(true)
     if (isAllCorrect && !reported) {
       onComplete()
       setReported(true)
     }
-  }, [isAllCorrect, onComplete, reported])
+  }
+
+  function handleAnswerChange(questionId: string, value: string) {
+    setIsJudged(false)
+    setAnswers((prev) => ({
+      ...prev,
+      [questionId]: value,
+    }))
+  }
 
   return (
     <section className="mt-4 space-y-4">
@@ -44,19 +54,19 @@ export function PracticeMode({ questions, onComplete }: PracticeModeProps) {
               Q{index + 1}. {question.prompt}
             </p>
             <input
-              className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
+              className={`w-full rounded-md border px-3 py-2 text-sm ${isJudged
+                ? isCorrect
+                  ? 'border-emerald-500 bg-emerald-50/50'
+                  : 'border-rose-500 bg-rose-50/50'
+                : 'border-slate-300'
+                }`}
               placeholder="回答を入力"
               value={answer}
-              onChange={(event) =>
-                setAnswers((prev) => ({
-                  ...prev,
-                  [question.id]: event.target.value,
-                }))
-              }
+              onChange={(event) => handleAnswerChange(question.id, event.target.value)}
             />
-            {answer.length > 0 ? (
+            {isJudged ? (
               <p className={`text-sm font-medium ${isCorrect ? 'text-emerald-700' : 'text-rose-700'}`}>
-                {isCorrect ? '正解です。' : '不正解です。もう一度試してください。'}
+                {isCorrect ? '✅ 正解です。' : '❌ 不正解です。もう一度試してください。'}
               </p>
             ) : null}
             <button
@@ -76,9 +86,21 @@ export function PracticeMode({ questions, onComplete }: PracticeModeProps) {
         )
       })}
 
-      <p className={`text-sm font-medium ${isAllCorrect ? 'text-emerald-700' : 'text-slate-600'}`}>
-        {isAllCorrect ? 'Practiceを完了しました。' : 'すべての問題に正解すると完了です。'}
-      </p>
+      <div className="flex flex-col items-start gap-4 pt-4 sm:flex-row sm:items-center">
+        <button
+          className="rounded-md bg-blue-600 px-6 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-500 active:bg-blue-700"
+          type="button"
+          onClick={handleJudge}
+        >
+          判定する
+        </button>
+
+        {isJudged && (
+          <p className={`text-sm font-medium ${isAllCorrect ? 'text-emerald-700' : 'text-rose-700'}`}>
+            {isAllCorrect ? '🎉 すべて正解！Practiceを完了しました。' : '⚠️ すべての問題に正解すると完了です。'}
+          </p>
+        )}
+      </div>
     </section>
   )
 }

--- a/apps/web/src/features/learning/TestMode.tsx
+++ b/apps/web/src/features/learning/TestMode.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { Fragment, useMemo, useState } from 'react'
 import type { TestTask } from '../../content/fundamentals/steps'
 
 interface TestModeProps {
@@ -28,6 +28,7 @@ const previewByStepId: Record<string, { title: string; description: string }> = 
 
 export function TestMode({ stepId, task, onComplete }: TestModeProps) {
   const [blankInput, setBlankInput] = useState('')
+  const [isJudged, setIsJudged] = useState(false)
   const [reported, setReported] = useState(false)
 
   const mergedCode = useMemo(() => task.starterCode.replace('____', blankInput), [blankInput, task.starterCode])
@@ -38,12 +39,20 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
     [blankInput, mergedCode, task.expectedKeywords],
   )
 
-  useEffect(() => {
+  function handleJudge() {
+    setIsJudged(true)
     if (isPassed && !reported) {
       onComplete()
       setReported(true)
     }
-  }, [isPassed, onComplete, reported])
+  }
+
+  function handleInputChange(value: string) {
+    setIsJudged(false)
+    setBlankInput(value)
+  }
+
+  const parts = task.starterCode.split('____')
 
   const preview = previewByStepId[stepId]
 
@@ -52,31 +61,47 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
       <h2 className="text-lg font-semibold">Test</h2>
       <p className="text-sm text-slate-700">{task.instruction}</p>
 
-      <div className="space-y-2 rounded-lg border border-slate-200 bg-slate-50 p-4">
-        <label className="text-sm font-medium text-slate-700" htmlFor="test-blank">
-          空欄入力
-        </label>
-        <input
-          id="test-blank"
-          className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm"
-          placeholder="例: setCount(count + 1)"
-          value={blankInput}
-          onChange={(event) => setBlankInput(event.target.value)}
-        />
-      </div>
-
-      <pre className="overflow-x-auto rounded-lg border border-slate-300 bg-slate-900 p-4 text-sm text-slate-100">
-        {mergedCode}
+      <pre className="overflow-x-auto whitespace-pre-wrap break-all rounded-lg border border-slate-300 bg-slate-900 p-4 font-mono text-sm leading-relaxed text-slate-100">
+        {parts.map((part, index) => (
+          <Fragment key={index}>
+            {part}
+            {index < parts.length - 1 && (
+              <input
+                className={`mx-1 inline-block w-64 rounded bg-slate-800 px-2 py-0.5 text-emerald-300 outline-none ring-1 placeholder:text-slate-500 focus:ring-2 ${isJudged
+                    ? isPassed
+                      ? 'ring-emerald-500 focus:ring-emerald-400'
+                      : 'ring-rose-500 focus:ring-rose-400'
+                    : 'ring-slate-500 focus:ring-blue-400'
+                  }`}
+                placeholder="例: setCount(count + 1)"
+                value={blankInput}
+                onChange={(event) => handleInputChange(event.target.value)}
+              />
+            )}
+          </Fragment>
+        ))}
       </pre>
 
-      <p className={`text-sm font-medium ${isPassed ? 'text-emerald-700' : 'text-slate-600'}`}>
-        {isPassed ? 'テスト合格。ライブプレビューが解禁されました。' : '必要キーワードを満たすと合格です。'}
-      </p>
+      <div className="flex flex-col items-start gap-4 pt-4 sm:flex-row sm:items-center">
+        <button
+          className="rounded-md bg-blue-600 px-6 py-2.5 text-sm font-medium text-white shadow-sm transition-colors hover:bg-blue-500 active:bg-blue-700"
+          type="button"
+          onClick={handleJudge}
+        >
+          判定する
+        </button>
 
-      {isPassed && preview ? (
-        <div className="rounded-lg border border-emerald-300 bg-emerald-50 p-4">
+        {isJudged && (
+          <p className={`text-sm font-medium ${isPassed ? 'text-emerald-700' : 'text-rose-700'}`}>
+            {isPassed ? '🎉 テスト合格！ライブプレビューが解禁されました。' : '❌ 必要キーワードを満たしていません。もう一度試してください。'}
+          </p>
+        )}
+      </div>
+
+      {isJudged && isPassed && preview ? (
+        <div className="mt-4 rounded-lg border border-emerald-300 bg-emerald-50 p-4">
           <p className="text-sm font-semibold text-emerald-800">{preview.title}</p>
-          <p className="text-sm text-emerald-700">{preview.description}</p>
+          <p className="mt-1 text-sm text-emerald-700">{preview.description}</p>
         </div>
       ) : null}
     </section>


### PR DESCRIPTION
Issue要否: 不要 根拠: Roadmap 03の「M2-1: 判定UI刷新（非同期判定方式へ）」として定義済みの範囲内であるため。内容: Practice / Test / Challenge の各モードに「判定する」ボタンを設置し、クリック時にのみ成否ダイアログが表示されるように修正。Testモードのコード内空欄を直接入力できるインライン形式に変更。