### PR TITLE
feat: M2 Challenge回答履歴の永続化を追加

### DIFF
--- a/apps/web/src/features/learning/ChallengeMode.tsx
+++ b/apps/web/src/features/learning/ChallengeMode.tsx
@@ -7,6 +7,7 @@ interface ChallengeModeProps {
   stepId: string
   task: ChallengeTask
   onComplete: () => void
+  onSubmitResult?: (result: { code: string; isPassed: boolean; matchedKeywords: string[] }) => Promise<void> | void
 }
 
 function getRandomPattern(task: ChallengeTask): ChallengePattern {
@@ -14,11 +15,12 @@ function getRandomPattern(task: ChallengeTask): ChallengePattern {
   return task.patterns[randomIndex]
 }
 
-export function ChallengeMode({ stepId, task, onComplete }: ChallengeModeProps) {
+export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: ChallengeModeProps) {
   const [pattern, setPattern] = useState<ChallengePattern>(() => getRandomPattern(task))
   const [code, setCode] = useState(() => pattern.starterCode)
   const [checked, setChecked] = useState(false)
   const [reported, setReported] = useState(false)
+  const [submissionError, setSubmissionError] = useState<string | null>(null)
 
   useEffect(() => {
     const nextPattern = getRandomPattern(task)
@@ -26,6 +28,7 @@ export function ChallengeMode({ stepId, task, onComplete }: ChallengeModeProps) 
     setCode(nextPattern.starterCode)
     setChecked(false)
     setReported(false)
+    setSubmissionError(null)
   }, [stepId, task])
 
   const missingKeywords = useMemo(
@@ -35,8 +38,26 @@ export function ChallengeMode({ stepId, task, onComplete }: ChallengeModeProps) 
   const hasSatisfiedRequirements = missingKeywords.length === 0
   const isPassed = checked && hasSatisfiedRequirements
 
-  function handleCheck() {
+  async function handleCheck() {
+    const matchedKeywords = pattern.expectedKeywords.filter((keyword) =>
+      code.toLowerCase().includes(keyword.toLowerCase()),
+    )
+
     setChecked(true)
+    setSubmissionError(null)
+
+    if (onSubmitResult) {
+      try {
+        await onSubmitResult({
+          code,
+          isPassed: hasSatisfiedRequirements,
+          matchedKeywords,
+        })
+      } catch (error) {
+        setSubmissionError(error instanceof Error ? error.message : '提出履歴の保存に失敗しました。')
+      }
+    }
+
     if (hasSatisfiedRequirements && !reported) {
       onComplete()
       setReported(true)
@@ -76,7 +97,7 @@ export function ChallengeMode({ stepId, task, onComplete }: ChallengeModeProps) 
         <button
           className="rounded-md bg-primary-mint px-6 py-2.5 text-sm font-bold text-white shadow-sm transition-colors hover:bg-primary-dark active:bg-emerald-700"
           type="button"
-          onClick={handleCheck}
+          onClick={() => void handleCheck()}
         >
           判定する
         </button>
@@ -91,6 +112,8 @@ export function ChallengeMode({ stepId, task, onComplete }: ChallengeModeProps) 
           </p>
         )}
       </div>
+
+      {submissionError ? <p className="text-sm text-rose-700">{submissionError}</p> : null}
 
       {checked && !isPassed ? (
         <div className="rounded-lg border border-rose-300 bg-rose-50 p-4">

--- a/apps/web/src/features/learning/ChallengeSubmissionHistory.tsx
+++ b/apps/web/src/features/learning/ChallengeSubmissionHistory.tsx
@@ -1,0 +1,65 @@
+﻿import type { ChallengeSubmission } from '@/services/challengeSubmissionService'
+import { formatDateTime } from '@/shared/utils/dateTime'
+
+interface ChallengeSubmissionHistoryProps {
+  submissions: ChallengeSubmission[]
+  isLoading: boolean
+  error: string | null
+}
+
+function getPreviewCode(code: string): string {
+  const trimmed = code.trim()
+  if (trimmed.length <= 160) {
+    return trimmed
+  }
+
+  return `${trimmed.slice(0, 160)}...`
+}
+
+export function ChallengeSubmissionHistory({
+  submissions,
+  isLoading,
+  error,
+}: ChallengeSubmissionHistoryProps) {
+  return (
+    <section className="mt-6 rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-bold text-slate-900">直近の提出履歴</h3>
+          <p className="text-xs text-slate-500">このステップの最新 5 件を表示します。</p>
+        </div>
+      </div>
+
+      {isLoading ? <p className="mt-3 text-sm text-slate-500">提出履歴を読み込み中...</p> : null}
+      {error ? <p className="mt-3 text-sm text-rose-700">{error}</p> : null}
+      {!isLoading && !error && submissions.length === 0 ? (
+        <p className="mt-3 text-sm text-slate-500">提出履歴はまだありません。</p>
+      ) : null}
+
+      {!isLoading && !error && submissions.length > 0 ? (
+        <ul className="mt-4 space-y-3">
+          {submissions.map((submission, index) => (
+            <li key={submission.id} className="rounded-lg border border-slate-200 bg-white p-3">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  {index === 0 ? 'Latest Submission' : `Submission ${index + 1}`}
+                </p>
+                <span
+                  className={`rounded-full px-2.5 py-1 text-xs font-semibold ${
+                    submission.is_passed ? 'bg-emerald-100 text-emerald-700' : 'bg-rose-100 text-rose-700'
+                  }`}
+                >
+                  {submission.is_passed ? '合格' : '未達成'}
+                </span>
+              </div>
+              <p className="mt-2 text-xs text-slate-500">{formatDateTime(submission.submitted_at)}</p>
+              <pre className="mt-3 overflow-x-auto whitespace-pre-wrap break-all rounded-md bg-slate-900 p-3 text-xs leading-relaxed text-slate-100">
+                <code>{getPreviewCode(submission.code)}</code>
+              </pre>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  )
+}

--- a/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
@@ -48,8 +48,9 @@ describe('ChallengeMode', () => {
   it('初回の正解判定で onComplete を呼ぶ', async () => {
     const user = userEvent.setup()
     const onComplete = vi.fn()
+    const onSubmitResult = vi.fn()
 
-    render(<ChallengeMode stepId="step-a" task={firstTask} onComplete={onComplete} />)
+    render(<ChallengeMode stepId="step-a" task={firstTask} onComplete={onComplete} onSubmitResult={onSubmitResult} />)
 
     const editor = await screen.findByLabelText('challenge-editor')
     fireEvent.change(editor, {
@@ -58,6 +59,11 @@ describe('ChallengeMode', () => {
     await user.click(screen.getByRole('button', { name: '判定する' }))
 
     expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(onSubmitResult).toHaveBeenCalledWith({
+      code: 'const [count, setCount] = useState(0); <button onClick={() => setCount(count + 1)} />',
+      isPassed: true,
+      matchedKeywords: ['useState', 'onClick'],
+    })
     expect(screen.getByRole('status').textContent).toContain('Challengeを完了しました')
   })
 

--- a/apps/web/src/features/learning/__tests__/ChallengeSubmissionHistory.test.tsx
+++ b/apps/web/src/features/learning/__tests__/ChallengeSubmissionHistory.test.tsx
@@ -1,0 +1,34 @@
+﻿import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { ChallengeSubmissionHistory } from '../ChallengeSubmissionHistory'
+import type { ChallengeSubmission } from '@/services/challengeSubmissionService'
+
+const submissions: ChallengeSubmission[] = [
+  {
+    id: 'submission-1',
+    user_id: 'user-1',
+    step_id: 'usestate-basic',
+    code: 'const [count, setCount] = useState(0);',
+    is_passed: true,
+    matched_keywords: ['useState'],
+    submitted_at: '2026-03-09T10:30:00.000Z',
+  },
+]
+
+describe('ChallengeSubmissionHistory', () => {
+  it('最新提出のコード・提出日時・合否を表示する', () => {
+    render(<ChallengeSubmissionHistory submissions={submissions} isLoading={false} error={null} />)
+
+    expect(screen.getByText('直近の提出履歴')).toBeTruthy()
+    expect(screen.getByText('Latest Submission')).toBeTruthy()
+    expect(screen.getByText('合格')).toBeTruthy()
+    expect(screen.getByText('const [count, setCount] = useState(0);')).toBeTruthy()
+    expect(screen.getByText(/2026\/03\/09/)).toBeTruthy()
+  })
+
+  it('履歴がない場合は空状態を表示する', () => {
+    render(<ChallengeSubmissionHistory submissions={[]} isLoading={false} error={null} />)
+
+    expect(screen.getByText('提出履歴はまだありません。')).toBeTruthy()
+  })
+})

--- a/apps/web/src/features/learning/hooks/useChallengeSubmission.ts
+++ b/apps/web/src/features/learning/hooks/useChallengeSubmission.ts
@@ -1,0 +1,30 @@
+﻿import { useCallback } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import { createChallengeSubmission } from '@/services/challengeSubmissionService'
+
+export interface ChallengeSubmissionAttempt {
+  code: string
+  isPassed: boolean
+  matchedKeywords: string[]
+}
+
+export function useChallengeSubmission(stepId: string) {
+  const { user } = useAuth()
+
+  return useCallback(
+    async ({ code, isPassed, matchedKeywords }: ChallengeSubmissionAttempt) => {
+      if (!user?.id) {
+        return
+      }
+
+      await createChallengeSubmission({
+        user_id: user.id,
+        step_id: stepId,
+        code,
+        is_passed: isPassed,
+        matched_keywords: matchedKeywords,
+      })
+    },
+    [stepId, user?.id],
+  )
+}

--- a/apps/web/src/features/learning/hooks/useRecentChallengeSubmissions.ts
+++ b/apps/web/src/features/learning/hooks/useRecentChallengeSubmissions.ts
@@ -1,0 +1,46 @@
+﻿import { useCallback, useEffect, useState } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import {
+  getRecentChallengeSubmissions,
+  type ChallengeSubmission,
+} from '@/services/challengeSubmissionService'
+
+export function useRecentChallengeSubmissions(stepId: string) {
+  const { user } = useAuth()
+  const [submissions, setSubmissions] = useState<ChallengeSubmission[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async () => {
+    if (!user?.id) {
+      setSubmissions([])
+      setError(null)
+      setIsLoading(false)
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const data = await getRecentChallengeSubmissions(user.id, stepId)
+      setSubmissions(data)
+    } catch (loadError) {
+      const message = loadError instanceof Error ? loadError.message : 'Challenge の提出履歴取得に失敗しました'
+      setError(message)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [stepId, user?.id])
+
+  useEffect(() => {
+    refresh().catch(() => undefined)
+  }, [refresh])
+
+  return {
+    submissions,
+    isLoading,
+    error,
+    refresh,
+  }
+}

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -8,29 +8,7 @@ import { AppHeader } from '../features/dashboard/components/AppHeader'
 import { supabaseConfigError } from '../lib/supabaseClient'
 import { BADGE_DEFINITIONS } from '../services/achievementService'
 import { getPointHistory, getProfile, upsertDisplayName, type PointHistoryRecord } from '../services/profileService'
-
-function formatDateTime(value: string): string {
-  const date = new Date(value)
-  return new Intl.DateTimeFormat('ja-JP', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  }).format(date)
-}
-
-function formatStudyDate(value: string | null): string {
-  if (!value) {
-    return '未記録'
-  }
-
-  return new Intl.DateTimeFormat('ja-JP', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).format(new Date(`${value}T00:00:00`))
-}
+import { formatDateTime, formatStudyDate } from '../shared/utils/dateTime'
 
 export function ProfilePage() {
   const { user, signOut } = useAuth()

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -1,13 +1,16 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Link, Navigate, useNavigate, useParams } from 'react-router-dom'
 import { LearningSidebar } from '../components/LearningSidebar'
 import { useAuth } from '../contexts/AuthContext'
 import { useLearningContext } from '../contexts/LearningContext'
 import { AppHeader } from '../features/dashboard/components/AppHeader'
 import { ChallengeMode } from '../features/learning/ChallengeMode'
+import { ChallengeSubmissionHistory } from '../features/learning/ChallengeSubmissionHistory'
 import { PracticeMode } from '../features/learning/PracticeMode'
 import { ReadMode } from '../features/learning/ReadMode'
 import { TestMode } from '../features/learning/TestMode'
+import { useChallengeSubmission } from '../features/learning/hooks/useChallengeSubmission'
+import { useRecentChallengeSubmissions } from '../features/learning/hooks/useRecentChallengeSubmissions'
 import { useLearningStep } from '../features/learning/hooks/useLearningStep'
 import type { LearningMode } from '../content/fundamentals/steps'
 
@@ -17,6 +20,15 @@ export function StepPage() {
   const { completedStepsCount, isLoadingStats } = useLearningContext()
   const navigate = useNavigate()
   const [activeMode, setActiveMode] = useState<LearningMode>('read')
+  const saveChallengeSubmission = useChallengeSubmission(stepId)
+  const recentChallengeSubmissions = useRecentChallengeSubmissions(stepId)
+  const handleChallengeSubmitResult = useCallback(
+    async (result: { code: string; isPassed: boolean; matchedKeywords: string[] }) => {
+      await saveChallengeSubmission(result)
+      await recentChallengeSubmissions.refresh()
+    },
+    [recentChallengeSubmissions, saveChallengeSubmission],
+  )
 
   const {
     step,
@@ -146,11 +158,19 @@ export function StepPage() {
               <TestMode stepId={step.id} task={step.testTask} onComplete={() => void handleModeComplete('test')} />
             ) : null}
             {activeMode === 'challenge' ? (
-              <ChallengeMode
-                stepId={step.id}
-                task={step.challengeTask}
-                onComplete={() => void handleModeComplete('challenge')}
-              />
+              <>
+                <ChallengeMode
+                  stepId={step.id}
+                  task={step.challengeTask}
+                  onComplete={() => void handleModeComplete('challenge')}
+                  onSubmitResult={handleChallengeSubmitResult}
+                />
+                <ChallengeSubmissionHistory
+                  submissions={recentChallengeSubmissions.submissions}
+                  isLoading={recentChallengeSubmissions.isLoading}
+                  error={recentChallengeSubmissions.error}
+                />
+              </>
             ) : null}
 
             {modeStatus.challenge ? (

--- a/apps/web/src/services/__tests__/challengeSubmissionService.test.ts
+++ b/apps/web/src/services/__tests__/challengeSubmissionService.test.ts
@@ -1,0 +1,106 @@
+﻿import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createChallengeSubmission, getRecentChallengeSubmissions } from '../challengeSubmissionService'
+
+const insert = vi.fn()
+const select = vi.fn()
+const single = vi.fn()
+const from = vi.fn()
+const eq = vi.fn()
+const order = vi.fn()
+const limit = vi.fn()
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {
+    from: (...args: unknown[]) => from(...args),
+  },
+}))
+
+describe('createChallengeSubmission', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    from.mockReturnValue({ insert })
+    insert.mockReturnValue({ select })
+    select.mockReturnValue({ single })
+    eq.mockReturnValue({ eq, order })
+    order.mockReturnValue({ limit })
+  })
+
+  it('challenge_submissions に提出コード・合否・一致キーワードを保存する', async () => {
+    const savedRow = {
+      id: 'submission-1',
+      user_id: 'user-1',
+      step_id: 'usestate-basic',
+      code: 'const ok = true',
+      is_passed: true,
+      matched_keywords: ['useState', 'onClick'],
+      submitted_at: '2026-03-09T00:00:00.000Z',
+    }
+    single.mockResolvedValue({ data: savedRow, error: null })
+
+    const result = await createChallengeSubmission({
+      user_id: 'user-1',
+      step_id: 'usestate-basic',
+      code: 'const ok = true',
+      is_passed: true,
+      matched_keywords: ['useState', 'onClick'],
+    })
+
+    expect(from).toHaveBeenCalledWith('challenge_submissions')
+    expect(insert).toHaveBeenCalledWith({
+      user_id: 'user-1',
+      step_id: 'usestate-basic',
+      code: 'const ok = true',
+      is_passed: true,
+      matched_keywords: ['useState', 'onClick'],
+    })
+    expect(select).toHaveBeenCalledWith('id, user_id, step_id, code, is_passed, matched_keywords, submitted_at')
+    expect(result).toEqual(savedRow)
+  })
+
+  it('Supabase エラーをアプリ共通エラーに変換する', async () => {
+    single.mockResolvedValue({
+      data: null,
+      error: { code: '23505', message: 'duplicate key value violates unique constraint' },
+    })
+
+    await expect(
+      createChallengeSubmission({
+        user_id: 'user-1',
+        step_id: 'usestate-basic',
+        code: 'const ok = true',
+        is_passed: false,
+        matched_keywords: [],
+      }),
+    ).rejects.toMatchObject({
+      name: 'AppError',
+      code: 'DB_UNIQUE_VIOLATION',
+      userMessage: 'Challenge の提出履歴保存に失敗しました',
+    })
+  })
+
+  it('直近の提出履歴を submitted_at 降順で取得する', async () => {
+    const rows = [
+      {
+        id: 'submission-2',
+        user_id: 'user-1',
+        step_id: 'usestate-basic',
+        code: 'latest',
+        is_passed: false,
+        matched_keywords: [],
+        submitted_at: '2026-03-09T11:00:00.000Z',
+      },
+    ]
+    from.mockReturnValue({ select })
+    select.mockReturnValue({ eq })
+    limit.mockResolvedValue({ data: rows, error: null })
+
+    const result = await getRecentChallengeSubmissions('user-1', 'usestate-basic', 3)
+
+    expect(from).toHaveBeenCalledWith('challenge_submissions')
+    expect(eq).toHaveBeenNthCalledWith(1, 'user_id', 'user-1')
+    expect(eq).toHaveBeenNthCalledWith(2, 'step_id', 'usestate-basic')
+    expect(order).toHaveBeenCalledWith('submitted_at', { ascending: false })
+    expect(limit).toHaveBeenCalledWith(3)
+    expect(result).toEqual(rows)
+  })
+})

--- a/apps/web/src/services/challengeSubmissionService.ts
+++ b/apps/web/src/services/challengeSubmissionService.ts
@@ -1,0 +1,49 @@
+﻿import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+import type { Tables, TablesInsert } from '../shared/types/database.types'
+
+export type ChallengeSubmission = Pick<
+  Tables<'challenge_submissions'>,
+  'id' | 'user_id' | 'step_id' | 'code' | 'is_passed' | 'matched_keywords' | 'submitted_at'
+>
+
+export type CreateChallengeSubmissionInput = Pick<
+  TablesInsert<'challenge_submissions'>,
+  'user_id' | 'step_id' | 'code' | 'is_passed' | 'matched_keywords'
+>
+
+export async function createChallengeSubmission(
+  input: CreateChallengeSubmissionInput,
+): Promise<ChallengeSubmission> {
+  const { data, error } = await supabase
+    .from('challenge_submissions')
+    .insert(input)
+    .select('id, user_id, step_id, code, is_passed, matched_keywords, submitted_at')
+    .single()
+
+  if (error) {
+    throw fromSupabaseError(error, 'Challenge の提出履歴保存に失敗しました')
+  }
+
+  return data
+}
+
+export async function getRecentChallengeSubmissions(
+  userId: string,
+  stepId: string,
+  limit = 5,
+): Promise<ChallengeSubmission[]> {
+  const { data, error } = await supabase
+    .from('challenge_submissions')
+    .select('id, user_id, step_id, code, is_passed, matched_keywords, submitted_at')
+    .eq('user_id', userId)
+    .eq('step_id', stepId)
+    .order('submitted_at', { ascending: false })
+    .limit(limit)
+
+  if (error) {
+    throw fromSupabaseError(error, 'Challenge の提出履歴取得に失敗しました')
+  }
+
+  return data ?? []
+}

--- a/apps/web/src/shared/utils/dateTime.ts
+++ b/apps/web/src/shared/utils/dateTime.ts
@@ -1,0 +1,22 @@
+﻿export function formatDateTime(value: string): string {
+  const date = new Date(value)
+  return new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(date)
+}
+
+export function formatStudyDate(value: string | null): string {
+  if (!value) {
+    return '未記録'
+  }
+
+  return new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date(`${value}T00:00:00`))
+}


### PR DESCRIPTION
## 概要
- roadmap06 M2 の Challenge回答履歴永続化を実装
- 提出保存serviceと履歴取得hookを追加
- Challenge画面で直近提出履歴を表示

## 変更内容
- challengeSubmissionService を追加し、提出保存と履歴取得を service 層へ分離
- useChallengeSubmission / useRecentChallengeSubmissions を追加し、UIからSupabase依存を分離
- ChallengeMode 提出時に保存処理を接続し、失敗時エラー表示を追加
- StepPage に直近履歴パネルを追加
- 日付整形を shared/utils/dateTime.ts へ共通化し、ProfilePage と共通利用
- 履歴サービスと履歴UIのテストを追加

## 検証
- cmd /c npm --workspace apps/web run typecheck
- cmd /c npm --workspace apps/web run lint
- cmd /c npm --workspace apps/web run test
- cmd /c npm --workspace apps/web run build

## Issue
- 不要
- 根拠: roadmap06 の既存タスク M2 の実装範囲で完結し、追加のトリアージ管理を必要としないため
