### PR TITLE
refactor: M2-2 関心の分離チェック — DashboardPage Supabase直接呼び出し解消

### DIFF
--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -9,7 +9,8 @@ import { DashboardSidebar } from '../features/dashboard/components/DashboardSide
 import { LearningOverviewCard } from '../features/dashboard/components/LearningOverviewCard'
 import { ReviewListWidget } from '../features/dashboard/components/ReviewListWidget'
 import { WelcomeBanner } from '../features/dashboard/components/WelcomeBanner'
-import { supabase, supabaseConfigError } from '../lib/supabaseClient'
+import { supabaseConfigError } from '../lib/supabaseClient'
+import { getProfile } from '../services/profileService'
 
 export function DashboardPage() {
   const { user, signOut } = useAuth()
@@ -41,15 +42,13 @@ export function DashboardPage() {
 
     async function loadDashboard() {
       try {
-        const profileResult = await supabase.from('profiles').select('display_name').eq('id', currentUserId).maybeSingle()
+        const profile = await getProfile(currentUserId)
 
         if (!isMounted) {
           return
         }
 
-        if (!profileResult.error) {
-          setDisplayName(profileResult.data?.display_name ?? null)
-        }
+        setDisplayName(profile?.display_name ?? null)
       } catch (loadError) {
         if (!isMounted) {
           return


### PR DESCRIPTION
## Summary

- `DashboardPage.tsx` が `supabase` クライアントを直接 import して `profiles` テーブルを参照していた違反を修正
- `getProfile(userId)` を `profileService.ts` 経由で呼び出すように変更
- `supabase` の直接 import を削除

## 調査結果

| ファイル | 状態 |
|---|---|
| `pages/DashboardPage.tsx` | ⚠️ 違反 → 修正済み |
| `pages/StepPage.tsx` | ✅ クリーン（`useLearningStep` 経由） |
| `pages/ProfilePage.tsx` | ✅ クリーン（`profileService` 経由） |
| `features/dashboard/DashboardSidebar.tsx` | ✅ クリーン（`statsService` 経由） |
| `features/dashboard/ReviewListWidget.tsx` | ✅ クリーン（`lib/reviewList` 経由） |
| `features/learning/PracticeMode.tsx` | ✅ クリーン（UI のみ） |
| `features/learning/TestMode.tsx` | ✅ クリーン（UI のみ） |
| `features/learning/ChallengeMode.tsx` | ✅ クリーン（UI のみ） |
| `features/api-practice/` コンポーネント群 | ✅ クリーン（`apiClient.ts` 経由） |

## Test plan

- [x] `npm run typecheck` — エラーなし
- [x] `npm run lint` — エラーなし（警告は既存の Fast Refresh 警告のみ）
- [x] `npm run test` — 152テスト全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)