### PR TITLE
fix: M1 学習導線の状態管理不具合を修正

### DIFF
--- a/apps/web/src/features/learning/ChallengeMode.tsx
+++ b/apps/web/src/features/learning/ChallengeMode.tsx
@@ -1,33 +1,45 @@
-import { Suspense, lazy, useMemo, useState } from 'react'
-import type { ChallengeTask } from '../../content/fundamentals/steps'
+import { Suspense, lazy, useEffect, useMemo, useState } from 'react'
+import type { ChallengePattern, ChallengeTask } from '../../content/fundamentals/steps'
 
 const MonacoEditor = lazy(() => import('@monaco-editor/react'))
 
 interface ChallengeModeProps {
+  stepId: string
   task: ChallengeTask
   onComplete: () => void
 }
 
-export function ChallengeMode({ task, onComplete }: ChallengeModeProps) {
-  // Use a random pattern on initial render
-  const [pattern] = useState(() => {
-    const randomIndex = Math.floor(Math.random() * task.patterns.length)
-    return task.patterns[randomIndex]
-  })
+function getRandomPattern(task: ChallengeTask): ChallengePattern {
+  const randomIndex = Math.floor(Math.random() * task.patterns.length)
+  return task.patterns[randomIndex]
+}
 
-  const [code, setCode] = useState(pattern.starterCode)
+export function ChallengeMode({ stepId, task, onComplete }: ChallengeModeProps) {
+  const [pattern, setPattern] = useState<ChallengePattern>(() => getRandomPattern(task))
+  const [code, setCode] = useState(() => pattern.starterCode)
   const [checked, setChecked] = useState(false)
+  const [reported, setReported] = useState(false)
+
+  useEffect(() => {
+    const nextPattern = getRandomPattern(task)
+    setPattern(nextPattern)
+    setCode(nextPattern.starterCode)
+    setChecked(false)
+    setReported(false)
+  }, [stepId, task])
 
   const missingKeywords = useMemo(
     () => pattern.expectedKeywords.filter((keyword) => !code.toLowerCase().includes(keyword.toLowerCase())),
     [code, pattern.expectedKeywords],
   )
-  const isPassed = checked && missingKeywords.length === 0
+  const hasSatisfiedRequirements = missingKeywords.length === 0
+  const isPassed = checked && hasSatisfiedRequirements
 
   function handleCheck() {
     setChecked(true)
-    if (isPassed) {
+    if (hasSatisfiedRequirements && !reported) {
       onComplete()
+      setReported(true)
     }
   }
 

--- a/apps/web/src/features/learning/TestMode.tsx
+++ b/apps/web/src/features/learning/TestMode.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo, useState } from 'react'
+import { Fragment, useEffect, useMemo, useState } from 'react'
 import type { TestTask } from '../../content/fundamentals/steps'
 import { addToReviewList, removeFromReviewList } from '../../lib/reviewList'
 
@@ -31,6 +31,12 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
   const [blankInput, setBlankInput] = useState('')
   const [isJudged, setIsJudged] = useState(false)
   const [reported, setReported] = useState(false)
+
+  useEffect(() => {
+    setBlankInput('')
+    setIsJudged(false)
+    setReported(false)
+  }, [stepId])
 
   const mergedCode = useMemo(() => task.starterCode.replace('____', blankInput), [blankInput, task.starterCode])
   const isPassed = useMemo(

--- a/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ChallengeMode } from '../ChallengeMode'
+import type { ChallengeTask } from '../../../content/fundamentals/steps'
+
+vi.mock('@monaco-editor/react', () => ({
+  default: ({ value, onChange }: { value?: string; onChange?: (nextValue: string) => void }) => (
+    <textarea
+      aria-label="challenge-editor"
+      value={value}
+      onChange={(event) => onChange?.(event.target.value)}
+    />
+  ),
+}))
+
+const firstTask: ChallengeTask = {
+  patterns: [
+    {
+      id: 'pattern-1',
+      prompt: '最初の課題',
+      requirements: ['要件1'],
+      hints: ['ヒント1'],
+      expectedKeywords: ['useState', 'onClick'],
+      starterCode: '',
+    },
+  ],
+}
+
+const secondTask: ChallengeTask = {
+  patterns: [
+    {
+      id: 'pattern-2',
+      prompt: '次の課題',
+      requirements: ['要件2'],
+      hints: ['ヒント2'],
+      expectedKeywords: ['return'],
+      starterCode: 'const nextStep = true;',
+    },
+  ],
+}
+
+describe('ChallengeMode', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('初回の正解判定で onComplete を呼ぶ', async () => {
+    const user = userEvent.setup()
+    const onComplete = vi.fn()
+
+    render(<ChallengeMode stepId="step-a" task={firstTask} onComplete={onComplete} />)
+
+    const editor = await screen.findByLabelText('challenge-editor')
+    fireEvent.change(editor, {
+      target: { value: 'const [count, setCount] = useState(0); <button onClick={() => setCount(count + 1)} />' },
+    })
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole('status').textContent).toContain('Challengeを完了しました')
+  })
+
+  it('stepId が変わると入力内容と判定状態をリセットする', async () => {
+    const user = userEvent.setup()
+    const onComplete = vi.fn()
+    const { rerender } = render(<ChallengeMode stepId="step-a" task={firstTask} onComplete={onComplete} />)
+
+    const editor = await screen.findByLabelText('challenge-editor')
+    fireEvent.change(editor, { target: { value: 'useState onClick' } })
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+    expect(onComplete).toHaveBeenCalledTimes(1)
+
+    rerender(<ChallengeMode stepId="step-b" task={secondTask} onComplete={onComplete} />)
+
+    expect(screen.queryByRole('status')).toBeNull()
+    expect((screen.getByLabelText('challenge-editor') as HTMLTextAreaElement).value).toBe('const nextStep = true;')
+    expect(screen.getByText('次の課題')).toBeTruthy()
+  })
+})

