### PR TITLE
feat: TestModeプレビューを拡充

### DIFF
--- a/apps/web/src/features/learning/TestMode.tsx
+++ b/apps/web/src/features/learning/TestMode.tsx
@@ -1,30 +1,12 @@
 import { Fragment, useEffect, useMemo, useState } from 'react'
 import type { TestTask } from '../../content/fundamentals/steps'
 import { addToReviewList, removeFromReviewList } from '../../services/reviewListService'
+import { previewByStepId } from './testModePreview'
 
 interface TestModeProps {
   stepId: string
   task: TestTask
   onComplete: () => void
-}
-
-const previewByStepId: Record<string, { title: string; description: string }> = {
-  'usestate-basic': {
-    title: 'Counter Preview',
-    description: 'クリックでカウントが増えるUIを確認できる状態です。',
-  },
-  events: {
-    title: 'Event Preview',
-    description: 'イベントハンドラが接続された状態です。',
-  },
-  conditional: {
-    title: 'Conditional Preview',
-    description: '条件分岐に応じて表示切り替えが動作する状態です。',
-  },
-  lists: {
-    title: 'List Preview',
-    description: 'リスト描画とkey設定が有効です。',
-  },
 }
 
 export function TestMode({ stepId, task, onComplete }: TestModeProps) {

--- a/apps/web/src/features/learning/__tests__/TestMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/TestMode.test.tsx
@@ -1,8 +1,10 @@
-import { render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TestMode } from '../TestMode'
+import { COURSES } from '../../../content/courseData'
 import type { TestTask } from '../../../content/fundamentals/steps'
+import { previewByStepId } from '../testModePreview'
 
 const addToReviewList = vi.fn()
 const removeFromReviewList = vi.fn()
@@ -27,6 +29,10 @@ const secondTask: TestTask = {
 }
 
 describe('TestMode', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
   beforeEach(() => {
     addToReviewList.mockReset()
     removeFromReviewList.mockReset()
@@ -50,5 +56,34 @@ describe('TestMode', () => {
     expect((screen.getByLabelText('コードの空欄を入力') as HTMLInputElement).value).toBe('')
     expect(screen.queryByRole('status')).toBeNull()
     expect(screen.getByText('次の問題')).toBeTruthy()
+  })
+
+  it('実装済み全ステップにプレビュー定義が存在する', () => {
+    const implementedStepIds = COURSES.flatMap((course) => course.steps)
+      .filter((step) => step.isImplemented)
+      .map((step) => step.id)
+
+    expect(implementedStepIds).toHaveLength(20)
+
+    for (const stepId of implementedStepIds) {
+      expect(previewByStepId[stepId]).toBeTruthy()
+      expect(previewByStepId[stepId].title.length).toBeGreaterThan(0)
+      expect(previewByStepId[stepId].description.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('新規追加したステップでも合格時にプレビューを表示する', async () => {
+    const user = userEvent.setup()
+    const onComplete = vi.fn()
+
+    render(<TestMode stepId="useeffect" task={firstTask} onComplete={onComplete} />)
+
+    await user.type(screen.getByLabelText('コードの空欄を入力'), 'setCount(count - 1)')
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+
+    expect(screen.getByText('Effect Sync Preview')).toBeTruthy()
+    expect(
+      screen.getByText('副作用で取得したデータや保存状態が、画面に同期される流れを確認できます。'),
+    ).toBeTruthy()
   })
 })

--- a/apps/web/src/features/learning/testModePreview.ts
+++ b/apps/web/src/features/learning/testModePreview.ts
@@ -1,0 +1,82 @@
+export const previewByStepId: Record<string, { title: string; description: string }> = {
+  'usestate-basic': {
+    title: 'Counter Preview',
+    description: 'クリックでカウントが増えるUIを確認できる状態です。',
+  },
+  events: {
+    title: 'Event Preview',
+    description: 'イベントハンドラが接続された状態です。',
+  },
+  conditional: {
+    title: 'Conditional Preview',
+    description: '条件分岐に応じて表示切り替えが動作する状態です。',
+  },
+  lists: {
+    title: 'List Preview',
+    description: 'リスト描画とkey設定が有効です。',
+  },
+  useeffect: {
+    title: 'Effect Sync Preview',
+    description: '副作用で取得したデータや保存状態が、画面に同期される流れを確認できます。',
+  },
+  forms: {
+    title: 'Form Control Preview',
+    description: '入力値の管理とバリデーション結果が、フォームUIに反映される状態を確認できます。',
+  },
+  usecontext: {
+    title: 'Context Sharing Preview',
+    description: 'Context 経由で共有された状態が、複数コンポーネントへ同時に届く様子を確認できます。',
+  },
+  usereducer: {
+    title: 'Reducer Flow Preview',
+    description: 'dispatch された action に応じて、状態が段階的に更新される流れを確認できます。',
+  },
+  'custom-hooks': {
+    title: 'Custom Hook Preview',
+    description: '再利用可能なロジックが Hook に切り出され、画面からシンプルに使われる状態を確認できます。',
+  },
+  'api-fetch': {
+    title: 'Fetch State Preview',
+    description: 'API から取得したデータが、ローディングを経て画面へ描画される流れを確認できます。',
+  },
+  performance: {
+    title: 'Performance Preview',
+    description: '不要な再計算や再描画を抑えながら、同じUIを保つ最適化の考え方を確認できます。',
+  },
+  testing: {
+    title: 'Testing Result Preview',
+    description: 'テストコードで UI の期待動作を固定し、変更時の退行を防ぐ考え方を確認できます。',
+  },
+  'api-counter-get': {
+    title: 'API Counter GET Preview',
+    description: 'GET リクエストで取得したカウンター値が、初期表示に反映される状態を確認できます。',
+  },
+  'api-counter-post': {
+    title: 'API Counter POST Preview',
+    description: 'POST リクエストで更新した値が、サーバー応答とともに画面へ反映される流れを確認できます。',
+  },
+  'api-tasks-list': {
+    title: 'Task List Preview',
+    description: 'API から取得したタスク一覧が、読み込み完了後に画面へ並ぶ状態を確認できます。',
+  },
+  'api-tasks-create': {
+    title: 'Task Create Preview',
+    description: 'フォーム送信で作成したタスクが、一覧へ即座に追加される流れを確認できます。',
+  },
+  'api-tasks-update': {
+    title: 'Task Update Preview',
+    description: '選択中タスクの変更内容が、更新APIの結果とともに一覧へ反映される状態を確認できます。',
+  },
+  'api-tasks-delete': {
+    title: 'Task Delete Preview',
+    description: '削除したタスクが一覧から消え、最新状態へ同期される流れを確認できます。',
+  },
+  'api-custom-hook': {
+    title: 'useTasks Preview',
+    description: 'API 操作をカスタム Hook にまとめ、一覧更新と状態管理を一箇所で扱う構成を確認できます。',
+  },
+  'api-error-loading': {
+    title: 'Error Handling Preview',
+    description: 'ローディング中とエラー時で表示を切り替え、非同期 UI を安全に扱う状態を確認できます。',
+  },
+}


### PR DESCRIPTION
## 概要
- TestMode のプレビュー定義を Course 2〜4 の16ステップ分追加
- プレビュー定義を専用モジュールへ分離
- 実装済み20ステップすべてにプレビュー定義が存在することをテストで検証

## Issue
- 不要
- 根拠: roadmap07 の M3-1 に定義済みの単一タスクで完結するため

## 検証
- cmd /c npm --workspace apps/web run lint
- cmd /c npm --workspace apps/web run typecheck
- cmd /c npm --workspace apps/web run test
- cmd /c npm --workspace apps/web run build