### PR TITLE
refactor: ボタンスタイルの統一と既存ボタン置換

### DIFF
--- a/apps/web/src/features/dashboard/components/LearningOverviewCard.tsx
+++ b/apps/web/src/features/dashboard/components/LearningOverviewCard.tsx
@@ -82,7 +82,7 @@ export function LearningOverviewCard({ completedCount }: LearningOverviewCardPro
         </div>
         {inProgressStep ? (
           <Link
-            className="rounded-xl bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-800"
+            className="rounded-xl bg-primary-mint px-4 py-2 text-sm font-semibold text-white shadow-sm transition-all duration-200 hover:bg-primary-dark active:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-primary-mint/30"
             to={`/step/${inProgressStep.id}`}
           >
             続きから再開

--- a/apps/web/src/features/learning/ChallengeMode.tsx
+++ b/apps/web/src/features/learning/ChallengeMode.tsx
@@ -1,4 +1,5 @@
 import { Suspense, lazy, useEffect, useMemo, useState } from 'react'
+import { Button } from '../../components/Button'
 import { ErrorBanner } from '../../components/ErrorBanner'
 import type { ChallengePattern, ChallengeTask } from '../../content/fundamentals/steps'
 
@@ -95,13 +96,9 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
       </div>
 
       <div className="flex flex-col items-start gap-4 pt-4 sm:flex-row sm:items-center">
-        <button
-          className="rounded-md bg-primary-mint px-6 py-2.5 text-sm font-bold text-white shadow-sm transition-colors hover:bg-primary-dark active:bg-emerald-700"
-          type="button"
-          onClick={() => void handleCheck()}
-        >
+        <Button size="lg" onClick={() => void handleCheck()}>
           判定する
-        </button>
+        </Button>
 
         {checked && (
           <p

--- a/apps/web/src/features/learning/PracticeMode.tsx
+++ b/apps/web/src/features/learning/PracticeMode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { Button } from '../../components/Button'
 import type { PracticeQuestion } from '../../content/fundamentals/steps'
 import { addToReviewList, removeFromReviewList } from '../../services/reviewListService'
 
@@ -111,13 +112,9 @@ export function PracticeMode({ stepId, questions, onComplete }: PracticeModeProp
       })}
 
       <div className="flex flex-col items-start gap-4 pt-4 sm:flex-row sm:items-center">
-        <button
-          className="rounded-md bg-primary-mint px-6 py-2.5 text-sm font-bold text-white shadow-sm transition-colors hover:bg-primary-dark active:bg-emerald-700"
-          type="button"
-          onClick={handleJudge}
-        >
+        <Button size="lg" onClick={handleJudge}>
           判定する
-        </button>
+        </Button>
 
         {isJudged && (
           <p

--- a/apps/web/src/features/learning/ReadMode.tsx
+++ b/apps/web/src/features/learning/ReadMode.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { Button } from '../../components/Button'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import Prism from 'prismjs'
@@ -25,15 +26,9 @@ export function ReadMode({ markdown, onComplete, isCompleted }: ReadModeProps) {
     <section className="mt-4 space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">Read</h2>
-        <button
-          className={`rounded-md px-4 py-2 text-sm font-bold text-white shadow-sm transition ${isCompleted ? 'cursor-not-allowed bg-slate-300' : 'bg-primary-mint hover:bg-primary-dark'
-            }`}
-          type="button"
-          onClick={onComplete}
-          disabled={isCompleted}
-        >
+        <Button onClick={onComplete} disabled={isCompleted}>
           {isCompleted ? 'Read完了済み' : 'Readを完了'}
-        </button>
+        </Button>
       </div>
 
       <article className="prose prose-slate prose-lg max-w-none rounded-2xl border border-slate-200 bg-white p-6 leading-relaxed shadow-sm md:prose-xl">

--- a/apps/web/src/features/learning/TestMode.tsx
+++ b/apps/web/src/features/learning/TestMode.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useEffect, useMemo, useState } from 'react'
+import { Button } from '../../components/Button'
 import type { TestTask } from '../../content/fundamentals/steps'
 import { addToReviewList, removeFromReviewList } from '../../services/reviewListService'
 import { previewByStepId } from './testModePreview'
@@ -78,13 +79,9 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
       </pre>
 
       <div className="flex flex-col items-start gap-4 pt-4 sm:flex-row sm:items-center">
-        <button
-          className="rounded-md bg-primary-mint px-6 py-2.5 text-sm font-bold text-white shadow-sm transition-colors hover:bg-primary-dark active:bg-emerald-700"
-          type="button"
-          onClick={handleJudge}
-        >
+        <Button size="lg" onClick={handleJudge}>
           判定する
-        </button>
+        </Button>
 
         {isJudged && (
           <p

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useMemo, useState } from 'react'
 import { Link, Navigate, useLocation } from 'react-router-dom'
+import { Button } from '../components/Button'
 import { ConfigErrorView } from '../components/ConfigErrorView'
 import { ErrorBanner } from '../components/ErrorBanner'
 import { useAuth } from '../contexts/AuthContext'
@@ -75,13 +76,9 @@ export function LoginPage() {
 
         {error ? <ErrorBanner>{error}</ErrorBanner> : null}
 
-        <button
-          className="w-full rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-60"
-          type="submit"
-          disabled={isSubmitting || Boolean(supabaseConfigError)}
-        >
+        <Button type="submit" fullWidth disabled={isSubmitting || Boolean(supabaseConfigError)}>
           {isSubmitting ? 'ログイン中...' : 'ログイン'}
-        </button>
+        </Button>
 
         <p className="text-center text-sm text-slate-600">
           はじめて利用しますか？{' '}

--- a/apps/web/src/pages/NotFoundPage.tsx
+++ b/apps/web/src/pages/NotFoundPage.tsx
@@ -17,7 +17,7 @@ export function NotFoundPage() {
 
       <div className="flex flex-wrap gap-3">
         <Link
-          className="inline-flex items-center justify-center rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white transition hover:bg-slate-700"
+          className="inline-flex items-center justify-center rounded-md bg-primary-mint px-4 py-2 text-sm font-semibold text-white shadow-sm transition-all duration-200 hover:bg-primary-dark active:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-primary-mint/30"
           to="/"
         >
           ダッシュボードへ戻る

--- a/apps/web/src/pages/SignUpPage.tsx
+++ b/apps/web/src/pages/SignUpPage.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useMemo, useState } from 'react'
 import { Link, Navigate, useNavigate } from 'react-router-dom'
+import { Button } from '../components/Button'
 import { ConfigErrorView } from '../components/ConfigErrorView'
 import { ErrorBanner } from '../components/ErrorBanner'
 import { useAuth } from '../contexts/AuthContext'
@@ -100,13 +101,9 @@ export function SignUpPage() {
 
         {error ? <ErrorBanner>{error}</ErrorBanner> : null}
 
-        <button
-          className="w-full rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-60"
-          type="submit"
-          disabled={isDisabled}
-        >
+        <Button type="submit" fullWidth disabled={isDisabled}>
           {isSubmitting ? '登録中...' : 'アカウントを作成'}
-        </button>
+        </Button>
 
         <p className="text-center text-sm text-slate-600">
           すでにアカウントをお持ちですか？{' '}


### PR DESCRIPTION
## Summary
- LoginPage/SignUpPageのbg-slate-900ボタンをButtonコンポーネント(variant=primary)に置換
- PracticeMode/TestMode/ChallengeModeの「判定する」ボタンをButton(size=lg)に置換
- ReadModeの「Readを完了」ボタンをButton(disabled対応)に置換
- NotFoundPage/LearningOverviewCardのLinkボタンをprimary-mint系スタイルに統一
- 8ファイル変更、コード20行減

## Test plan
- [x] lint PASS
- [x] 全220テストPASS
- [x] build成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)