--- a/apps/web/src/features/learning/__tests__/PracticeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/PracticeMode.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PracticeMode } from '../PracticeMode'
+import type { PracticeQuestion } from '../../../content/fundamentals/steps'
+
+const addToReviewList = vi.fn()
+const removeFromReviewList = vi.fn()
+
+vi.mock('../../../lib/reviewList', () => ({
+  addToReviewList: (...args: unknown[]) => addToReviewList(...args),
+  removeFromReviewList: (...args: unknown[]) => removeFromReviewList(...args),
+}))
+
+const firstQuestions: PracticeQuestion[] = [
+  {
+    id: 'q1',
+    prompt: '最初の質問',
+    answer: 'React',
+    hint: 'ヒント1',
+    explanation: '解説1',
+  },
+]
+
+const secondQuestions: PracticeQuestion[] = [
+  {
+    id: 'q2',
+    prompt: '次の質問',
+    answer: 'TypeScript',
+    hint: 'ヒント2',
+    explanation: '解説2',
+  },
+]
+
+describe('PracticeMode', () => {
+  beforeEach(() => {
+    addToReviewList.mockReset()
+    removeFromReviewList.mockReset()
+  })
+
+  it('stepId が変わると回答・ヒント・判定状態をリセットする', async () => {
+    const user = userEvent.setup()
+    const onComplete = vi.fn()
+    const { rerender } = render(<PracticeMode stepId="step-a" questions={firstQuestions} onComplete={onComplete} />)
+
+    await user.type(screen.getByLabelText('Q1 回答欄'), 'React')
+    await user.click(screen.getByRole('button', { name: 'ヒントを表示' }))
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(removeFromReviewList).toHaveBeenCalledWith('step-a')
+    expect(screen.getByRole('status').textContent).toContain('Practiceを完了しました')
+    expect(screen.getByText('ヒント1')).toBeTruthy()
+
+    rerender(<PracticeMode stepId="step-b" questions={secondQuestions} onComplete={onComplete} />)
+
+    expect((screen.getByLabelText('Q1 回答欄') as HTMLInputElement).value).toBe('')
+    expect(screen.queryByRole('status')).toBeNull()
+    expect(screen.queryByText('ヒント1')).toBeNull()
+    expect(screen.getByText('Q1. 次の質問')).toBeTruthy()
+  })
+})

