### PR TITLE
feat: ErrorBanner共通コンポーネントを作成

### DIFF
--- a/apps/web/src/components/ErrorBanner.tsx
+++ b/apps/web/src/components/ErrorBanner.tsx
@@ -1,0 +1,38 @@
+import { X } from 'lucide-react'
+
+const VARIANT_STYLES = {
+  error: 'border-rose-200 bg-rose-50 text-rose-700',
+  success: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  warning: 'border-amber-200 bg-amber-50 text-amber-700',
+  info: 'border-indigo-200 bg-indigo-50 text-indigo-700',
+} as const
+
+interface ErrorBannerProps {
+  variant?: keyof typeof VARIANT_STYLES
+  children: React.ReactNode
+  onDismiss?: () => void
+  className?: string
+}
+
+export function ErrorBanner({ variant = 'error', children, onDismiss, className = '' }: ErrorBannerProps) {
+  return (
+    <div
+      className={`rounded-lg border px-3 py-2 text-sm ${VARIANT_STYLES[variant]} ${className}`}
+      role={variant === 'error' ? 'alert' : 'status'}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex-1">{children}</div>
+        {onDismiss ? (
+          <button
+            type="button"
+            className="shrink-0 rounded p-0.5 opacity-60 transition hover:opacity-100"
+            onClick={onDismiss}
+            aria-label="閉じる"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/__tests__/ErrorBanner.test.tsx
+++ b/apps/web/src/components/__tests__/ErrorBanner.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ErrorBanner } from '../ErrorBanner'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('ErrorBanner', () => {
+  it('children をレンダリングする', () => {
+    render(<ErrorBanner>エラーが発生しました</ErrorBanner>)
+    expect(screen.getByText('エラーが発生しました')).toBeTruthy()
+  })
+
+  it('デフォルトで error バリアント（role="alert"）が適用される', () => {
+    render(<ErrorBanner>エラー</ErrorBanner>)
+    expect(screen.getByRole('alert')).toBeTruthy()
+    expect(screen.getByRole('alert').className).toContain('border-rose-200')
+  })
+
+  it('success バリアントが適用される（role="status"）', () => {
+    render(<ErrorBanner variant="success">成功</ErrorBanner>)
+    expect(screen.getByRole('status')).toBeTruthy()
+    expect(screen.getByRole('status').className).toContain('border-emerald-200')
+  })
+
+  it('warning バリアントが適用される', () => {
+    render(<ErrorBanner variant="warning">警告</ErrorBanner>)
+    expect(screen.getByRole('status').className).toContain('border-amber-200')
+  })
+
+  it('info バリアントが適用される', () => {
+    render(<ErrorBanner variant="info">情報</ErrorBanner>)
+    expect(screen.getByRole('status').className).toContain('border-indigo-200')
+  })
+
+  it('onDismiss が渡されると閉じるボタンが表示される', () => {
+    const handleDismiss = vi.fn()
+    render(<ErrorBanner onDismiss={handleDismiss}>エラー</ErrorBanner>)
+    const closeButton = screen.getByRole('button', { name: '閉じる' })
+    expect(closeButton).toBeTruthy()
+    fireEvent.click(closeButton)
+    expect(handleDismiss).toHaveBeenCalledOnce()
+  })
+
+  it('onDismiss がない場合は閉じるボタンが表示されない', () => {
+    render(<ErrorBanner>エラー</ErrorBanner>)
+    expect(screen.queryByRole('button', { name: '閉じる' })).toBeNull()
+  })
+
+  it('className を追加できる', () => {
+    render(<ErrorBanner className="mb-4">エラー</ErrorBanner>)
+    expect(screen.getByRole('alert').className).toContain('mb-4')
+  })
+})

--- a/apps/web/src/features/learning/ChallengeMode.tsx
+++ b/apps/web/src/features/learning/ChallengeMode.tsx
@@ -1,4 +1,5 @@
 import { Suspense, lazy, useEffect, useMemo, useState } from 'react'
+import { ErrorBanner } from '../../components/ErrorBanner'
 import type { ChallengePattern, ChallengeTask } from '../../content/fundamentals/steps'
 
 const MonacoEditor = lazy(() => import('@monaco-editor/react'))
@@ -113,7 +114,7 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
         )}
       </div>
 
-      {submissionError ? <p className="text-sm text-rose-700">{submissionError}</p> : null}
+      {submissionError ? <ErrorBanner>{submissionError}</ErrorBanner> : null}
 
       {checked && !isPassed ? (
         <div className="rounded-lg border border-rose-300 bg-rose-50 p-4">

--- a/apps/web/src/features/learning/ChallengeSubmissionHistory.tsx
+++ b/apps/web/src/features/learning/ChallengeSubmissionHistory.tsx
@@ -1,4 +1,5 @@
-﻿import type { ChallengeSubmission } from '@/services/challengeSubmissionService'
+﻿import { ErrorBanner } from '@/components/ErrorBanner'
+import type { ChallengeSubmission } from '@/services/challengeSubmissionService'
 import { formatDateTime } from '@/shared/utils/dateTime'
 
 interface ChallengeSubmissionHistoryProps {
@@ -31,7 +32,7 @@ export function ChallengeSubmissionHistory({
       </div>
 
       {isLoading ? <p className="mt-3 text-sm text-slate-500">提出履歴を読み込み中...</p> : null}
-      {error ? <p className="mt-3 text-sm text-rose-700">{error}</p> : null}
+      {error ? <ErrorBanner className="mt-3">{error}</ErrorBanner> : null}
       {!isLoading && !error && submissions.length === 0 ? (
         <p className="mt-3 text-sm text-slate-500">提出履歴はまだありません。</p>
       ) : null}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { ConfigErrorView } from '../components/ConfigErrorView'
+import { ErrorBanner } from '../components/ErrorBanner'
 import { getFirstImplementedStep, IMPLEMENTED_STEP_COUNT } from '../content/courseData'
 import { useAuth } from '../contexts/AuthContext'
 import { useLearningContext } from '../contexts/LearningContext'
@@ -89,7 +90,7 @@ export function DashboardPage() {
 
       <main className="mx-auto w-full max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
         {supabaseConfigError ? <ConfigErrorView message={supabaseConfigError} /> : null}
-        {error ? <p className="mb-4 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{error}</p> : null}
+        {error ? <ErrorBanner className="mb-4">{error}</ErrorBanner> : null}
 
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
           <section className="space-y-6 lg:col-span-8">

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useMemo, useState } from 'react'
 import { Link, Navigate, useLocation } from 'react-router-dom'
 import { ConfigErrorView } from '../components/ConfigErrorView'
+import { ErrorBanner } from '../components/ErrorBanner'
 import { useAuth } from '../contexts/AuthContext'
 import { supabaseConfigError } from '../lib/supabaseClient'
 
@@ -72,7 +73,7 @@ export function LoginPage() {
           />
         </label>
 
-        {error ? <p className="text-sm text-red-700" role="alert">{error}</p> : null}
+        {error ? <ErrorBanner>{error}</ErrorBanner> : null}
 
         <button
           className="w-full rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-60"

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { ConfigErrorView } from '../components/ConfigErrorView'
+import { ErrorBanner } from '../components/ErrorBanner'
 import { useAchievementContext } from '../contexts/AchievementContext'
 import { useAuth } from '../contexts/AuthContext'
 import { useLearningContext } from '../contexts/LearningContext'
@@ -122,8 +123,8 @@ export function ProfilePage() {
 
       <main className="mx-auto w-full max-w-7xl space-y-6 px-4 py-8 sm:px-6 lg:px-8">
         {supabaseConfigError ? <ConfigErrorView message={supabaseConfigError} /> : null}
-        {error ? <p className="rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">{error}</p> : null}
-        {notice ? <p className="rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">{notice}</p> : null}
+        {error ? <ErrorBanner>{error}</ErrorBanner> : null}
+        {notice ? <ErrorBanner variant="success">{notice}</ErrorBanner> : null}
 
         <section className="rounded-2xl border border-slate-100 bg-white p-6 shadow-sm">
           <div className="flex flex-wrap items-start justify-between gap-4">

--- a/apps/web/src/pages/SignUpPage.tsx
+++ b/apps/web/src/pages/SignUpPage.tsx
@@ -1,6 +1,7 @@
 import { FormEvent, useMemo, useState } from 'react'
 import { Link, Navigate, useNavigate } from 'react-router-dom'
 import { ConfigErrorView } from '../components/ConfigErrorView'
+import { ErrorBanner } from '../components/ErrorBanner'
 import { useAuth } from '../contexts/AuthContext'
 import { supabaseConfigError } from '../lib/supabaseClient'
 
@@ -97,7 +98,7 @@ export function SignUpPage() {
           <span className="mt-1 block text-xs text-slate-500">{MIN_PASSWORD_LENGTH}文字以上で入力してください。</span>
         </label>
 
-        {error ? <p className="text-sm text-red-700" role="alert">{error}</p> : null}
+        {error ? <ErrorBanner>{error}</ErrorBanner> : null}
 
         <button
           className="w-full rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-60"

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react'
 import { Link, Navigate, useNavigate, useParams } from 'react-router-dom'
+import { ErrorBanner } from '../components/ErrorBanner'
 import { LearningSidebar } from '../components/LearningSidebar'
 import { useAuth } from '../contexts/AuthContext'
 import { useLearningContext } from '../contexts/LearningContext'
@@ -129,7 +130,7 @@ export function StepPage() {
               })}
             </div>
 
-            {syncMessage ? <p className="mt-4 text-sm text-rose-700">{syncMessage}</p> : null}
+            {syncMessage ? <ErrorBanner className="mt-4">{syncMessage}</ErrorBanner> : null}
 
             {activeMode === 'read' ? (
               <ReadMode


### PR DESCRIPTION
## Summary
- 4バリアント(error/success/warning/info)対応のErrorBannerコンポーネントを新規作成
- lucide-reactのXアイコンによる閉じるボタン(onDismiss)対応
- 7ファイルのインラインエラー/成功表示をErrorBannerに置換
- テスト8件追加（全212テストPASS）

## 変更ファイル
- `ErrorBanner.tsx` — 新規コンポーネント
- `ErrorBanner.test.tsx` — テスト8件
- `DashboardPage.tsx`, `ProfilePage.tsx`, `LoginPage.tsx`, `SignUpPage.tsx`, `StepPage.tsx`, `ChallengeMode.tsx`, `ChallengeSubmissionHistory.tsx` — ErrorBanner適用

## Test plan
- [x] typecheck PASS
- [x] lint PASS
- [x] 全212テストPASS
- [x] build成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)