### PR TITLE
feat: M5-1 パフォーマンス・アクセシビリティ・SEO

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,7 +4,21 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" href="/coden_logo.png" />
-    <title>Coden</title>
+    <title>Coden — React実践学習プラットフォーム</title>
+    <meta name="description" content="Codenは「チュートリアル地獄」を脱出し、React実践力を段階的に身につけるための学習プラットフォームです。全20ステップ・4コースで、基礎から API 連携まで習得できます。" />
+
+    <!-- OGP -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Coden — React実践学習プラットフォーム" />
+    <meta property="og:description" content="チュートリアル地獄を抜け出し、Reactの実装力を段階的に獲得。全20ステップ・Read → Practice → Test → Challenge の4段階学習。" />
+    <meta property="og:image" content="/coden_logo.png" />
+    <meta property="og:locale" content="ja_JP" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Coden — React実践学習プラットフォーム" />
+    <meta name="twitter:description" content="チュートリアル地獄を抜け出し、Reactの実装力を段階的に獲得。全20ステップ・Read → Practice → Test → Challenge の4段階学習。" />
+    <meta name="twitter:image" content="/coden_logo.png" />
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "globals": "^17.3.0",
     "jsdom": "^28.1.0",
     "postcss": "^8.5.6",
+    "rollup-plugin-visualizer": "^7.0.0",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.56.0",

