### PR TITLE
feat: M3-2 共通エラー型 + Supabase 型自動生成

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
     "test": "vitest run",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "types:supabase": "npx supabase gen types typescript --project-id texpfxcqwfvcccgrqomf > src/shared/types/database.types.ts"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",

--- a/apps/web/src/services/__tests__/achievementService.test.ts
+++ b/apps/web/src/services/__tests__/achievementService.test.ts
@@ -42,6 +42,8 @@ function makeCompletedProgress(stepId: string) {
     practice_done: true,
     test_done: true,
     challenge_done: true,
+    updated_at: '',
+    completed_at: null,
   }
 }
 

--- a/apps/web/src/services/achievementService.ts
+++ b/apps/web/src/services/achievementService.ts
@@ -1,14 +1,11 @@
 import { COURSES } from '../content/courseData'
 import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+import type { Tables } from '../shared/types/database.types'
 import { getAllStepProgress } from './progressService'
 import { getLearningStats } from './statsService'
 
-export interface Achievement {
-  id: string
-  user_id: string
-  badge_id: BadgeId
-  earned_at: string
-}
+export type Achievement = Omit<Tables<'achievements'>, 'badge_id'> & { badge_id: BadgeId }
 
 export const BADGE_DEFINITIONS = [
   { id: 'first-step', name: '最初の一歩', description: '初めてステップを完了した' },
@@ -63,7 +60,7 @@ export async function getUnlockedAchievements(userId: string): Promise<BadgeId[]
   const { data, error } = await supabase.from('achievements').select('badge_id').eq('user_id', userId)
 
   if (error) {
-    throw error
+    throw fromSupabaseError(error, '実績の取得に失敗しました')
   }
 
   return (data ?? []).map((row) => row.badge_id).filter(isBadgeId)
@@ -80,7 +77,7 @@ export async function unlockAchievement(userId: string, badgeId: BadgeId): Promi
     return false
   }
 
-  throw error
+  throw fromSupabaseError(error, 'バッジの付与に失敗しました')
 }
 
 export async function checkAndUnlockAchievements(userId: string): Promise<BadgeId[]> {

--- a/apps/web/src/services/pointService.ts
+++ b/apps/web/src/services/pointService.ts
@@ -1,4 +1,5 @@
 import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
 
 export async function awardPoints(userId: string, amount: number, reason: string): Promise<void> {
     const { error } = await supabase.rpc('award_points_tx', {
@@ -8,6 +9,6 @@ export async function awardPoints(userId: string, amount: number, reason: string
     })
 
     if (error) {
-        throw error
+        throw fromSupabaseError(error, 'ポイントの付与に失敗しました')
     }
 }

--- a/apps/web/src/services/profileService.ts
+++ b/apps/web/src/services/profileService.ts
@@ -1,18 +1,9 @@
 import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+import type { Tables } from '../shared/types/database.types'
 
-export interface ProfileRecord {
-  id: string
-  display_name: string | null
-  created_at: string
-}
-
-export interface PointHistoryRecord {
-  id: string
-  user_id: string
-  amount: number
-  reason: string
-  created_at: string
-}
+export type ProfileRecord = Tables<'profiles'>
+export type PointHistoryRecord = Tables<'point_history'>
 
 export async function getProfile(userId: string): Promise<ProfileRecord | null> {
   const { data, error } = await supabase
@@ -22,7 +13,7 @@ export async function getProfile(userId: string): Promise<ProfileRecord | null> 
     .maybeSingle()
 
   if (error) {
-    throw error
+    throw fromSupabaseError(error, 'プロフィールの取得に失敗しました')
   }
 
   return data
@@ -39,7 +30,7 @@ export async function upsertDisplayName(userId: string, displayName: string | nu
   )
 
   if (error) {
-    throw error
+    throw fromSupabaseError(error, 'プロフィールの更新に失敗しました')
   }
 }
 
@@ -53,7 +44,7 @@ export async function getPointHistory(userId: string, limit = 50): Promise<Point
     .limit(safeLimit)
 
   if (error) {
-    throw error
+    throw fromSupabaseError(error, 'ポイント履歴の取得に失敗しました')
   }
 
   return data ?? []

--- a/apps/web/src/services/progressService.ts
+++ b/apps/web/src/services/progressService.ts
@@ -1,17 +1,14 @@
 import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+import type { Tables } from '../shared/types/database.types'
 
 export type ProgressMode = 'read' | 'practice' | 'test' | 'challenge'
 
-interface StepProgressRow {
-  user_id: string
-  step_id: string
-  read_done: boolean
-  practice_done: boolean
-  test_done: boolean
-  challenge_done: boolean
-  updated_at?: string
-  completed_at?: string | null
-}
+// クエリで SELECT する列のみを含む型（id は SELECT しないため除外）
+type StepProgressRow = Pick<
+  Tables<'step_progress'>,
+  'user_id' | 'step_id' | 'read_done' | 'practice_done' | 'test_done' | 'challenge_done' | 'updated_at' | 'completed_at'
+>
 
 type ProgressPatch = Partial<
   Pick<StepProgressRow, 'read_done' | 'practice_done' | 'test_done' | 'challenge_done' | 'completed_at'>
@@ -24,7 +21,7 @@ export async function getAllStepProgress(userId: string): Promise<StepProgressRo
     .eq('user_id', userId)
 
   if (error) {
-    throw error
+    throw fromSupabaseError(error, '学習進捗の取得に失敗しました')
   }
 
   return data as StepProgressRow[]
@@ -39,7 +36,7 @@ export async function getStepProgress(userId: string, stepId: string): Promise<S
     .maybeSingle()
 
   if (error) {
-    throw error
+    throw fromSupabaseError(error, '学習進捗の取得に失敗しました')
   }
 
   return data
@@ -59,7 +56,7 @@ export async function upsertProgress(userId: string, stepId: string, patch: Prog
   })
 
   if (error) {
-    throw error
+    throw fromSupabaseError(error, '学習進捗の保存に失敗しました')
   }
 }
 
