### PR TITLE
feat: M1-1 データ整合性修正（ポイントRPC化・バッジ isImplemented フィルタ・ストリーク統一）

### DIFF
--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -14,6 +14,7 @@ import { ReadMode } from '../features/learning/ReadMode'
 import { TestMode } from '../features/learning/TestMode'
 import { awardPoints } from '../services/pointService'
 import { getStepProgress, updateModeCompletion, upsertProgress } from '../services/progressService'
+import { recordStudyActivity } from '../services/statsService'
 
 type ModeStatus = Record<LearningMode, boolean>
 
@@ -176,6 +177,9 @@ export function StepPage() {
         return
       }
 
+      // 全モード完了前かどうかを記録（ストリーク更新の判定に使う）
+      const wasStepCompleted = modeStatus.read && modeStatus.practice && modeStatus.test && modeStatus.challenge
+
       setModeStatus((prev) => ({ ...prev, [mode]: true }))
       setSyncMessage(null)
 
@@ -188,6 +192,16 @@ export function StepPage() {
 
         const latestProgress = await getStepProgress(user.id, step.id)
         setModeStatus(toModeStatus(latestProgress))
+
+        // ストリーク更新: ステップが今回初めて全モード完了になった場合のみ実施
+        const isNowStepCompleted =
+          latestProgress?.read_done &&
+          latestProgress?.practice_done &&
+          latestProgress?.test_done &&
+          latestProgress?.challenge_done
+        if (isNowStepCompleted && !wasStepCompleted) {
+          await recordStudyActivity(user.id)
+        }
 
         const reason = `「${step.title}」の${mode}モード完了`
         await awardPoints(user.id, 10, reason)

--- a/apps/web/src/services/achievementService.ts
+++ b/apps/web/src/services/achievementService.ts
@@ -28,6 +28,7 @@ export const BADGE_DEFINITIONS = [
 export type BadgeId = (typeof BADGE_DEFINITIONS)[number]['id']
 
 const BADGE_ID_SET = new Set<BadgeId>(BADGE_DEFINITIONS.map((badge) => badge.id))
+// all-complete は全20ステップ完了が条件なので未実装ステップも含む
 const ALL_STEP_IDS = COURSES.flatMap((course) => course.steps.map((step) => step.id))
 const COURSE_COMPLETION_RULES: Array<{ badgeId: BadgeId; stepIds: string[] }> = [
   { badgeId: 'course-1-complete', stepIds: getCourseStepIds('course-1') },
@@ -37,7 +38,12 @@ const COURSE_COMPLETION_RULES: Array<{ badgeId: BadgeId; stepIds: string[] }> = 
 ]
 
 function getCourseStepIds(courseId: string): string[] {
-  return COURSES.find((course) => course.id === courseId)?.steps.map((step) => step.id) ?? []
+  // isImplemented: false のステップはバッジ判定対象外とし、未実装コースの誤解禁を防止する
+  return (
+    COURSES.find((course) => course.id === courseId)
+      ?.steps.filter((step) => step.isImplemented)
+      .map((step) => step.id) ?? []
+  )
 }
 
 function isBadgeId(value: string): value is BadgeId {

--- a/apps/web/src/services/pointService.ts
+++ b/apps/web/src/services/pointService.ts
@@ -1,41 +1,13 @@
 import { supabase } from '../lib/supabaseClient'
-import { applyStudyActivity, getLearningStats } from './statsService'
-
-export type { LearningStats } from './statsService'
 
 export async function awardPoints(userId: string, amount: number, reason: string): Promise<void> {
-    // 1. Get current stats
-    const stats = await getLearningStats(userId)
-
-    // 2. Calculate new points and streak
-    const newStats = applyStudyActivity(stats)
-    newStats.total_points += amount
-
-    // 3. Upsert stats
-    const { error: statsError } = await supabase.from('learning_stats').upsert(
-        {
-            user_id: userId,
-            total_points: newStats.total_points,
-            current_streak: newStats.current_streak,
-            max_streak: newStats.max_streak,
-            last_study_date: newStats.last_study_date,
-            updated_at: new Date().toISOString(),
-        },
-        { onConflict: 'user_id', ignoreDuplicates: false }
-    )
-
-    if (statsError) {
-        throw statsError
-    }
-
-    // 4. Insert history
-    const { error: historyError } = await supabase.from('point_history').insert({
-        user_id: userId,
-        amount,
-        reason,
+    const { error } = await supabase.rpc('award_points_tx', {
+        p_user_id: userId,
+        p_amount: amount,
+        p_reason: reason,
     })
 
-    if (historyError) {
-        throw historyError
+    if (error) {
+        throw error
     }
 }

--- a/apps/web/supabase/sql/004_award_points_rpc.sql
+++ b/apps/web/supabase/sql/004_award_points_rpc.sql
@@ -1,0 +1,30 @@
+-- M1-1: award_points_tx RPC
+-- learning_stats UPSERT + point_history INSERT を1トランザクションで実行する。
+-- Supabase SQL Editor で実行する。
+
+create or replace function public.award_points_tx(
+  p_user_id uuid,
+  p_amount   integer,
+  p_reason   text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  -- total_points をアトミックに加算（行が存在しなければ INSERT）
+  insert into public.learning_stats (user_id, total_points, updated_at)
+  values (p_user_id, p_amount, now())
+  on conflict (user_id) do update
+    set total_points = public.learning_stats.total_points + excluded.total_points,
+        updated_at   = now();
+
+  -- ポイント履歴を記録
+  insert into public.point_history (user_id, amount, reason)
+  values (p_user_id, p_amount, p_reason);
+end;
+$$;
+
+-- authenticated ロールに実行権限を付与
+grant execute on function public.award_points_tx(uuid, integer, text) to authenticated;


### PR DESCRIPTION
## 概要

roadmap04 M1 タスク1「データ整合性の修正」を実装する。

## 変更内容

### 1. Supabase RPC `award_points_tx` を新設（`004_award_points_rpc.sql`）
- `learning_stats` UPSERT（`total_points` アトミック加算）+ `point_history` INSERT を1トランザクションで実行
- 旧実装では2段階DB更新の間でエラーが発生するとポイントが加算されずに履歴だけ残る（またはその逆）データ不整合が起きていた

### 2. `pointService.awardPoints` をRPC呼び出しに置き換え
- 旧ロジック（`getLearningStats` → `applyStudyActivity` → UPSERT → INSERT）を削除
- `supabase.rpc('award_points_tx', ...)` 1行に集約

### 3. `achievementService.getCourseStepIds` に `isImplemented` フィルタを追加
- `isImplemented: false` のステップをバッジ判定対象外とし、未実装コース（course-3/4）のバッジが誤って判定される可能性を排除
- `ALL_STEP_IDS`（all-complete バッジ用）は全20ステップを維持（仕様「全20ステップ完了」に準拠）

### 4. ストリーク更新タイミングをステップ全4モード完了時に統一（`StepPage.tsx`）
- 旧実装：モード完了のたびに `applyStudyActivity` 経由でストリーク更新
- 新実装：ステップが今回初めて全モード完了になった場合のみ `recordStudyActivity` を呼ぶ

## 検証結果

- `npm run typecheck`: pass
- `npm run build`: pass（chunk size 警告は M5 対応予定）

## Issue要否

不要（roadmap04 M1-1 に既定義のタスクのため）

## マージ可否

問題なくマージ可能。変更はサービス層とStepPageのロジックのみ。typecheck・build ともにパス。