### PR TITLE
feat: Button共通コンポーネントを作成

### DIFF
--- a/apps/web/src/components/Button.tsx
+++ b/apps/web/src/components/Button.tsx
@@ -1,0 +1,47 @@
+import type { ButtonHTMLAttributes, ReactNode } from 'react'
+
+const VARIANT_STYLES = {
+  primary:
+    'bg-primary-mint text-white hover:bg-primary-dark active:bg-emerald-700 shadow-sm',
+  secondary:
+    'bg-slate-100 text-slate-700 hover:bg-slate-200 hover:text-slate-900 border border-slate-300',
+  danger:
+    'bg-rose-600 text-white hover:bg-rose-700 active:bg-rose-800 shadow-sm',
+} as const
+
+const SIZE_STYLES = {
+  sm: 'px-3 py-1.5 text-xs',
+  md: 'px-4 py-2 text-sm',
+  lg: 'px-6 py-2.5 text-sm',
+} as const
+
+const BASE_STYLES =
+  'inline-flex items-center justify-center rounded-md font-semibold transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-primary-mint/30'
+
+const DISABLED_STYLES =
+  'disabled:bg-slate-200 disabled:text-slate-400 disabled:border-slate-200 disabled:shadow-none disabled:cursor-not-allowed disabled:hover:bg-slate-200'
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: keyof typeof VARIANT_STYLES
+  size?: keyof typeof SIZE_STYLES
+  fullWidth?: boolean
+  children: ReactNode
+}
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  fullWidth = false,
+  className = '',
+  children,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      className={`${BASE_STYLES} ${VARIANT_STYLES[variant]} ${SIZE_STYLES[size]} ${DISABLED_STYLES} ${fullWidth ? 'w-full' : ''} ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+}

--- a/apps/web/src/components/__tests__/Button.test.tsx
+++ b/apps/web/src/components/__tests__/Button.test.tsx
@@ -1,0 +1,90 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Button } from '../Button'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('Button', () => {
+  it('children をレンダリングする', () => {
+    render(<Button>テスト</Button>)
+    expect(screen.getByRole('button', { name: 'テスト' })).toBeTruthy()
+  })
+
+  it('デフォルトで primary バリアントが適用される', () => {
+    render(<Button>Primary</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn.className).toContain('bg-primary-mint')
+  })
+
+  it('secondary バリアントが適用される', () => {
+    render(<Button variant="secondary">Secondary</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn.className).toContain('bg-slate-100')
+  })
+
+  it('danger バリアントが適用される', () => {
+    render(<Button variant="danger">Danger</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn.className).toContain('bg-rose-600')
+  })
+
+  it('sm サイズが適用される', () => {
+    render(<Button size="sm">Small</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn.className).toContain('px-3')
+    expect(btn.className).toContain('text-xs')
+  })
+
+  it('lg サイズが適用される', () => {
+    render(<Button size="lg">Large</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn.className).toContain('px-6')
+  })
+
+  it('fullWidth で w-full が適用される', () => {
+    render(<Button fullWidth>Full</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn.className).toContain('w-full')
+  })
+
+  it('disabled 時に disabled スタイルが適用される', () => {
+    render(<Button disabled>Disabled</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn).toHaveProperty('disabled', true)
+    expect(btn.className).toContain('disabled:bg-slate-200')
+  })
+
+  it('onClick が呼ばれる', () => {
+    const handleClick = vi.fn()
+    render(<Button onClick={handleClick}>Click</Button>)
+    fireEvent.click(screen.getByRole('button'))
+    expect(handleClick).toHaveBeenCalledOnce()
+  })
+
+  it('disabled 時に onClick が呼ばれない', () => {
+    const handleClick = vi.fn()
+    render(<Button disabled onClick={handleClick}>Click</Button>)
+    fireEvent.click(screen.getByRole('button'))
+    expect(handleClick).not.toHaveBeenCalled()
+  })
+
+  it('追加の className を渡せる', () => {
+    render(<Button className="mt-4">Extra</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn.className).toContain('mt-4')
+  })
+
+  it('type 属性を渡せる', () => {
+    render(<Button type="submit">Submit</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn.getAttribute('type')).toBe('submit')
+  })
+
+  it('フォーカスリングにブランドカラーが使われる', () => {
+    render(<Button>Focus</Button>)
+    const btn = screen.getByRole('button')
+    expect(btn.className).toContain('focus:ring-primary-mint')
+  })
+})


### PR DESCRIPTION
## Summary
- `Button` 共通コンポーネントを作成（variant / size / disabled / fullWidth 対応）
- M3 での既存ボタン置換の基盤として準備
- このタスクではコンポーネント作成のみ、既存ボタンの置換は M3-2 で実施

## 設計判断
| 項目 | 選択 | 理由 |
|------|------|------|
| disabled スタイル | `bg-slate-200 text-slate-400` | `opacity-60` よりも「押せない」ことが視覚的に明確 |
| フォーカスリング | `focus:ring-primary-mint/30` | ブランドカラーで統一（UIレビュー指摘事項） |
| transition | `transition-all duration-200` | 一貫したインタラクションフィードバック |

## 検証結果
- typecheck: ✅ 通過
- lint: ✅ 通過
- test: ✅ 204件全通過（+13件追加）
- build: ✅ 通過

## Issue要否
不要: roadmap08 M1-2 タスクとして管理済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)