### PR TITLE
refactor: displayName取得ロジックを共通化

### DIFF
--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -11,6 +11,7 @@ import { ReviewListWidget } from '../features/dashboard/components/ReviewListWid
 import { WelcomeBanner } from '../features/dashboard/components/WelcomeBanner'
 import { supabaseConfigError } from '../lib/supabaseClient'
 import { getProfile } from '../services/profileService'
+import { getDisplayName } from '../shared/utils/getDisplayName'
 
 export function DashboardPage() {
   const { user, signOut } = useAuth()
@@ -21,17 +22,21 @@ export function DashboardPage() {
   const [error, setError] = useState<string | null>(null)
   const firstImplementedStep = getFirstImplementedStep()
 
-  const greetingName = useMemo(() => {
-    if (displayName) {
-      return displayName
-    }
-
-    if (user?.email) {
-      return user.email.split('@')[0]
-    }
-
-    return 'ゲスト'
-  }, [displayName, user?.email])
+  const greetingName = useMemo(
+    () =>
+      getDisplayName(
+        user
+          ? {
+              ...user,
+              user_metadata: {
+                ...user.user_metadata,
+                display_name: displayName ?? user.user_metadata?.display_name,
+              },
+            }
+          : null,
+      ),
+    [displayName, user],
+  )
 
   useEffect(() => {
     if (!userId || supabaseConfigError) {

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -9,6 +9,7 @@ import { supabaseConfigError } from '../lib/supabaseClient'
 import { BADGE_DEFINITIONS } from '../services/achievementService'
 import { getPointHistory, getProfile, upsertDisplayName, type PointHistoryRecord } from '../services/profileService'
 import { formatDateTime, formatStudyDate } from '../shared/utils/dateTime'
+import { getDisplayName } from '../shared/utils/getDisplayName'
 
 export function ProfilePage() {
   const { user, signOut } = useAuth()
@@ -25,17 +26,21 @@ export function ProfilePage() {
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
 
-  const headerDisplayName = useMemo(() => {
-    if (displayName) {
-      return displayName
-    }
-
-    if (user?.email) {
-      return user.email.split('@')[0]
-    }
-
-    return 'ゲスト'
-  }, [displayName, user?.email])
+  const headerDisplayName = useMemo(
+    () =>
+      getDisplayName(
+        user
+          ? {
+              ...user,
+              user_metadata: {
+                ...user.user_metadata,
+                display_name: displayName ?? user.user_metadata?.display_name,
+              },
+            }
+          : null,
+      ),
+    [displayName, user],
+  )
 
   useEffect(() => {
     if (!userId || supabaseConfigError) {

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -13,6 +13,7 @@ import { useChallengeSubmission } from '../features/learning/hooks/useChallengeS
 import { useRecentChallengeSubmissions } from '../features/learning/hooks/useRecentChallengeSubmissions'
 import { useLearningStep } from '../features/learning/hooks/useLearningStep'
 import type { LearningMode } from '../content/fundamentals/steps'
+import { getDisplayName } from '../shared/utils/getDisplayName'
 
 export function StepPage() {
   const { stepId = '' } = useParams()
@@ -42,18 +43,7 @@ export function StepPage() {
     handleModeComplete,
   } = useLearningStep(stepId)
 
-  const headerDisplayName = useMemo(() => {
-    const metadataName = user?.user_metadata?.display_name
-    if (typeof metadataName === 'string' && metadataName.length > 0) {
-      return metadataName
-    }
-
-    if (user?.email) {
-      return user.email.split('@')[0]
-    }
-
-    return 'ゲスト'
-  }, [user?.email, user?.user_metadata])
+  const headerDisplayName = useMemo(() => getDisplayName(user), [user])
 
   const modeButtons: { id: LearningMode; label: string }[] = useMemo(
     () => [

--- a/apps/web/src/shared/utils/__tests__/getDisplayName.test.ts
+++ b/apps/web/src/shared/utils/__tests__/getDisplayName.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { getDisplayName } from '../getDisplayName'
+
+describe('getDisplayName', () => {
+  it('user_metadata.display_name を優先する', () => {
+    expect(
+      getDisplayName({
+        email: 'coder@example.com',
+        user_metadata: { display_name: 'Coden User' },
+      } as never),
+    ).toBe('Coden User')
+  })
+
+  it('display_name が空白のみなら email のローカル部へフォールバックする', () => {
+    expect(
+      getDisplayName({
+        email: 'coder@example.com',
+        user_metadata: { display_name: '   ' },
+      } as never),
+    ).toBe('coder')
+  })
+
+  it('display_name が無ければ email のローカル部へフォールバックする', () => {
+    expect(
+      getDisplayName({
+        email: 'coder@example.com',
+        user_metadata: {},
+      } as never),
+    ).toBe('coder')
+  })
+
+  it('user と email が無ければ ゲスト を返す', () => {
+    expect(getDisplayName(null)).toBe('ゲスト')
+    expect(
+      getDisplayName({
+        email: null,
+        user_metadata: {},
+      } as never),
+    ).toBe('ゲスト')
+  })
+})

--- a/apps/web/src/shared/utils/getDisplayName.ts
+++ b/apps/web/src/shared/utils/getDisplayName.ts
@@ -1,0 +1,16 @@
+import type { User } from '@supabase/supabase-js'
+
+type DisplayNameUser = Pick<User, 'email' | 'user_metadata'> | null | undefined
+
+export function getDisplayName(user: DisplayNameUser): string {
+  const metadataName = user?.user_metadata?.display_name
+  if (typeof metadataName === 'string' && metadataName.trim().length > 0) {
+    return metadataName.trim()
+  }
+
+  if (typeof user?.email === 'string' && user.email.length > 0) {
+    return user.email.split('@')[0]
+  }
+
+  return 'ゲスト'
+}


### PR DESCRIPTION
## 概要
- getDisplayName ヘルパーを追加して displayName のフォールバックを共通化
- Step / Dashboard / Profile の重複ロジックを置換
- helper のユニットテストを追加

## 変更内容
- pps/web/src/shared/utils/getDisplayName.ts を追加
- 3ページの表示名導出を helper 経由へ統一
- pps/web/src/shared/utils/__tests__/getDisplayName.test.ts を追加

## 検証
- cmd /c npm --workspace apps/web run lint
- cmd /c npm --workspace apps/web run typecheck
- cmd /c npm --workspace apps/web run test
- cmd /c npm --workspace apps/web run build

## Issue
- Issue不要: roadmap07 の M1-1 タスクとして管理済みのため