### PR TITLE
feat: M6-1 バッジ解禁とAchievementContextを実装

### DIFF
--- a/apps/web/src/contexts/AchievementContext.tsx
+++ b/apps/web/src/contexts/AchievementContext.tsx
@@ -1,0 +1,102 @@
+import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react'
+import { BADGE_DEFINITIONS, checkAndUnlockAchievements, getUnlockedAchievements, type BadgeId } from '../services/achievementService'
+import { useAuth } from './AuthContext'
+
+interface AchievementContextType {
+  unlockedBadgeIds: BadgeId[]
+  refreshAchievements: () => Promise<void>
+  isChecking: boolean
+}
+
+const AchievementContext = createContext<AchievementContextType | null>(null)
+
+export function useAchievementContext() {
+  const context = useContext(AchievementContext)
+  if (!context) {
+    throw new Error('useAchievementContext must be used within an AchievementProvider')
+  }
+  return context
+}
+
+export function AchievementProvider({ children }: { children: ReactNode }) {
+  const { user } = useAuth()
+  const userId = user?.id ?? null
+  const [unlockedBadgeIds, setUnlockedBadgeIds] = useState<BadgeId[]>([])
+  const [newlyUnlockedBadge, setNewlyUnlockedBadge] = useState<BadgeId | null>(null)
+  const [toastQueue, setToastQueue] = useState<BadgeId[]>([])
+  const [isChecking, setIsChecking] = useState(false)
+
+  const refreshAchievements = useCallback(async () => {
+    if (!userId) {
+      setUnlockedBadgeIds([])
+      setToastQueue([])
+      setNewlyUnlockedBadge(null)
+      setIsChecking(false)
+      return
+    }
+
+    setIsChecking(true)
+    try {
+      const newlyUnlocked = await checkAndUnlockAchievements(userId)
+      const latestUnlocked = await getUnlockedAchievements(userId)
+      setUnlockedBadgeIds(latestUnlocked)
+
+      if (newlyUnlocked.length > 0) {
+        setToastQueue((prev) => [...prev, ...newlyUnlocked])
+      }
+    } finally {
+      setIsChecking(false)
+    }
+  }, [userId])
+
+  useEffect(() => {
+    void refreshAchievements().catch((error) => {
+      console.error('Failed to refresh achievements:', error)
+    })
+  }, [refreshAchievements])
+
+  useEffect(() => {
+    if (newlyUnlockedBadge || toastQueue.length === 0) {
+      return
+    }
+
+    const [nextBadge, ...rest] = toastQueue
+    setNewlyUnlockedBadge(nextBadge)
+    setToastQueue(rest)
+  }, [newlyUnlockedBadge, toastQueue])
+
+  useEffect(() => {
+    if (!newlyUnlockedBadge) {
+      return
+    }
+
+    const timer = window.setTimeout(() => {
+      setNewlyUnlockedBadge(null)
+    }, 4000)
+
+    return () => window.clearTimeout(timer)
+  }, [newlyUnlockedBadge])
+
+  const badgeDef = newlyUnlockedBadge ? BADGE_DEFINITIONS.find((badge) => badge.id === newlyUnlockedBadge) : null
+
+  return (
+    <AchievementContext.Provider value={{ unlockedBadgeIds, refreshAchievements, isChecking }}>
+      {children}
+
+      {badgeDef ? (
+        <div className="fixed bottom-5 right-5 z-50 animate-bounce rounded-xl border-2 border-amber-300 bg-amber-50 px-4 py-3 shadow-xl">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-amber-200 text-xl shadow-inner">
+              🏆
+            </div>
+            <div>
+              <p className="text-xs font-bold text-amber-600">新しいバッジを獲得しました！</p>
+              <p className="font-semibold text-amber-900">{badgeDef.name}</p>
+              <p className="text-xs text-amber-700">{badgeDef.description}</p>
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </AchievementContext.Provider>
+  )
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,7 @@ import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 import { ProtectedRoute, GuestRoute } from './components/ProtectedRoute'
 import { AuthProvider } from './contexts/AuthContext'
 import { LearningProvider } from './contexts/LearningContext'
+import { AchievementProvider } from './contexts/AchievementContext'
 import { DashboardPage } from './pages/DashboardPage'
 import { LoginPage } from './pages/LoginPage'
 import { StepPage } from './pages/StepPage'
@@ -55,7 +56,9 @@ if (supabaseConfigError) {
     <React.StrictMode>
       <AuthProvider>
         <LearningProvider>
-          <RouterProvider router={router} />
+          <AchievementProvider>
+            <RouterProvider router={router} />
+          </AchievementProvider>
         </LearningProvider>
       </AuthProvider>
     </React.StrictMode>,

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -6,6 +6,7 @@ import { fundamentalsSteps, getFundamentalsStep, type LearningMode } from '../co
 import { getIntermediateStep, intermediateSteps } from '../content/intermediate/steps'
 import { useAuth } from '../contexts/AuthContext'
 import { useLearningContext } from '../contexts/LearningContext'
+import { useAchievementContext } from '../contexts/AchievementContext'
 import { AppHeader } from '../features/dashboard/components/AppHeader'
 import { ChallengeMode } from '../features/learning/ChallengeMode'
 import { PracticeMode } from '../features/learning/PracticeMode'
@@ -36,6 +37,7 @@ export function StepPage() {
   const { stepId = '' } = useParams()
   const { signOut, user } = useAuth()
   const { refreshStats, completedStepsCount, isLoadingStats } = useLearningContext()
+  const { refreshAchievements } = useAchievementContext()
   const navigate = useNavigate()
   const [activeMode, setActiveMode] = useState<LearningMode>('read')
   const [modeStatus, setModeStatus] = useState<ModeStatus>(INITIAL_MODE_STATUS)
@@ -190,13 +192,18 @@ export function StepPage() {
         const reason = `「${step.title}」の${mode}モード完了`
         await awardPoints(user.id, 10, reason)
         await refreshStats()
+        try {
+          await refreshAchievements()
+        } catch (err) {
+          console.error('Achievement refresh failed:', err)
+        }
       } catch (error) {
         setModeStatus((prev) => ({ ...prev, [mode]: false }))
         const message = error instanceof Error ? error.message : '進捗保存に失敗しました。'
         setSyncMessage(message)
       }
     },
-    [modeStatus, refreshStats, step, user?.id],
+    [modeStatus, refreshStats, refreshAchievements, step, user?.id],
   )
 
   async function handleSignOut() {

--- a/apps/web/src/services/achievementService.ts
+++ b/apps/web/src/services/achievementService.ts
@@ -1,0 +1,144 @@
+import { COURSES } from '../content/courseData'
+import { supabase } from '../lib/supabaseClient'
+import { getAllStepProgress } from './progressService'
+import { getLearningStats } from './pointService'
+
+export interface Achievement {
+  id: string
+  user_id: string
+  badge_id: BadgeId
+  earned_at: string
+}
+
+export const BADGE_DEFINITIONS = [
+  { id: 'first-step', name: '最初の一歩', description: '初めてステップを完了した' },
+  { id: 'first-challenge', name: '初チャレンジャー', description: '初めてチャレンジモードをクリアした' },
+  { id: 'streak-3', name: '3日連続', description: '3日連続で学習した' },
+  { id: 'streak-7', name: '週間学習者', description: '7日連続で学習した' },
+  { id: 'streak-30', name: '継続の達人', description: '30日連続で学習した' },
+  { id: 'course-1-complete', name: '基礎マスター', description: 'React基礎コースを完了した' },
+  { id: 'course-2-complete', name: '応用習得者', description: 'React応用コースを完了した' },
+  { id: 'course-3-complete', name: '実践者', description: 'React実践コースを完了した' },
+  { id: 'course-4-complete', name: 'API連携マスター', description: 'API連携実践コースを完了した' },
+  { id: 'all-complete', name: 'Coden完走者', description: '全20ステップを完了した' },
+  { id: 'pt-500', name: '500Pt達成', description: '累計500Pt以上を獲得した' },
+  { id: 'pt-1000', name: '1000Pt達成', description: '累計1000Pt以上を獲得した' },
+] as const
+
+export type BadgeId = (typeof BADGE_DEFINITIONS)[number]['id']
+
+const BADGE_ID_SET = new Set<BadgeId>(BADGE_DEFINITIONS.map((badge) => badge.id))
+const ALL_STEP_IDS = COURSES.flatMap((course) => course.steps.map((step) => step.id))
+const COURSE_COMPLETION_RULES: Array<{ badgeId: BadgeId; stepIds: string[] }> = [
+  { badgeId: 'course-1-complete', stepIds: getCourseStepIds('course-1') },
+  { badgeId: 'course-2-complete', stepIds: getCourseStepIds('course-2') },
+  { badgeId: 'course-3-complete', stepIds: getCourseStepIds('course-3') },
+  { badgeId: 'course-4-complete', stepIds: getCourseStepIds('course-4') },
+]
+
+function getCourseStepIds(courseId: string): string[] {
+  return COURSES.find((course) => course.id === courseId)?.steps.map((step) => step.id) ?? []
+}
+
+function isBadgeId(value: string): value is BadgeId {
+  return BADGE_ID_SET.has(value as BadgeId)
+}
+
+function isStepCompleted(progress: {
+  read_done: boolean
+  practice_done: boolean
+  test_done: boolean
+  challenge_done: boolean
+}) {
+  return progress.read_done && progress.practice_done && progress.test_done && progress.challenge_done
+}
+
+export async function getUnlockedAchievements(userId: string): Promise<BadgeId[]> {
+  const { data, error } = await supabase.from('achievements').select('badge_id').eq('user_id', userId)
+
+  if (error) {
+    throw error
+  }
+
+  return (data ?? []).map((row) => row.badge_id).filter(isBadgeId)
+}
+
+export async function unlockAchievement(userId: string, badgeId: BadgeId): Promise<boolean> {
+  const { error } = await supabase.from('achievements').insert({ user_id: userId, badge_id: badgeId })
+
+  if (!error) {
+    return true
+  }
+
+  if (error.code === '23505') {
+    return false
+  }
+
+  throw error
+}
+
+export async function checkAndUnlockAchievements(userId: string): Promise<BadgeId[]> {
+  const newlyUnlocked: BadgeId[] = []
+  const [unlockedBadgeIds, progresses, stats] = await Promise.all([
+    getUnlockedAchievements(userId),
+    getAllStepProgress(userId),
+    getLearningStats(userId),
+  ])
+  const unlockedSet = new Set<BadgeId>(unlockedBadgeIds)
+  const completedStepIds = new Set(progresses.filter(isStepCompleted).map((progress) => progress.step_id))
+
+  const tryUnlock = async (badgeId: BadgeId) => {
+    if (unlockedSet.has(badgeId)) {
+      return
+    }
+
+    const unlockedNow = await unlockAchievement(userId, badgeId)
+    if (!unlockedNow) {
+      return
+    }
+
+    unlockedSet.add(badgeId)
+    newlyUnlocked.push(badgeId)
+  }
+
+  if (completedStepIds.size >= 1) {
+    await tryUnlock('first-step')
+  }
+
+  if (progresses.some((progress) => progress.challenge_done)) {
+    await tryUnlock('first-challenge')
+  }
+
+  if (stats.current_streak >= 3) {
+    await tryUnlock('streak-3')
+  }
+  if (stats.current_streak >= 7) {
+    await tryUnlock('streak-7')
+  }
+  if (stats.current_streak >= 30) {
+    await tryUnlock('streak-30')
+  }
+
+  for (const rule of COURSE_COMPLETION_RULES) {
+    if (rule.stepIds.length === 0) {
+      continue
+    }
+
+    if (rule.stepIds.every((stepId) => completedStepIds.has(stepId))) {
+      await tryUnlock(rule.badgeId)
+    }
+  }
+
+  if (ALL_STEP_IDS.length > 0 && ALL_STEP_IDS.every((stepId) => completedStepIds.has(stepId))) {
+    await tryUnlock('all-complete')
+  }
+
+  if (stats.total_points >= 500) {
+    await tryUnlock('pt-500')
+  }
+  if (stats.total_points >= 1000) {
+    await tryUnlock('pt-1000')
+  }
+
+  return newlyUnlocked
+}

--- a/apps/web/src/services/progressService.ts
+++ b/apps/web/src/services/progressService.ts
@@ -17,6 +17,19 @@ type ProgressPatch = Partial<
   Pick<StepProgressRow, 'read_done' | 'practice_done' | 'test_done' | 'challenge_done' | 'completed_at'>
 >
 
+export async function getAllStepProgress(userId: string): Promise<StepProgressRow[]> {
+  const { data, error } = await supabase
+    .from('step_progress')
+    .select('user_id, step_id, read_done, practice_done, test_done, challenge_done, updated_at, completed_at')
+    .eq('user_id', userId)
+
+  if (error) {
+    throw error
+  }
+
+  return data as StepProgressRow[]
+}
+
 export async function getStepProgress(userId: string, stepId: string): Promise<StepProgressRow | null> {
   const { data, error } = await supabase
     .from('step_progress')


### PR DESCRIPTION
## 概要
- M6-1としてachievementServiceを追加し、coden-v1 4-4の全バッジ条件を判定
- AchievementContextを追加し、解禁時トースト通知を表示
- StepPage完了時に実績再評価を行うよう連携

## 変更内容
- apps/web/src/services/achievementService.ts
- apps/web/src/contexts/AchievementContext.tsx
- apps/web/src/services/progressService.ts
- apps/web/src/pages/StepPage.tsx
- apps/web/src/main.tsx

## 検証
- cmd /c npm run typecheck
- cmd /c npm run build

## Issue要否
- 不要（roadmap03のM6-1タスクとして管理済み）