### PR TITLE
fix: ナビゲーション情報の整理

### DIFF
--- a/apps/web/src/features/dashboard/components/AppHeader.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeader.tsx
@@ -80,7 +80,6 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
             >
               プロフィール
             </Link>
-            <span className="cursor-not-allowed pb-1 text-slate-400" aria-disabled="true">コミュニティ (準備中)</span>
           </nav>
         </div>
 

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -86,8 +86,7 @@ export function StepPage() {
     return (
       <main className="mx-auto flex min-h-screen max-w-4xl flex-col gap-6 px-6 py-16">
         <h1 className="text-3xl font-bold">指定したステップが見つかりません</h1>
-        <p className="text-slate-600">stepId: {stepId}</p>
-        <Link className="text-sm font-medium text-blue-700 underline" to="/step/usestate-basic">
+        <Link className="text-sm font-medium text-primary-dark underline" to="/step/usestate-basic">
           最初のステップへ戻る
         </Link>
       </main>
@@ -109,8 +108,6 @@ export function StepPage() {
           <LearningSidebar courseTitle={sidebarTitle} currentStepId={stepId} steps={sidebarSteps} />
 
           <div className="flex-1 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-            <p className="text-xs font-medium uppercase tracking-wide text-slate-500">stepId: {step.id}</p>
-
             <div className="mt-4 flex flex-wrap gap-2 border-b border-slate-200 pb-4">
               {modeButtons.map((mode) => {
                 const isActive = activeMode === mode.id
@@ -182,7 +179,7 @@ export function StepPage() {
         </section>
 
         <div className="flex gap-4 text-sm">
-          <Link className="font-medium text-blue-700 underline" to="/">
+          <Link className="font-medium text-primary-dark underline" to="/">
             ダッシュボードへ戻る
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- AppHeaderの「コミュニティ (準備中)」を非表示化（MVP不要）
- StepPageのstepIdデバッグ表示を削除
- StepPageの2箇所のtext-blue-700リンクをtext-primary-darkに統一

## Test plan
- [x] lint PASS
- [x] 全220テストPASS
- [x] build成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)