### PR TITLE
feat: M6-2 学習ヒートマップと統計をDB連携

### DIFF
--- a/apps/web/src/contexts/LearningContext.tsx
+++ b/apps/web/src/contexts/LearningContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
 import { useAuth } from './AuthContext'
-import { getLearningStats, type LearningStats } from '../services/pointService'
+import { getLearningStats, type LearningStats } from '../services/statsService'
 import { getCompletedStepCount } from '../services/progressService'
 
 interface LearningContextType {

--- a/apps/web/src/features/dashboard/components/DashboardSidebar.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardSidebar.tsx
@@ -1,4 +1,19 @@
-const HEATMAP_LEVELS = [0, 1, 2, 1, 0, 3, 2, 0, 0, 1, 2, 3, 1, 0, 0, 0, 2, 1, 3, 2, 0, 1, 2, 3, 1, 0, 2, 1]
+import { useEffect, useMemo, useState } from 'react'
+import { useAuth } from '../../../contexts/AuthContext'
+import { useLearningContext } from '../../../contexts/LearningContext'
+import {
+  calculatePointGoalProgress,
+  countMonthlyStudyDays,
+  getLearningHeatmap,
+  type HeatmapCell,
+} from '../../../services/statsService'
+
+const HEATMAP_DAYS = 30
+const EMPTY_HEATMAP: HeatmapCell[] = Array.from({ length: HEATMAP_DAYS }, (_, index) => ({
+  date: `empty-${index}`,
+  count: 0,
+  level: 0,
+}))
 
 function heatmapColor(level: number) {
   if (level === 3) return 'bg-primary-dark'
@@ -8,6 +23,56 @@ function heatmapColor(level: number) {
 }
 
 export function DashboardSidebar() {
+  const { user } = useAuth()
+  const { stats } = useLearningContext()
+  const [heatmap, setHeatmap] = useState<HeatmapCell[]>([])
+  const [isLoadingHeatmap, setIsLoadingHeatmap] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+
+    if (!user?.id) {
+      setHeatmap([])
+      setIsLoadingHeatmap(false)
+      setError(null)
+      return () => {
+        isMounted = false
+      }
+    }
+
+    setIsLoadingHeatmap(true)
+    setError(null)
+
+    getLearningHeatmap(user.id, HEATMAP_DAYS)
+      .then((data) => {
+        if (isMounted) {
+          setHeatmap(data)
+        }
+      })
+      .catch((loadError) => {
+        if (!isMounted) {
+          return
+        }
+        const message = loadError instanceof Error ? loadError.message : '学習ヒートマップの取得に失敗しました。'
+        setError(message)
+        setHeatmap([])
+      })
+      .finally(() => {
+        if (isMounted) {
+          setIsLoadingHeatmap(false)
+        }
+      })
+
+    return () => {
+      isMounted = false
+    }
+  }, [user?.id])
+
+  const pointGoal = useMemo(() => calculatePointGoalProgress(stats?.total_points ?? 0), [stats?.total_points])
+  const heatmapCells = heatmap.length > 0 ? heatmap : EMPTY_HEATMAP
+  const monthlyStudyDays = useMemo(() => countMonthlyStudyDays(heatmap), [heatmap])
+
   return (
     <aside className="space-y-5">
       <section className="relative overflow-hidden rounded-2xl border border-emerald-100 bg-white shadow-sm">
@@ -18,21 +83,26 @@ export function DashboardSidebar() {
           <div className="grid grid-cols-2 gap-3">
             <div className="rounded-xl border border-orange-100 bg-orange-50 p-3 text-center">
               <p className="text-[10px] font-bold uppercase tracking-wide text-orange-600">連続学習</p>
-              <p className="mt-1 text-2xl font-black text-orange-700">3日</p>
+              <p className="mt-1 text-2xl font-black text-orange-700">{stats?.current_streak ?? 0}日</p>
             </div>
             <div className="rounded-xl border border-indigo-100 bg-indigo-50 p-3 text-center">
               <p className="text-[10px] font-bold uppercase tracking-wide text-indigo-600">合計ポイント</p>
-              <p className="mt-1 text-2xl font-black text-indigo-700">450pt</p>
+              <p className="mt-1 text-2xl font-black text-indigo-700">{stats?.total_points ?? 0}pt</p>
             </div>
           </div>
 
           <div>
             <div className="mb-1 flex justify-between text-xs font-semibold text-text-light">
-              <span>次のレベルまで</span>
-              <span className="text-primary-mint">50 / 500 pt</span>
+              <span>次の目標まで</span>
+              <span className="text-primary-mint">
+                {pointGoal.current} / {pointGoal.target} pt
+              </span>
             </div>
             <div className="h-2 w-full overflow-hidden rounded-full bg-slate-100">
-              <div className="h-full w-[10%] rounded-full bg-mint-gradient" />
+              <div
+                className="h-full rounded-full bg-mint-gradient transition-all duration-300"
+                style={{ width: `${pointGoal.percent}%` }}
+              />
             </div>
           </div>
 
@@ -57,13 +127,15 @@ export function DashboardSidebar() {
           <span className="text-xs text-text-light">過去30日</span>
         </div>
         <div className="flex flex-wrap gap-1.5">
-          {HEATMAP_LEVELS.map((level, index) => (
-            <span key={`${level}-${index}`} className={`h-3 w-3 rounded-sm ${heatmapColor(level)}`} />
+          {heatmapCells.map((cell, index) => (
+            <span key={`${cell.date}-${index}`} className={`h-3 w-3 rounded-sm ${heatmapColor(cell.level)}`} />
           ))}
         </div>
         <p className="mt-3 text-center text-xs text-text-light">
-          今月は <span className="font-bold text-text-dark">12日</span> 学習しました
+          今月は <span className="font-bold text-text-dark">{monthlyStudyDays}日</span> 学習しました
         </p>
+        {isLoadingHeatmap ? <p className="mt-2 text-center text-[11px] text-text-light">ヒートマップを更新中...</p> : null}
+        {error ? <p className="mt-2 text-center text-[11px] text-rose-600">{error}</p> : null}
       </section>
 
       <section className="rounded-2xl bg-gradient-to-br from-indigo-600 to-sky-600 p-5 text-white shadow-sm">

--- a/apps/web/src/services/achievementService.ts
+++ b/apps/web/src/services/achievementService.ts
@@ -1,7 +1,7 @@
 import { COURSES } from '../content/courseData'
 import { supabase } from '../lib/supabaseClient'
 import { getAllStepProgress } from './progressService'
-import { getLearningStats } from './pointService'
+import { getLearningStats } from './statsService'
 
 export interface Achievement {
   id: string

--- a/apps/web/src/services/pointService.ts
+++ b/apps/web/src/services/pointService.ts
@@ -1,72 +1,14 @@
 import { supabase } from '../lib/supabaseClient'
+import { applyStudyActivity, getLearningStats } from './statsService'
 
-export interface LearningStats {
-    user_id: string
-    total_points: number
-    current_streak: number
-    max_streak: number
-    last_study_date: string | null
-}
-
-export async function getLearningStats(userId: string): Promise<LearningStats> {
-    const { data, error } = await supabase
-        .from('learning_stats')
-        .select('*')
-        .eq('user_id', userId)
-        .maybeSingle()
-
-    if (error) {
-        throw error
-    }
-
-    return (
-        data ?? {
-            user_id: userId,
-            total_points: 0,
-            current_streak: 0,
-            max_streak: 0,
-            last_study_date: null,
-        }
-    )
-}
-
-function calculateStreak(stats: LearningStats, todayDateStr: string, yesterdayDateStr: string): LearningStats {
-    const newStats = { ...stats }
-
-    if (stats.last_study_date === todayDateStr) {
-        // Already studied today
-        return newStats
-    }
-
-    if (stats.last_study_date === yesterdayDateStr) {
-        // Studied yesterday, increment
-        newStats.current_streak += 1
-    } else {
-        // Broken streak or first time
-        newStats.current_streak = 1
-    }
-
-    newStats.last_study_date = todayDateStr
-    if (newStats.current_streak > newStats.max_streak) {
-        newStats.max_streak = newStats.current_streak
-    }
-
-    return newStats
-}
+export type { LearningStats } from './statsService'
 
 export async function awardPoints(userId: string, amount: number, reason: string): Promise<void> {
     // 1. Get current stats
     const stats = await getLearningStats(userId)
 
     // 2. Calculate new points and streak
-    const now = new Date()
-    const todayDateStr = now.toISOString().split('T')[0]
-
-    const yesterday = new Date(now)
-    yesterday.setDate(now.getDate() - 1)
-    const yesterdayDateStr = yesterday.toISOString().split('T')[0]
-
-    const newStats = calculateStreak(stats, todayDateStr, yesterdayDateStr)
+    const newStats = applyStudyActivity(stats)
     newStats.total_points += amount
 
     // 3. Upsert stats

--- a/apps/web/src/services/statsService.ts
+++ b/apps/web/src/services/statsService.ts
@@ -1,0 +1,184 @@
+import { supabase } from '../lib/supabaseClient'
+
+export interface LearningStats {
+  user_id: string
+  total_points: number
+  current_streak: number
+  max_streak: number
+  last_study_date: string | null
+}
+
+export interface HeatmapCell {
+  date: string
+  count: number
+  level: number
+}
+
+export interface PointGoalProgress {
+  current: number
+  target: number
+  percent: number
+}
+
+function toDateStringUtc(date: Date): string {
+  const [datePart] = date.toISOString().split('T')
+  return datePart ?? ''
+}
+
+function createDefaultLearningStats(userId: string): LearningStats {
+  return {
+    user_id: userId,
+    total_points: 0,
+    current_streak: 0,
+    max_streak: 0,
+    last_study_date: null,
+  }
+}
+
+function toHeatmapLevel(count: number): number {
+  if (count >= 3) return 3
+  if (count === 2) return 2
+  if (count === 1) return 1
+  return 0
+}
+
+function buildDateRange(days: number, now = new Date()): string[] {
+  const safeDays = Math.max(1, days)
+  const base = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+  const dateRange: string[] = []
+
+  for (let offset = safeDays - 1; offset >= 0; offset -= 1) {
+    const date = new Date(base)
+    date.setUTCDate(base.getUTCDate() - offset)
+    dateRange.push(toDateStringUtc(date))
+  }
+
+  return dateRange
+}
+
+export async function getLearningStats(userId: string): Promise<LearningStats> {
+  const { data, error } = await supabase
+    .from('learning_stats')
+    .select('user_id, total_points, current_streak, max_streak, last_study_date')
+    .eq('user_id', userId)
+    .maybeSingle()
+
+  if (error) {
+    throw error
+  }
+
+  return data ?? createDefaultLearningStats(userId)
+}
+
+export function applyStudyActivity(stats: LearningStats, now = new Date()): LearningStats {
+  const nextStats = { ...stats }
+  const todayDateStr = toDateStringUtc(now)
+  const yesterday = new Date(now)
+  yesterday.setUTCDate(yesterday.getUTCDate() - 1)
+  const yesterdayDateStr = toDateStringUtc(yesterday)
+
+  if (stats.last_study_date === todayDateStr) {
+    return nextStats
+  }
+
+  if (stats.last_study_date === yesterdayDateStr) {
+    nextStats.current_streak += 1
+  } else {
+    nextStats.current_streak = 1
+  }
+
+  nextStats.last_study_date = todayDateStr
+  if (nextStats.current_streak > nextStats.max_streak) {
+    nextStats.max_streak = nextStats.current_streak
+  }
+
+  return nextStats
+}
+
+export async function recordStudyActivity(userId: string, now = new Date()): Promise<LearningStats> {
+  const currentStats = await getLearningStats(userId)
+  const nextStats = applyStudyActivity(currentStats, now)
+
+  const { error } = await supabase.from('learning_stats').upsert(
+    {
+      user_id: userId,
+      total_points: nextStats.total_points,
+      current_streak: nextStats.current_streak,
+      max_streak: nextStats.max_streak,
+      last_study_date: nextStats.last_study_date,
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'user_id', ignoreDuplicates: false },
+  )
+
+  if (error) {
+    throw error
+  }
+
+  return nextStats
+}
+
+export async function getLearningHeatmap(userId: string, days = 30): Promise<HeatmapCell[]> {
+  const dateRange = buildDateRange(days)
+  const startDate = dateRange[0]
+
+  const { data, error } = await supabase
+    .from('point_history')
+    .select('created_at')
+    .eq('user_id', userId)
+    .gte('created_at', `${startDate}T00:00:00.000Z`)
+
+  if (error) {
+    throw error
+  }
+
+  const dateCountMap = new Map<string, number>()
+  for (const row of data ?? []) {
+    const createdAt = typeof row.created_at === 'string' ? row.created_at : ''
+    const dateKey = createdAt.slice(0, 10)
+    if (!dateKey) {
+      continue
+    }
+    dateCountMap.set(dateKey, (dateCountMap.get(dateKey) ?? 0) + 1)
+  }
+
+  return dateRange.map((date) => {
+    const count = dateCountMap.get(date) ?? 0
+    return {
+      date,
+      count,
+      level: toHeatmapLevel(count),
+    }
+  })
+}
+
+export function calculatePointGoalProgress(totalPoints: number): PointGoalProgress {
+  const milestones = [500, 1000, 1500, 2000]
+  const safePoints = Math.max(0, totalPoints)
+
+  let nextThreshold = Math.ceil((safePoints + 1) / 500) * 500
+  for (const threshold of milestones) {
+    if (threshold > safePoints) {
+      nextThreshold = threshold
+      break
+    }
+  }
+
+  let previousThreshold = 0
+  for (const threshold of milestones) {
+    if (threshold <= safePoints) {
+      previousThreshold = threshold
+    }
+  }
+
+  const target = Math.max(1, nextThreshold - previousThreshold)
+  const current = Math.max(0, safePoints - previousThreshold)
+  const percent = Math.min(100, Math.max(0, Math.round((current / target) * 100)))
+
+  return { current, target, percent }
+}
+
+export function countMonthlyStudyDays(heatmap: HeatmapCell[], now = new Date()): number {
+  const monthPrefix = toDateStringUtc(now).slice(0, 7)
+  return heatmap.filter((cell) => cell.date.startsWith(monthPrefix) && cell.count > 0).length
+}


### PR DESCRIPTION
## 概要
- M6-2として、学習統計サービス（statsService.ts）を追加
- ダッシュボードの学習ステータス/ヒートマップをDB連携に置換

## 変更内容
- pps/web/src/services/statsService.ts
  - learning_stats 取得（getLearningStats）
  - 学習日記録ロジック（pplyStudyActivity / ecordStudyActivity）
  - point_history 由来の過去30日ヒートマップ取得（getLearningHeatmap）
  - 目標Pt進捗計算（calculatePointGoalProgress）
- pps/web/src/features/dashboard/components/DashboardSidebar.tsx
  - 固定値を廃止し、learning_stats + point_history から動的表示
- pps/web/src/services/pointService.ts
  - ストリーク更新ロジックを statsService へ集約
- pps/web/src/contexts/LearningContext.tsx
  - 統計取得元を statsService へ変更
- pps/web/src/services/achievementService.ts
  - getLearningStats の参照先変更

## 検証
- 
pm --workspace apps/web run typecheck 通過
- 
pm --workspace apps/web run build 通過
- 
pm --workspace apps/web run test はスクリプト未定義

## Issue要否
- 不要
- 理由: roadmap03 の M6-2 タスクとしてスコープ/完了条件が既に定義済みのため