### PR TITLE
refactor: フォーカスリングとフォームスタイルの統一

### DIFF
--- a/apps/web/src/features/learning/PracticeMode.tsx
+++ b/apps/web/src/features/learning/PracticeMode.tsx
@@ -70,7 +70,7 @@ export function PracticeMode({ stepId, questions, onComplete }: PracticeModeProp
               Q{index + 1}. {question.prompt}
             </p>
             <input
-              className={`w-full rounded-md border px-3 py-2 text-sm ${isJudged
+              className={`w-full rounded-md border px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary-mint/30 focus:border-primary-mint ${isJudged
                 ? isCorrect
                   ? 'border-emerald-500 bg-emerald-50/50'
                   : 'border-rose-500 bg-rose-50/50'

--- a/apps/web/src/features/learning/TestMode.tsx
+++ b/apps/web/src/features/learning/TestMode.tsx
@@ -65,7 +65,7 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
                   ? isPassed
                     ? 'ring-emerald-500 focus:ring-emerald-400'
                     : 'ring-rose-500 focus:ring-rose-400'
-                  : 'ring-slate-500 focus:ring-blue-400'
+                  : 'ring-slate-500 focus:ring-primary-mint'
                   }`}
                 placeholder="例: setCount(count + 1)"
                 aria-label="コードの空欄を入力"

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -52,7 +52,7 @@ export function LoginPage() {
         <label className="block">
           <span className="mb-1 block text-sm font-medium text-slate-700">メールアドレス</span>
           <input
-            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm outline-none ring-blue-500 focus:ring-2"
+            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary-mint/30 focus:border-primary-mint"
             type="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
@@ -64,7 +64,7 @@ export function LoginPage() {
         <label className="block">
           <span className="mb-1 block text-sm font-medium text-slate-700">パスワード</span>
           <input
-            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm outline-none ring-blue-500 focus:ring-2"
+            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary-mint/30 focus:border-primary-mint"
             type="password"
             value={password}
             onChange={(event) => setPassword(event.target.value)}

--- a/apps/web/src/pages/SignUpPage.tsx
+++ b/apps/web/src/pages/SignUpPage.tsx
@@ -74,7 +74,7 @@ export function SignUpPage() {
           <span className="mb-1 block text-sm font-medium text-slate-700">メールアドレス</span>
           <input
             aria-label="メールアドレス"
-            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm outline-none ring-blue-500 focus:ring-2"
+            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary-mint/30 focus:border-primary-mint"
             type="email"
             value={email}
             onChange={(event) => setEmail(event.target.value)}
@@ -87,7 +87,7 @@ export function SignUpPage() {
           <span className="mb-1 block text-sm font-medium text-slate-700">パスワード</span>
           <input
             aria-label="パスワード"
-            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm outline-none ring-blue-500 focus:ring-2"
+            className="w-full rounded-md border border-slate-300 px-3 py-2 text-sm outline-none focus:ring-2 focus:ring-primary-mint/30 focus:border-primary-mint"
             type="password"
             value={password}
             onChange={(event) => setPassword(event.target.value)}


### PR DESCRIPTION
## Summary
- LoginPage/SignUpPageのinput: ring-blue-500 → focus:ring-primary-mint/30 + focus:border-primary-mint
- TestModeのinline input: focus:ring-blue-400 → focus:ring-primary-mint
- PracticeModeのinput: フォーカスリングなし → focus:ring-primary-mint/30 + focus:border-primary-mint追加
- ProfilePageは既にfocus:ring-primary-mint/20で正しいことを確認（変更なし）

## Test plan
- [x] lint PASS
- [x] 全220テストPASS
- [x] build成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)