--- a/apps/web/src/features/learning/__tests__/TestMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/TestMode.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TestMode } from '../TestMode'
+import type { TestTask } from '../../../content/fundamentals/steps'
+
+const addToReviewList = vi.fn()
+const removeFromReviewList = vi.fn()
+
+vi.mock('../../../lib/reviewList', () => ({
+  addToReviewList: (...args: unknown[]) => addToReviewList(...args),
+  removeFromReviewList: (...args: unknown[]) => removeFromReviewList(...args),
+}))
+
+const firstTask: TestTask = {
+  instruction: '最初の問題',
+  starterCode: 'const [count, setCount] = useState(0)\n____',
+  expectedKeywords: ['setCount', 'count - 1'],
+  explanation: '解説1',
+}
+
+const secondTask: TestTask = {
+  instruction: '次の問題',
+  starterCode: '<input value={name} ____={(e) => setName(e.target.value)} />',
+  expectedKeywords: ['onChange'],
+  explanation: '解説2',
+}
+
+describe('TestMode', () => {
+  beforeEach(() => {
+    addToReviewList.mockReset()
+    removeFromReviewList.mockReset()
+  })
+
+  it('stepId が変わると入力内容と判定状態をリセットする', async () => {
+    const user = userEvent.setup()
+    const onComplete = vi.fn()
+    const { rerender } = render(<TestMode stepId="step-a" task={firstTask} onComplete={onComplete} />)
+
+    const input = screen.getByLabelText('コードの空欄を入力')
+    await user.type(input, 'setCount(count - 1)')
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(removeFromReviewList).toHaveBeenCalledWith('step-a')
+    expect(screen.getByRole('status').textContent).toContain('テスト合格')
+
+    rerender(<TestMode stepId="step-b" task={secondTask} onComplete={onComplete} />)
+
+    expect((screen.getByLabelText('コードの空欄を入力') as HTMLInputElement).value).toBe('')
+    expect(screen.queryByRole('status')).toBeNull()
+    expect(screen.getByText('次の問題')).toBeTruthy()
+  })
+})

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -146,7 +146,11 @@ export function StepPage() {
               <TestMode stepId={step.id} task={step.testTask} onComplete={() => void handleModeComplete('test')} />
             ) : null}
             {activeMode === 'challenge' ? (
-              <ChallengeMode task={step.challengeTask} onComplete={() => void handleModeComplete('challenge')} />
+              <ChallengeMode
+                stepId={step.id}
+                task={step.challengeTask}
+                onComplete={() => void handleModeComplete('challenge')}
+              />
             ) : null}
 
             {modeStatus.challenge ? (


### PR DESCRIPTION
## 概要
- Challenge初回正解時の完了判定を修正
- Challenge/TestのstepId切替時リセットを追加
- 学習モードの状態リセット回帰テストを追加

## 変更内容
- ChallengeMode に stepId 依存の初期化と重複完了防止を追加
- TestMode に stepId 変更時の入力/判定リセットを追加
- StepPage から ChallengeMode へ stepId を明示的に渡すよう修正
- ChallengeMode / TestMode / PracticeMode のコンポーネントテストを追加

## 検証
- cmd /c npm --workspace apps/web run typecheck
- cmd /c npm --workspace apps/web run lint
- cmd /c npm --workspace apps/web run test
- cmd /c npm --workspace apps/web run build

## Issue
- 不要
- 根拠: roadmap06 の既存タスク M1 の実装範囲で完結し、追加のトリアージ管理を必要としないため