@@ -99,7 +96,7 @@ export async function getCompletedStepCount(userId: string) {
     .eq('user_id', userId)
 
   if (error) {
-    throw error
+    throw fromSupabaseError(error, '完了ステップ数の取得に失敗しました')
   }
 
   const completed = (data ?? []).filter(

--- a/apps/web/src/services/statsService.ts
+++ b/apps/web/src/services/statsService.ts
@@ -1,12 +1,11 @@
 import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+import type { Tables } from '../shared/types/database.types'
 
-export interface LearningStats {
-  user_id: string
-  total_points: number
-  current_streak: number
-  max_streak: number
-  last_study_date: string | null
-}
+export type LearningStats = Pick<
+  Tables<'learning_stats'>,
+  'user_id' | 'total_points' | 'current_streak' | 'max_streak' | 'last_study_date'
+>
 
 export interface HeatmapCell {
   date: string
@@ -64,7 +63,7 @@ export async function getLearningStats(userId: string): Promise<LearningStats> {
     .maybeSingle()
 
   if (error) {
-    throw error
+    throw fromSupabaseError(error, '学習統計の取得に失敗しました')
   }
 
   return data ?? createDefaultLearningStats(userId)
@@ -112,7 +111,7 @@ export async function recordStudyActivity(userId: string, now = new Date()): Pro
   )
 
   if (error) {
-    throw error
+    throw fromSupabaseError(error, '学習記録の保存に失敗しました')
   }
 
   return nextStats
@@ -129,7 +128,7 @@ export async function getLearningHeatmap(userId: string, days = 30): Promise<Hea
     .gte('created_at', `${startDate}T00:00:00.000Z`)
 
   if (error) {
-    throw error
+    throw fromSupabaseError(error, 'ヒートマップデータの取得に失敗しました')
   }
 
   const dateCountMap = new Map<string, number>()

--- a/apps/web/src/shared/errors.ts
+++ b/apps/web/src/shared/errors.ts
@@ -1,0 +1,46 @@
+/**
+ * アプリケーション共通エラー型
+ *
+ * Supabase PostgrestError などの外部エラーを AppError に変換することで、
+ * サービス層のエラーを一貫した型として上位レイヤーに伝える。
+ */
+
+export type AppErrorCode =
+  | 'DB_UNIQUE_VIOLATION' // Supabase: 23505 (一意制約違反)
+  | 'DB_NOT_FOUND' // Supabase: PGRST116 (行が見つからない)
+  | 'DB_ERROR' // その他の DB エラー
+  | 'UNKNOWN' // 予期しないエラー
+
+export class AppError extends Error {
+  readonly code: AppErrorCode
+  readonly userMessage: string
+  readonly cause: unknown
+
+  constructor(code: AppErrorCode, userMessage: string, cause?: unknown) {
+    super(userMessage)
+    this.name = 'AppError'
+    this.code = code
+    this.userMessage = userMessage
+    this.cause = cause
+  }
+}
+
+function toAppErrorCode(pgCode: string): AppErrorCode {
+  if (pgCode === '23505') return 'DB_UNIQUE_VIOLATION'
+  if (pgCode === 'PGRST116') return 'DB_NOT_FOUND'
+  return 'DB_ERROR'
+}
+
+/**
+ * Supabase PostgrestError を AppError に変換するヘルパー
+ *
+ * @param error - Supabase が返すエラーオブジェクト（code / message を持つ）
+ * @param userMessage - ユーザーに表示するメッセージ（省略時は error.message を使用）
+ */
+export function fromSupabaseError(
+  error: { code: string; message: string },
+  userMessage?: string,
+): AppError {
+  const code = toAppErrorCode(error.code)
+  return new AppError(code, userMessage ?? error.message, error)
+}

--- a/apps/web/src/shared/types/database.types.ts
+++ b/apps/web/src/shared/types/database.types.ts
@@ -1,0 +1,313 @@
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
+
+export type Database = {
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
+  __InternalSupabase: {
+    PostgrestVersion: "14.4"
+  }
+  public: {
+    Tables: {
+      achievements: {
+        Row: {
+          badge_id: string
+          earned_at: string
+          id: string
+          user_id: string
+        }
+        Insert: {
+          badge_id: string
+          earned_at?: string
+          id?: string
+          user_id: string
+        }
+        Update: {
+          badge_id?: string
+          earned_at?: string
+          id?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      challenge_submissions: {
+        Row: {
+          code: string
+          id: string
+          is_passed: boolean
+          matched_keywords: string[]
+          step_id: string
+          submitted_at: string
+          user_id: string
+        }
+        Insert: {
+          code: string
+          id?: string
+          is_passed?: boolean
+          matched_keywords?: string[]
+          step_id: string
+          submitted_at?: string
+          user_id: string
+        }
+        Update: {
+          code?: string
+          id?: string
+          is_passed?: boolean
+          matched_keywords?: string[]
+          step_id?: string
+          submitted_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      learning_stats: {
+        Row: {
+          current_streak: number
+          id: string
+          last_study_date: string | null
+          max_streak: number
+          total_points: number
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          current_streak?: number
+          id?: string
+          last_study_date?: string | null
+          max_streak?: number
+          total_points?: number
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          current_streak?: number
+          id?: string
+          last_study_date?: string | null
+          max_streak?: number
+          total_points?: number
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      point_history: {
+        Row: {
+          amount: number
+          created_at: string
+          id: string
+          reason: string
+          user_id: string
+        }
+        Insert: {
+          amount: number
+          created_at?: string
+          id?: string
+          reason: string
+          user_id: string
+        }
+        Update: {
+          amount?: number
+          created_at?: string
+          id?: string
+          reason?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      profiles: {
+        Row: {
+          created_at: string
+          display_name: string | null
+          id: string
+        }
+        Insert: {
+          created_at?: string
+          display_name?: string | null
+          id: string
+        }
+        Update: {
+          created_at?: string
+          display_name?: string | null
+          id?: string
+        }
+        Relationships: []
+      }
+      step_progress: {
+        Row: {
+          challenge_done: boolean
+          completed_at: string | null
+          id: string
+          practice_done: boolean
+          read_done: boolean
+          step_id: string
+          test_done: boolean
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          challenge_done?: boolean
+          completed_at?: string | null
+          id?: string
+          practice_done?: boolean
+          read_done?: boolean
+          step_id: string
+          test_done?: boolean
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          challenge_done?: boolean
+          completed_at?: string | null
+          id?: string
+          practice_done?: boolean
+          read_done?: boolean
+          step_id?: string
+          test_done?: boolean
+          updated_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+    }
+    Views: {
+      [_ in never]: never
+    }
+    Functions: {
+      [_ in never]: never
+    }
+    Enums: {
+      [_ in never]: never
+    }
+    CompositeTypes: {
+      [_ in never]: never
+    }
+  }
+}
+
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+
+export type Tables<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
+    : never
+
+export type TablesInsert<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
+    : never
+
+export type TablesUpdate<
+  DefaultSchemaTableNameOrOptions extends
+    | keyof DefaultSchema["Tables"]
+    | { schema: keyof DatabaseWithoutInternals },
+  TableName extends DefaultSchemaTableNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
+> = DefaultSchemaTableNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
+    : never
+
+export type Enums<
+  DefaultSchemaEnumNameOrOptions extends
+    | keyof DefaultSchema["Enums"]
+    | { schema: keyof DatabaseWithoutInternals },
+  EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
+> = DefaultSchemaEnumNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof DefaultSchema["CompositeTypes"]
+    | { schema: keyof DatabaseWithoutInternals },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof DatabaseWithoutInternals
+  }
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends {
+  schema: keyof DatabaseWithoutInternals
+}
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
+
+export const Constants = {
+  public: {
+    Enums: {},
+  },
+} as const


### PR DESCRIPTION
## Summary
- \`src/shared/errors.ts\` 新設: \`AppError\` クラス（code / userMessage / cause）+ \`fromSupabaseError()\` ヘルパー
- \`src/shared/types/database.types.ts\` を \`supabase gen types\` で生成（313行）
- 全サービス（5ファイル）の \`throw error\` → \`throw fromSupabaseError(error, '日本語メッセージ')\` に統一
- ローカル型定義を \`Tables<>\` ヘルパー型への参照に置換
- \`package.json\` に \`types:supabase\` スクリプトを追加

## Test plan
- [x] typecheck ✅
- [x] lint ✅
- [x] test ✅ 25/25
- [x] build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)