### PR TITLE
chore: M3 APIモック起動基盤を整備

### DIFF
--- a/apps/web/mock-api/db.json
+++ b/apps/web/mock-api/db.json
@@ -1,0 +1,22 @@
+{
+  "counter": {
+    "value": 0
+  },
+  "tasks": [
+    {
+      "id": "1",
+      "title": "Learn React basics",
+      "completed": true
+    },
+    {
+      "id": "2",
+      "title": "Review useEffect",
+      "completed": false
+    },
+    {
+      "id": "3",
+      "title": "Connect to API",
+      "completed": false
+    }
+  ]
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "api:dev": "json-server --watch mock-api/db.json --port 3001",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
@@ -38,6 +39,7 @@
     "eslint-plugin-react-refresh": "^0.5.0",
     "globals": "^17.3.0",
     "jsdom": "^28.1.0",
+    "json-server": "^1.0.0-beta.9",
     "postcss": "^8.5.6",
     "rollup-plugin-visualizer": "^7.0.0",
     "tailwindcss": "^3.4.17",

--- a/db.json
+++ b/db.json
@@ -1,8 +1,0 @@
-{
-  "counter": { "value": 0 },
-  "tasks": [
-    { "id": "1", "title": "Reactの基礎を学ぶ", "completed": true },
-    { "id": "2", "title": "useEffectを理解する", "completed": false },
-    { "id": "3", "title": "APIと連携する", "completed": false }
-  ]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,7 @@
       "version": "0.1.0",
       "workspaces": [
         "apps/*"
-      ],
-      "devDependencies": {
-        "json-server": "^1.0.0-beta.9"
-      }
+      ]
     },
     "apps/web": {
       "name": "@coden/web",
@@ -42,6 +39,7 @@
         "eslint-plugin-react-refresh": "^0.5.0",
         "globals": "^17.3.0",
         "jsdom": "^28.1.0",
+        "json-server": "^1.0.0-beta.9",
         "postcss": "^8.5.6",
         "rollup-plugin-visualizer": "^7.0.0",
         "tailwindcss": "^3.4.17",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
     "typecheck": "npm --workspace @coden/web run typecheck",
     "lint": "npm --workspace @coden/web run lint",
     "test": "npm --workspace @coden/web run test",
-    "api:dev": "json-server --port 3001 db.json"
-  },
-  "devDependencies": {
-    "json-server": "^1.0.0-beta.9"
+    "api:dev": "npm --workspace @coden/web run api:dev"
   }
 }


### PR DESCRIPTION
## 概要
- roadmap06 M3-1 の API モック起動基盤を整備
- json-server の起動責務を apps/web 側へ寄せる
- mock API の初期データを workspace 配下へ移動

## 変更内容
- pps/web/package.json に pi:dev スクリプトを追加
- ルート pi:dev は workspace スクリプトを呼ぶ委譲構成へ変更
- pps/web/mock-api/db.json を追加し、/counter と /tasks の初期データを定義
- ルート直下の db.json を削除して API モックの責務を pps/web に集約
- json-server の依存メタを workspace 側へ移動し、package-lock.json を整合

## 検証
- cmd /c npm --workspace apps/web run api:dev -- --help
- cmd /c npm --workspace apps/web run typecheck
- cmd /c npm --workspace apps/web run lint
- cmd /c npm --workspace apps/web run test
- cmd /c npm --workspace apps/web run build
- cmd /c npm --workspace apps/web run api:dev 実行時に json-server 起動まで到達することを確認（この環境では EADDRINUSE: 3001 で停止。既存プロセス競合によるもの）

## Issue
- 不要
- 根拠: roadmap06 の既存タスク M3-1 の実装範囲で完結し、追加のトリアージ管理を必要としないため
