### PR TITLE
test: 学習補助機能の主要導線テストを追加

### DIFF
--- a/apps/web/src/pages/__tests__/DashboardPage.test.tsx
+++ b/apps/web/src/pages/__tests__/DashboardPage.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DashboardPage } from '../DashboardPage'
+import { addToReviewList, clearReviewList } from '@/services/reviewListService'
+
+const getProfileMock = vi.fn()
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: {
+      id: 'user-1',
+      email: 'tester@example.com',
+    },
+    signOut: vi.fn(),
+  }),
+}))
+
+vi.mock('@/contexts/LearningContext', () => ({
+  useLearningContext: () => ({
+    completedStepsCount: 3,
+  }),
+}))
+
+vi.mock('@/features/dashboard/components/AppHeader', () => ({
+  AppHeader: ({ displayName }: { displayName: string }) => <div>{displayName} header</div>,
+}))
+
+vi.mock('@/features/dashboard/components/DashboardSidebar', () => ({
+  DashboardSidebar: () => <aside>sidebar</aside>,
+}))
+
+vi.mock('@/features/dashboard/components/LearningOverviewCard', () => ({
+  LearningOverviewCard: ({ completedCount }: { completedCount: number }) => <div>overview {completedCount}</div>,
+}))
+
+vi.mock('@/features/dashboard/components/WelcomeBanner', () => ({
+  WelcomeBanner: ({ displayName }: { displayName: string }) => <div>Welcome {displayName}</div>,
+}))
+
+vi.mock('@/services/profileService', () => ({
+  getProfile: (...args: unknown[]) => getProfileMock(...args),
+}))
+
+vi.mock('@/lib/supabaseClient', () => ({
+  supabaseConfigError: null,
+}))
+
+describe('DashboardPage', () => {
+  beforeEach(() => {
+    clearReviewList()
+    getProfileMock.mockReset()
+    getProfileMock.mockResolvedValue({
+      display_name: 'Coden User',
+    })
+  })
+
+  it('復習リストをダッシュボード導線上に表示する', async () => {
+    addToReviewList('usestate-basic')
+
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('復習リスト')).toBeTruthy()
+    expect(screen.getByText('このリストは現在の端末とブラウザにのみ保存されます。')).toBeTruthy()
+    expect(screen.getByRole('link', { name: /useState基礎/i }).getAttribute('href')).toBe('/step/usestate-basic')
+    expect(getProfileMock).toHaveBeenCalledWith('user-1')
+  })
+})

--- a/apps/web/src/pages/__tests__/StepPage.test.tsx
+++ b/apps/web/src/pages/__tests__/StepPage.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { describe, expect, it, vi } from 'vitest'
+import { StepPage } from '../StepPage'
+
+const useChallengeSubmissionMock = vi.fn()
+const useRecentChallengeSubmissionsMock = vi.fn()
+const useLearningStepMock = vi.fn()
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: {
+      id: 'user-1',
+      email: 'tester@example.com',
+      user_metadata: {},
+    },
+    signOut: vi.fn(),
+  }),
+}))
+
+vi.mock('@/contexts/LearningContext', () => ({
+  useLearningContext: () => ({
+    completedStepsCount: 20,
+    isLoadingStats: false,
+  }),
+}))
+
+vi.mock('@/components/LearningSidebar', () => ({
+  LearningSidebar: () => <aside>learning sidebar</aside>,
+}))
+
+vi.mock('@/features/dashboard/components/AppHeader', () => ({
+  AppHeader: ({ displayName }: { displayName: string }) => <div>{displayName} header</div>,
+}))
+
+vi.mock('@/features/learning/ReadMode', () => ({
+  ReadMode: () => <div>read mode</div>,
+}))
+
+vi.mock('@/features/learning/PracticeMode', () => ({
+  PracticeMode: () => <div>practice mode</div>,
+}))
+
+vi.mock('@/features/learning/TestMode', () => ({
+  TestMode: () => <div>test mode</div>,
+}))
+
+vi.mock('@/features/learning/ChallengeMode', () => ({
+  ChallengeMode: () => <div>challenge mode</div>,
+}))
+
+vi.mock('@/features/learning/hooks/useChallengeSubmission', () => ({
+  useChallengeSubmission: (...args: unknown[]) => useChallengeSubmissionMock(...args),
+}))
+
+vi.mock('@/features/learning/hooks/useRecentChallengeSubmissions', () => ({
+  useRecentChallengeSubmissions: (...args: unknown[]) => useRecentChallengeSubmissionsMock(...args),
+}))
+
+vi.mock('@/features/learning/hooks/useLearningStep', () => ({
+  useLearningStep: (...args: unknown[]) => useLearningStepMock(...args),
+}))
+
+describe('StepPage', () => {
+  it('Challenge タブで提出履歴を主要導線上に表示する', async () => {
+    const user = userEvent.setup()
+
+    useChallengeSubmissionMock.mockReturnValue(vi.fn())
+    useRecentChallengeSubmissionsMock.mockReturnValue({
+      submissions: [
+        {
+          id: 'submission-1',
+          user_id: 'user-1',
+          step_id: 'usestate-basic',
+          code: 'const [count, setCount] = useState(0);',
+          is_passed: true,
+          matched_keywords: ['useState'],
+          submitted_at: '2026-03-09T10:30:00.000Z',
+        },
+      ],
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+    })
+    useLearningStepMock.mockReturnValue({
+      step: {
+        id: 'usestate-basic',
+        title: 'useState基礎',
+        summary: 'summary',
+        readMarkdown: '# read',
+        practiceQuestions: [],
+        testTask: {
+          instruction: 'instruction',
+          starterCode: 'const value = ____;',
+          expectedKeywords: ['value'],
+        },
+        challengeTask: {
+          patterns: [
+            {
+              id: 'pattern-1',
+              prompt: 'challenge',
+              requirements: [],
+              hints: [],
+              expectedKeywords: ['useState'],
+              starterCode: 'const [count, setCount] = useState(0);',
+            },
+          ],
+        },
+        order: 1,
+      },
+      isUnavailableStep: false,
+      modeStatus: {
+        read: false,
+        practice: false,
+        test: false,
+        challenge: false,
+      },
+      syncMessage: null,
+      toastMessage: null,
+      nextStep: undefined,
+      sidebarTitle: 'React基礎',
+      sidebarSteps: [],
+      isStepCompleted: false,
+      handleModeComplete: vi.fn(),
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/step/usestate-basic']}>
+        <Routes>
+          <Route path="/step/:stepId" element={<StepPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Challenge' }))
+
+    expect(screen.getByText('直近の提出履歴')).toBeTruthy()
+    expect(screen.getByText('Latest Submission')).toBeTruthy()
+    expect(screen.getByText('合格')).toBeTruthy()
+    expect(screen.getByText('const [count, setCount] = useState(0);')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## 概要
- ダッシュボードで復習リストが主要導線上に表示されることを確認するページテストを追加
- StepPage の Challenge タブから提出履歴が表示されることを確認するページテストを追加
- M1〜M5 の既存学習モード修正に対する回帰を全体テストで再確認

## Issue
- 不要: roadmap06 M5-2 に作業スコープが定義済みのため

## 検証
- cmd /c npm run lint
- cmd /c npm run typecheck
- cmd /c npm run test
- cmd /c npm run build