--- a/apps/web/src/components/LearningSidebar.tsx
+++ b/apps/web/src/components/LearningSidebar.tsx
@@ -12,9 +12,9 @@ export function LearningSidebar({ courseTitle, currentStepId, steps }: LearningS
   const { completedStepsCount, isLoadingStats } = useLearningContext()
 
   return (
-    <aside className="w-full rounded-2xl border border-slate-200 bg-white p-4 shadow-sm lg:w-72">
+    <aside className="w-full rounded-2xl border border-slate-200 bg-white p-4 shadow-sm lg:w-72" aria-label="学習コースナビゲーション">
       <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">{courseTitle}</p>
-      <ul className="mt-3 space-y-2">
+      <ul className="mt-3 space-y-2" aria-label={courseTitle}>
         {steps.map((step) => {
           const isCurrent = step.id === currentStepId
           const isLocked = !isLoadingStats && step.order > completedStepsCount + 1
@@ -33,7 +33,10 @@ export function LearningSidebar({ courseTitle, currentStepId, steps }: LearningS
           if (isLocked) {
             return (
               <li key={step.id}>
-                <div className={`${baseClass} border-slate-200 bg-slate-50 text-slate-400 opacity-60`}>
+                <div
+                  className={`${baseClass} border-slate-200 bg-slate-50 text-slate-400 opacity-60`}
+                  aria-disabled="true"
+                >
                   {content}
                 </div>
               </li>
@@ -49,6 +52,7 @@ export function LearningSidebar({ courseTitle, currentStepId, steps }: LearningS
                   }`}
                 to={`/step/${step.id}`}
                 replace
+                aria-current={isCurrent ? 'page' : undefined}
               >
                 {content}
               </Link>

--- a/apps/web/src/features/dashboard/components/AppHeader.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeader.tsx
@@ -18,13 +18,14 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
             <span className="font-display text-2xl font-bold tracking-tight text-primary-mint">Coden</span>
           </div>
 
-          <nav className="hidden items-center gap-5 text-sm font-medium md:flex">
+          <nav className="hidden items-center gap-5 text-sm font-medium md:flex" aria-label="メインナビゲーション">
             <Link
               to="/"
               className={`pb-1 ${location.pathname === '/'
                 ? 'border-b-2 border-primary-mint text-slate-900'
                 : 'text-slate-500 hover:text-slate-700'
                 }`}
+              aria-current={location.pathname === '/' ? 'page' : undefined}
             >
               ダッシュボード
             </Link>
@@ -34,6 +35,7 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
                 ? 'border-b-2 border-primary-mint text-slate-900'
                 : 'text-slate-500 hover:text-slate-700'
                 }`}
+              aria-current={location.pathname.startsWith('/step') ? 'page' : undefined}
             >
               コース一覧
             </Link>
@@ -43,10 +45,11 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
                 ? 'border-b-2 border-primary-mint text-slate-900'
                 : 'text-slate-500 hover:text-slate-700'
                 }`}
+              aria-current={location.pathname === '/profile' ? 'page' : undefined}
             >
               プロフィール
             </Link>
-            <span className="cursor-not-allowed pb-1 text-slate-400">コミュニティ (準備中)</span>
+            <span className="cursor-not-allowed pb-1 text-slate-400" aria-disabled="true">コミュニティ (準備中)</span>
           </nav>
         </div>
 

--- a/apps/web/src/features/learning/ChallengeMode.tsx
+++ b/apps/web/src/features/learning/ChallengeMode.tsx
@@ -70,7 +70,11 @@ export function ChallengeMode({ task, onComplete }: ChallengeModeProps) {
         </button>
 
         {checked && (
-          <p className={`text-sm font-medium ${isPassed ? 'text-emerald-700' : 'text-rose-700'}`}>
+          <p
+            className={`text-sm font-medium ${isPassed ? 'text-emerald-700' : 'text-rose-700'}`}
+            role="status"
+            aria-live="polite"
+          >
             {isPassed ? '🎉 Challengeを完了しました！' : '❌ 要件を満たしていません。'}
           </p>
         )}

--- a/apps/web/src/features/learning/PracticeMode.tsx
+++ b/apps/web/src/features/learning/PracticeMode.tsx
@@ -62,6 +62,7 @@ export function PracticeMode({ questions, onComplete }: PracticeModeProps) {
                 }`}
               placeholder="回答を入力"
               value={answer}
+              aria-label={`Q${index + 1} 回答欄`}
               onChange={(event) => handleAnswerChange(question.id, event.target.value)}
             />
             {isJudged ? (
@@ -72,6 +73,7 @@ export function PracticeMode({ questions, onComplete }: PracticeModeProps) {
             <button
               className="rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-700 hover:bg-slate-100"
               type="button"
+              aria-expanded={hints[question.id] ?? false}
               onClick={() =>
                 setHints((prev) => ({
                   ...prev,
@@ -96,7 +98,11 @@ export function PracticeMode({ questions, onComplete }: PracticeModeProps) {
         </button>
 
         {isJudged && (
-          <p className={`text-sm font-medium ${isAllCorrect ? 'text-emerald-700' : 'text-rose-700'}`}>
+          <p
+            className={`text-sm font-medium ${isAllCorrect ? 'text-emerald-700' : 'text-rose-700'}`}
+            role="status"
+            aria-live="polite"
+          >
             {isAllCorrect ? '🎉 すべて正解！Practiceを完了しました。' : '⚠️ すべての問題に正解すると完了です。'}
           </p>
         )}

--- a/apps/web/src/features/learning/ReadMode.tsx
+++ b/apps/web/src/features/learning/ReadMode.tsx
@@ -92,7 +92,7 @@ export function ReadMode({ markdown, onComplete, isCompleted }: ReadModeProps) {
           {markdown}
         </ReactMarkdown>
       </article>
-      {copyMessage ? <p className="text-sm text-slate-600">{copyMessage}</p> : null}
+      {copyMessage ? <p className="text-sm text-slate-600" role="status" aria-live="polite">{copyMessage}</p> : null}
     </section>
   )
 }

--- a/apps/web/src/features/learning/TestMode.tsx
+++ b/apps/web/src/features/learning/TestMode.tsx
@@ -74,6 +74,7 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
                   : 'ring-slate-500 focus:ring-blue-400'
                   }`}
                 placeholder="例: setCount(count + 1)"
+                aria-label="コードの空欄を入力"
                 value={blankInput}
                 onChange={(event) => handleInputChange(event.target.value)}
               />
@@ -92,7 +93,11 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
         </button>
 
         {isJudged && (
-          <p className={`text-sm font-medium ${isPassed ? 'text-emerald-700' : 'text-rose-700'}`}>
+          <p
+            className={`text-sm font-medium ${isPassed ? 'text-emerald-700' : 'text-rose-700'}`}
+            role="status"
+            aria-live="polite"
+          >
             {isPassed ? '🎉 テスト合格！ライブプレビューが解禁されました。' : '❌ 必要キーワードを満たしていません。もう一度試してください。'}
           </p>
         )}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,24 +1,37 @@
-import React from 'react'
+import React, { lazy, Suspense } from 'react'
 import ReactDOM from 'react-dom/client'
 import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
 import { ProtectedRoute, GuestRoute } from './components/ProtectedRoute'
 import { AuthProvider } from './contexts/AuthContext'
 import { LearningProvider } from './contexts/LearningContext'
 import { AchievementProvider } from './contexts/AchievementContext'
-import { DashboardPage } from './pages/DashboardPage'
-import { LoginPage } from './pages/LoginPage'
-import { ProfilePage } from './pages/ProfilePage'
-import { StepPage } from './pages/StepPage'
 import { ConfigErrorView } from './components/ConfigErrorView'
 import { supabaseConfigError } from './lib/supabaseClient'
 import './styles/globals.css'
+
+// Route-based Code Splitting: 各ページを動的インポートでチャンク分割
+const DashboardPage = lazy(() => import('./pages/DashboardPage').then((m) => ({ default: m.DashboardPage })))
+const LoginPage = lazy(() => import('./pages/LoginPage').then((m) => ({ default: m.LoginPage })))
+const ProfilePage = lazy(() => import('./pages/ProfilePage').then((m) => ({ default: m.ProfilePage })))
+const StepPage = lazy(() => import('./pages/StepPage').then((m) => ({ default: m.StepPage })))
+
+// ページ遷移中のフォールバック UI
+function PageLoading() {
+  return (
+    <div className="flex min-h-screen items-center justify-center" aria-live="polite" aria-label="ページを読み込み中">
+      <div className="text-gray-500">読み込み中...</div>
+    </div>
+  )
+}
 
 const router = createBrowserRouter([
   {
     path: '/login',
     element: (
       <GuestRoute>
-        <LoginPage />
+        <Suspense fallback={<PageLoading />}>
+          <LoginPage />
+        </Suspense>
       </GuestRoute>
     ),
   },
@@ -26,7 +39,9 @@ const router = createBrowserRouter([
     path: '/',
     element: (
       <ProtectedRoute>
-        <DashboardPage />
+        <Suspense fallback={<PageLoading />}>
+          <DashboardPage />
+        </Suspense>
       </ProtectedRoute>
     ),
   },
@@ -34,7 +49,9 @@ const router = createBrowserRouter([
     path: '/step/:stepId',
     element: (
       <ProtectedRoute>
-        <StepPage />
+        <Suspense fallback={<PageLoading />}>
+          <StepPage />
+        </Suspense>
       </ProtectedRoute>
     ),
   },
@@ -42,7 +59,9 @@ const router = createBrowserRouter([
     path: '/profile',
     element: (
       <ProtectedRoute>
-        <ProfilePage />
+        <Suspense fallback={<PageLoading />}>
+          <ProfilePage />
+        </Suspense>
       </ProtectedRoute>
     ),
   },

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -72,7 +72,7 @@ export function LoginPage() {
           />
         </label>
 
-        {error ? <p className="text-sm text-red-700">{error}</p> : null}
+        {error ? <p className="text-sm text-red-700" role="alert">{error}</p> : null}
 
         <button
           className="w-full rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-60"

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -120,6 +120,7 @@ export function StepPage() {
                     className={`rounded-md px-4 py-2 text-sm font-bold transition ${isActive ? 'bg-primary-mint text-white shadow-sm' : 'bg-slate-100 text-slate-600 hover:bg-slate-200 hover:text-slate-900'
                       }`}
                     type="button"
+                    aria-pressed={isActive}
                     onClick={() => setActiveMode(mode.id)}
                   >
                     {mode.label}
@@ -158,6 +159,7 @@ export function StepPage() {
                 <button
                   className="mt-3 rounded-lg bg-primary-mint px-4 py-2 text-sm font-bold text-white transition hover:bg-primary-dark"
                   type="button"
+                  aria-label={nextStep ? `次のステップ「${nextStep.title}」へ進む` : 'ダッシュボードへ戻る'}
                   onClick={handleNextStep}
                 >
                   {nextStep ? '次のステップへ進む' : 'ダッシュボードへ戻る'}
@@ -174,7 +176,11 @@ export function StepPage() {
         </div>
 
         {toastMessage ? (
-          <div className="fixed bottom-5 right-5 z-50 max-w-sm rounded-xl border border-emerald-200 bg-white px-4 py-3 text-sm text-emerald-900 shadow-xl">
+          <div
+            className="fixed bottom-5 right-5 z-50 max-w-sm rounded-xl border border-emerald-200 bg-white px-4 py-3 text-sm text-emerald-900 shadow-xl"
+            role="alert"
+            aria-live="assertive"
+          >
             <p className="font-semibold">学習達成</p>
             <p className="mt-1">{toastMessage}</p>
           </div>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,9 +1,31 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { visualizer } from 'rollup-plugin-visualizer'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    visualizer({
+      filename: 'dist/stats.html',
+      open: false,
+      gzipSize: true,
+      brotliSize: true,
+    }),
+  ],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+          'vendor-supabase': ['@supabase/supabase-js'],
+          'vendor-monaco': ['@monaco-editor/react'],
+          'vendor-markdown': ['react-markdown', 'remark-gfm'],
+          'vendor-prism': ['prismjs'],
+        },
+      },
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "globals": "^17.3.0",
         "jsdom": "^28.1.0",
         "postcss": "^8.5.6",
+        "rollup-plugin-visualizer": "^7.0.0",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.56.0",
@@ -4946,6 +4947,22 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -5034,6 +5051,21 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/color-convert": {
@@ -5181,6 +5213,49 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -5219,6 +5294,13 @@
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -5645,6 +5727,29 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+      "integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -5813,6 +5918,22 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5836,12 +5957,60 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-potential-custom-element-name": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6209,6 +6378,27 @@
       ],
       "license": "MIT"
     },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6361,6 +6551,19 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/prelude-ls": {
@@ -6531,6 +6734,50 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.0.tgz",
+      "integrity": "sha512-loo4kmhTg7GMO0hqaUv/azvLPUT2B4jXU3gNMG35gm1mWKpOzhV6rspb/Mqmsfg7oOTdkzdmOckCIwGB5Ca1CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^11.0.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -6621,6 +6868,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6656,6 +6913,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/strip-indent": {
@@ -7195,6 +7499,54 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -7212,12 +7564,50 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",


### PR DESCRIPTION
## Summary
- Route ベース Code Splitting（React.lazy + Suspense × 4ページ）でビルドサイズを大幅削減
- `vite.config.ts` に manualChunks（react / supabase / monaco / markdown / prism）と rollup-plugin-visualizer を追加
- 主要コンポーネント（LearningSidebar / StepPage / AppHeader / PracticeMode / TestMode / ChallengeMode / ReadMode / LoginPage）に ARIA ラベルを追加
- `index.html` に description meta・OGP・Twitter Card を追加

## ビルドサイズ改善
| | Before | After |
|---|---|---|
| メインバンドル (gzip) | 243 kB（1チャンク） | 64 kB（index.js のみ） |
| ページ別チャンク | なし | LoginPage 1 kB / DashboardPage 4 kB / ProfilePage 3 kB |
| ベンダーチャンク | なし | react 33 kB / supabase 45 kB / markdown 48 kB / monaco 5 kB / prism 7 kB |

## ARIA 追加箇所
- `LearningSidebar`: `aside aria-label` / `ul aria-label` / `aria-current="page"` / `aria-disabled`
- `StepPage`: mode ボタン `aria-pressed` / toast `role="alert" aria-live="assertive"` / 次ステップボタン `aria-label`
- `AppHeader`: `nav aria-label` / Link `aria-current="page"` / 準備中 span `aria-disabled`
- `PracticeMode`: input `aria-label` / ヒントボタン `aria-expanded` / 判定 `role="status" aria-live`
- `TestMode`: 空欄 input `aria-label` / 判定 `role="status" aria-live`
- `ChallengeMode` / `ReadMode`: 結果 `role="status" aria-live`
- `LoginPage`: エラー `role="alert"`

## Test plan
- [x] typecheck ✅
- [x] lint ✅（warnings 既存のみ、errors なし）
- [x] test ✅（152/152 passed）
- [x] build ✅

## マージ判断
CI 全ゲート通過。M5-1 スコープ（Code Splitting・manualChunks・visualizer・ARIA・OGP）をすべて網羅しており、マイルストーンブランチへのマージを承認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)