### PR TITLE
feat: 404ページを追加

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,6 +1,6 @@
 import React, { lazy, Suspense } from 'react'
 import ReactDOM from 'react-dom/client'
-import { createBrowserRouter, Navigate, RouterProvider } from 'react-router-dom'
+import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { ProtectedRoute, GuestRoute } from './components/ProtectedRoute'
 import { AuthProvider } from './contexts/AuthContext'
 import { LearningProvider } from './contexts/LearningContext'
@@ -12,6 +12,7 @@ import './styles/globals.css'
 // Route-based Code Splitting: 各ページを動的インポートでチャンク分割
 const DashboardPage = lazy(() => import('./pages/DashboardPage').then((m) => ({ default: m.DashboardPage })))
 const LoginPage = lazy(() => import('./pages/LoginPage').then((m) => ({ default: m.LoginPage })))
+const NotFoundPage = lazy(() => import('./pages/NotFoundPage').then((m) => ({ default: m.NotFoundPage })))
 const ProfilePage = lazy(() => import('./pages/ProfilePage').then((m) => ({ default: m.ProfilePage })))
 const SignUpPage = lazy(() => import('./pages/SignUpPage').then((m) => ({ default: m.SignUpPage })))
 const StepPage = lazy(() => import('./pages/StepPage').then((m) => ({ default: m.StepPage })))
@@ -76,7 +77,14 @@ const router = createBrowserRouter([
       </ProtectedRoute>
     ),
   },
-  { path: '*', element: <Navigate to="/" replace /> },
+  {
+    path: '*',
+    element: (
+      <Suspense fallback={<PageLoading />}>
+        <NotFoundPage />
+      </Suspense>
+    ),
+  },
 ])
 
 const rootElement = document.getElementById('root')!

--- a/apps/web/src/pages/NotFoundPage.tsx
+++ b/apps/web/src/pages/NotFoundPage.tsx
@@ -1,0 +1,34 @@
+import { Link } from 'react-router-dom'
+
+export function NotFoundPage() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 px-6 py-16">
+      <header className="space-y-3">
+        <div className="flex items-center gap-3">
+          <img src="/coden_logo.png" alt="Coden Logo" className="h-12 w-12 object-contain" />
+          <p className="font-display text-2xl font-bold tracking-tight text-primary-mint">Coden MVP</p>
+        </div>
+        <p className="text-sm font-semibold uppercase tracking-[0.3em] text-slate-500">404 Not Found</p>
+        <h1 className="font-display text-4xl font-bold tracking-tight text-slate-900">ページが見つかりません</h1>
+        <p className="max-w-2xl text-base leading-7 text-slate-600">
+          指定したURLのページは存在しないか、移動した可能性があります。学習を続ける場合はダッシュボードへ戻ってください。
+        </p>
+      </header>
+
+      <div className="flex flex-wrap gap-3">
+        <Link
+          className="inline-flex items-center justify-center rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-700"
+          to="/"
+        >
+          ダッシュボードへ戻る
+        </Link>
+        <Link
+          className="inline-flex items-center justify-center rounded-md border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+          to="/login"
+        >
+          ログインページを見る
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/apps/web/src/pages/__tests__/NotFoundPage.test.tsx
+++ b/apps/web/src/pages/__tests__/NotFoundPage.test.tsx
@@ -1,0 +1,32 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it } from 'vitest'
+import { NotFoundPage } from '../NotFoundPage'
+
+describe('NotFoundPage', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('404 メッセージとホームへの導線を表示する', () => {
+    render(
+      <MemoryRouter>
+        <NotFoundPage />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('heading', { name: 'ページが見つかりません' })).toBeTruthy()
+    expect(screen.getByText('404 Not Found')).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'ダッシュボードへ戻る' }).getAttribute('href')).toBe('/')
+  })
+
+  it('ログインページへの補助導線を表示する', () => {
+    render(
+      <MemoryRouter>
+        <NotFoundPage />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('link', { name: 'ログインページを見る' }).getAttribute('href')).toBe('/login')
+  })
+})


### PR DESCRIPTION
## 概要
- NotFoundPage を追加し、404メッセージとホーム導線を実装
- main.tsx のワイルドカードルートを NotFoundPage 表示へ差し替え
- NotFoundPage のユニットテストを追加

## Issue
- 不要
- 根拠: roadmap07 の M2-2 に定義済みのタスク範囲で完結するため

## 検証
- cmd /c npm --workspace apps/web run lint
- cmd /c npm --workspace apps/web run typecheck
- cmd /c npm --workspace apps/web run test
- cmd /c npm --workspace apps/web run build