### PR TITLE
feat: lucide-react導入とSpinnerコンポーネントによるローディング表示統一

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",
     "@supabase/supabase-js": "^2.57.4",
+    "lucide-react": "^0.577.0",
     "prismjs": "^1.30.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/apps/web/src/components/ProtectedRoute.tsx
+++ b/apps/web/src/components/ProtectedRoute.tsx
@@ -1,17 +1,14 @@
 import type { ReactNode } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
+import { PageSpinner } from './Spinner'
 
 export function ProtectedRoute({ children }: { children: ReactNode }) {
   const { isLoading, user } = useAuth()
   const location = useLocation()
 
   if (isLoading) {
-    return (
-      <main className="mx-auto flex min-h-screen max-w-3xl items-center justify-center px-6 py-16">
-        <p className="text-sm text-slate-600">認証状態を確認中...</p>
-      </main>
-    )
+    return <PageSpinner label="認証状態を確認中..." />
   }
 
   if (!user) {
@@ -25,11 +22,7 @@ export function GuestRoute({ children }: { children: ReactNode }) {
   const { isLoading, user } = useAuth()
 
   if (isLoading) {
-    return (
-      <main className="mx-auto flex min-h-screen max-w-3xl items-center justify-center px-6 py-16">
-        <p className="text-sm text-slate-600">認証状態を確認中...</p>
-      </main>
-    )
+    return <PageSpinner label="認証状態を確認中..." />
   }
 
   if (user) {

--- a/apps/web/src/components/Spinner.tsx
+++ b/apps/web/src/components/Spinner.tsx
@@ -1,0 +1,30 @@
+import { Loader2 } from 'lucide-react'
+
+const SIZE_MAP = {
+  sm: 'h-4 w-4',
+  md: 'h-6 w-6',
+  lg: 'h-10 w-10',
+} as const
+
+interface SpinnerProps {
+  size?: keyof typeof SIZE_MAP
+  label?: string
+  className?: string
+}
+
+export function Spinner({ size = 'md', label, className = '' }: SpinnerProps) {
+  return (
+    <div className={`flex items-center gap-2 ${className}`} role="status" aria-label={label ?? '読み込み中'}>
+      <Loader2 className={`${SIZE_MAP[size]} animate-spin text-primary-mint`} />
+      {label ? <span className="text-sm text-text-light">{label}</span> : null}
+    </div>
+  )
+}
+
+export function PageSpinner({ label = '読み込み中...' }: { label?: string }) {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <Spinner size="lg" label={label} />
+    </div>
+  )
+}

--- a/apps/web/src/components/__tests__/Spinner.test.tsx
+++ b/apps/web/src/components/__tests__/Spinner.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { PageSpinner, Spinner } from '../Spinner'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Spinner', () => {
+  it('role="status" でレンダリングされる', () => {
+    render(<Spinner />)
+    expect(screen.getByRole('status')).toBeTruthy()
+  })
+
+  it('デフォルトで aria-label="読み込み中" が設定される', () => {
+    render(<Spinner />)
+    expect(screen.getByRole('status').getAttribute('aria-label')).toBe('読み込み中')
+  })
+
+  it('label を指定するとテキストが表示される', () => {
+    render(<Spinner label="データを取得中..." />)
+    expect(screen.getByText('データを取得中...')).toBeTruthy()
+  })
+
+  it('label を指定すると aria-label にも反映される', () => {
+    render(<Spinner label="認証確認中..." />)
+    expect(screen.getByRole('status').getAttribute('aria-label')).toBe('認証確認中...')
+  })
+
+  it('label なしではテキストが表示されない', () => {
+    const { container } = render(<Spinner />)
+    const spans = container.querySelectorAll('span')
+    expect(spans.length).toBe(0)
+  })
+
+  it('className を追加できる', () => {
+    const { container } = render(<Spinner className="mt-4" />)
+    const wrapper = container.firstElementChild as HTMLElement
+    expect(wrapper.className).toContain('mt-4')
+  })
+})
+
+describe('PageSpinner', () => {
+  it('フルスクリーンのローディング表示をレンダリングする', () => {
+    render(<PageSpinner />)
+    expect(screen.getByText('読み込み中...')).toBeTruthy()
+  })
+
+  it('カスタムラベルを表示できる', () => {
+    render(<PageSpinner label="認証状態を確認中..." />)
+    expect(screen.getByText('認証状態を確認中...')).toBeTruthy()
+  })
+
+  it('min-h-screen でフルスクリーン表示になる', () => {
+    const { container } = render(<PageSpinner />)
+    const wrapper = container.firstElementChild as HTMLElement
+    expect(wrapper.className).toContain('min-h-screen')
+  })
+})

--- a/apps/web/src/features/dashboard/components/DashboardSidebar.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardSidebar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { Spinner } from '@/components/Spinner'
 import { useAuth } from '@/contexts/AuthContext'
 import { useLearningContext } from '@/contexts/LearningContext'
 import {
@@ -134,7 +135,7 @@ export function DashboardSidebar() {
         <p className="mt-3 text-center text-xs text-text-light">
           今月は <span className="font-bold text-text-dark">{monthlyStudyDays}日</span> 学習しました
         </p>
-        {isLoadingHeatmap ? <p className="mt-2 text-center text-[11px] text-text-light">ヒートマップを更新中...</p> : null}
+        {isLoadingHeatmap ? <div className="mt-2 flex justify-center"><Spinner size="sm" /></div> : null}
         {error ? <p className="mt-2 text-center text-[11px] text-rose-600">{error}</p> : null}
       </section>
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from './contexts/AuthContext'
 import { LearningProvider } from './contexts/LearningContext'
 import { AchievementProvider } from './contexts/AchievementContext'
 import { ConfigErrorView } from './components/ConfigErrorView'
+import { PageSpinner } from './components/Spinner'
 import { supabaseConfigError } from './lib/supabaseClient'
 import './styles/globals.css'
 
@@ -19,11 +20,7 @@ const StepPage = lazy(() => import('./pages/StepPage').then((m) => ({ default: m
 
 // ページ遷移中のフォールバック UI
 function PageLoading() {
-  return (
-    <div className="flex min-h-screen items-center justify-center" aria-live="polite" aria-label="ページを読み込み中">
-      <div className="text-gray-500">読み込み中...</div>
-    </div>
-  )
+  return <PageSpinner />
 }
 
 const router = createBrowserRouter([

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -8,6 +8,7 @@ import { AppHeader } from '../features/dashboard/components/AppHeader'
 import { supabaseConfigError } from '../lib/supabaseClient'
 import { BADGE_DEFINITIONS } from '../services/achievementService'
 import { getPointHistory, getProfile, upsertDisplayName, type PointHistoryRecord } from '../services/profileService'
+import { Spinner } from '../components/Spinner'
 import { formatDateTime, formatStudyDate } from '../shared/utils/dateTime'
 import { getDisplayName } from '../shared/utils/getDisplayName'
 
@@ -207,7 +208,7 @@ export function ProfilePage() {
 
         <section className="rounded-2xl border border-slate-100 bg-white p-6 shadow-sm">
           <h2 className="mb-4 text-lg font-bold text-text-dark">ポイント履歴</h2>
-          {isLoading ? <p className="text-sm text-text-light">履歴を読み込み中...</p> : null}
+          {isLoading ? <Spinner size="sm" label="履歴を読み込み中..." /> : null}
           {!isLoading && pointHistory.length === 0 ? <p className="text-sm text-text-light">ポイント履歴はまだありません。</p> : null}
           {pointHistory.length > 0 ? (
             <ul className="divide-y divide-slate-100">

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -12,6 +12,7 @@ import { TestMode } from '../features/learning/TestMode'
 import { useChallengeSubmission } from '../features/learning/hooks/useChallengeSubmission'
 import { useRecentChallengeSubmissions } from '../features/learning/hooks/useRecentChallengeSubmissions'
 import { useLearningStep } from '../features/learning/hooks/useLearningStep'
+import { PageSpinner } from '../components/Spinner'
 import type { LearningMode } from '../content/fundamentals/steps'
 import { getDisplayName } from '../shared/utils/getDisplayName'
 
@@ -77,11 +78,7 @@ export function StepPage() {
   }
 
   if (isLoadingStats) {
-    return (
-      <div className="flex min-h-screen items-center justify-center bg-slate-50">
-        <p className="font-medium text-slate-500">読み込み中...</p>
-      </div>
-    )
+    return <PageSpinner />
   }
 
   if (!step) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "@supabase/supabase-js": "^2.57.4",
+        "lucide-react": "^0.577.0",
         "prismjs": "^1.30.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -6240,6 +6241,15 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -6513,7 +6523,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6693,6 +6702,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },


### PR DESCRIPTION
## Summary
- `lucide-react` パッケージを導入（M1以降のアイコン置換基盤）
- `Spinner` / `PageSpinner` 共通コンポーネントを作成（sm/md/lg サイズ対応、ブランドカラー）
- 全5箇所のテキストのみローディング表示を Spinner に置換
- Spinner のユニットテスト9件を追加

## 変更内容
| ファイル | 変更 |
|---------|------|
| `components/Spinner.tsx` | 新規作成 |
| `components/__tests__/Spinner.test.tsx` | 新規作成（9テスト） |
| `main.tsx` | PageLoading → PageSpinner |
| `StepPage.tsx` | テキスト表示 → PageSpinner |
| `ProtectedRoute.tsx` | テキスト表示 → PageSpinner |
| `DashboardSidebar.tsx` | テキスト表示 → Spinner(sm) |
| `ProfilePage.tsx` | テキスト表示 → Spinner(sm) |

## 検証結果
- typecheck: ✅ 通過
- lint: ✅ 通過
- test: ✅ 191件全通過（+9件追加）
- build: ✅ 通過

## Issue要否
不要: roadmap08 M1-1 タスクとして管理済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)