### PR TITLE
fix: M4-1 MVP向けの準備中導線を整理

### DIFF
--- a/apps/web/src/content/courseData.ts
+++ b/apps/web/src/content/courseData.ts
@@ -207,3 +207,7 @@ export function getNextStep(currentStepId: string): StepMeta | undefined {
   if (currentIndex === -1) return undefined
   return allSteps[currentIndex + 1]
 }
+
+export function getFirstImplementedStep(): StepMeta | undefined {
+  return COURSES.flatMap((course) => course.steps).find((step) => step.isImplemented)
+}

--- a/apps/web/src/features/dashboard/components/AppHeader.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeader.tsx
@@ -1,4 +1,5 @@
 import { Link, useLocation } from 'react-router-dom'
+import { getFirstImplementedStep } from '@/content/courseData'
 import { useLearningContext } from '@/contexts/LearningContext'
 
 interface AppHeaderProps {
@@ -9,6 +10,8 @@ interface AppHeaderProps {
 export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
   const { stats } = useLearningContext()
   const location = useLocation()
+  const firstImplementedStep = getFirstImplementedStep()
+  const learningPath = firstImplementedStep ? `/step/${firstImplementedStep.id}` : '/'
   return (
     <header className="sticky top-0 z-40 border-b border-slate-200/70 bg-white/90 backdrop-blur">
       <div className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
@@ -30,14 +33,14 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
               ダッシュボード
             </Link>
             <Link
-              to="/"
+              to={learningPath}
               className={`pb-1 ${location.pathname.startsWith('/step')
                 ? 'border-b-2 border-primary-mint text-slate-900'
                 : 'text-slate-500 hover:text-slate-700'
                 }`}
               aria-current={location.pathname.startsWith('/step') ? 'page' : undefined}
             >
-              コース一覧
+              学習を始める
             </Link>
             <Link
               to="/profile"

--- a/apps/web/src/features/dashboard/components/DashboardSidebar.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardSidebar.tsx
@@ -140,18 +140,15 @@ export function DashboardSidebar() {
 
       <section className="rounded-2xl bg-gradient-to-br from-indigo-600 to-sky-600 p-5 text-white shadow-sm">
         <p className="mb-2 inline-block rounded bg-white/20 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide">
-          Daily Challenge
+          Bonus Challenge
         </p>
-        <h3 className="font-bold">ボーナス問題を解く</h3>
-        <p className="mt-1 text-sm text-indigo-100">React Hooks クイズに正解して +50pt を獲得しましょう。</p>
-        <button
-          className="mt-4 w-full cursor-not-allowed rounded-lg bg-white/50 py-2 text-sm font-semibold text-indigo-400"
-          type="button"
-          disabled
-          aria-disabled="true"
-        >
-          準備中
-        </button>
+        <h3 className="font-bold">MVPでは未提供です</h3>
+        <p className="mt-1 text-sm text-indigo-100">
+          現在のMVPでは、20ステップの学習フローに集中できる構成にしています。追加チャレンジは今後の拡張予定です。
+        </p>
+        <div className="mt-4 rounded-lg border border-white/25 bg-white/10 px-4 py-3 text-sm font-medium text-indigo-50">
+          機能状態: 準備中
+        </div>
       </section>
     </aside>
   )

--- a/apps/web/src/features/dashboard/components/__tests__/DashboardNavigation.test.tsx
+++ b/apps/web/src/features/dashboard/components/__tests__/DashboardNavigation.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import { AppHeader } from '../AppHeader'
+import { DashboardSidebar } from '../DashboardSidebar'
+
+vi.mock('@/contexts/LearningContext', () => ({
+  useLearningContext: () => ({
+    stats: {
+      total_points: 120,
+      current_streak: 3,
+    },
+  }),
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: null,
+  }),
+}))
+
+vi.mock('@/services/statsService', () => ({
+  calculatePointGoalProgress: () => ({
+    current: 120,
+    target: 200,
+    percent: 60,
+  }),
+  countMonthlyStudyDays: () => 0,
+  getLearningHeatmap: vi.fn().mockResolvedValue([]),
+}))
+
+describe('dashboard navigation placeholders', () => {
+  it('AppHeader の学習導線が最初の実装済みステップを指す', () => {
+    render(
+      <MemoryRouter>
+        <AppHeader displayName="tester" onSignOut={() => undefined} />
+      </MemoryRouter>,
+    )
+
+    const link = screen.getByRole('link', { name: '学習を始める' })
+    expect(link.getAttribute('href')).toBe('/step/usestate-basic')
+  })
+
+  it('Bonus Challenge プレースホルダーが MVP 対象外であることを明示する', () => {
+    render(
+      <MemoryRouter>
+        <DashboardSidebar />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('MVPでは未提供です')).toBeTruthy()
+    expect(screen.getByText('機能状態: 準備中')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: '準備中' })).toBeNull()
+  })
+})

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { ConfigErrorView } from '../components/ConfigErrorView'
-import { IMPLEMENTED_STEP_COUNT } from '../content/courseData'
+import { getFirstImplementedStep, IMPLEMENTED_STEP_COUNT } from '../content/courseData'
 import { useAuth } from '../contexts/AuthContext'
 import { useLearningContext } from '../contexts/LearningContext'
 import { AppHeader } from '../features/dashboard/components/AppHeader'
@@ -19,6 +19,7 @@ export function DashboardPage() {
   const userId = user?.id ?? null
   const [displayName, setDisplayName] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const firstImplementedStep = getFirstImplementedStep()
 
   const greetingName = useMemo(() => {
     if (displayName) {
@@ -90,9 +91,11 @@ export function DashboardPage() {
             <WelcomeBanner displayName={greetingName} />
             <LearningOverviewCard completedCount={Math.min(completedStepsCount, IMPLEMENTED_STEP_COUNT)} />
             <ReviewListWidget />
-            <Link className="inline-flex text-sm font-semibold text-primary-dark underline" to="/step/usestate-basic">
-              学習画面へ移動（/step/usestate-basic）
-            </Link>
+            {firstImplementedStep ? (
+              <Link className="inline-flex text-sm font-semibold text-primary-dark underline" to={`/step/${firstImplementedStep.id}`}>
+                最初のレッスンから始める
+              </Link>
+            ) : null}
           </section>
 
           <section className="lg:col-span-4">


### PR DESCRIPTION
## 概要
- Dashboard の学習導線を最初の実装済みステップから導出するよう変更
- AppHeader の文言と遷移先の不整合を解消
- Bonus Challenge のプレースホルダーを MVP 対象外であることが伝わる表示へ整理
- ナビゲーション整理の回帰テストを追加

## 検証
- cmd /c npm --workspace apps/web run typecheck
- cmd /c npm --workspace apps/web run lint
- cmd /c npm --workspace apps/web run test
- cmd /c npm --workspace apps/web run build

## Issue要否
- 不要
- 根拠: roadmap06 の M4-1 で定義済みのスコープ内で完結するため