### PR TITLE
refactor: テキストカラーとCSS変数の整理

### DIFF
--- a/apps/web/src/features/learning/PracticeMode.tsx
+++ b/apps/web/src/features/learning/PracticeMode.tsx
@@ -106,7 +106,7 @@ export function PracticeMode({ stepId, questions, onComplete }: PracticeModeProp
             >
               ヒントを{hints[question.id] ? '隠す' : '表示'}
             </button>
-            {hints[question.id] ? <p className="text-sm text-blue-700">{question.hint}</p> : null}
+            {hints[question.id] ? <p className="text-sm text-primary-dark">{question.hint}</p> : null}
           </article>
         )
       })}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -4,19 +4,11 @@
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  --primary-mint: #2cc295;
-  --primary-dark: #1e9e78;
-  --secondary-bg: #f0fdf9;
-  --text-dark: #1f2937;
-  --text-light: #6b7280;
-}
-
 body {
   margin: 0;
   min-height: 100vh;
   font-family: 'Noto Sans JP', sans-serif;
-  color: var(--text-dark);
+  color: #1f2937;
   background-color: #f9fafb;
 }
 
@@ -35,12 +27,5 @@ body {
 @layer utilities {
   .font-display {
     font-family: 'Nunito', sans-serif;
-  }
-
-  .glass-card {
-    background: rgba(255, 255, 255, 0.95);
-    backdrop-filter: blur(10px);
-    border: 1px solid rgba(255, 255, 255, 0.5);
-    box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
   }
 }


### PR DESCRIPTION
## Summary
- PracticeModeのヒント表示: text-blue-700 → text-primary-dark
- globals.cssの:root CSS変数定義を削除（tailwind.config.jsに一元化済み）
- 未使用の.glass-cardユーティリティを削除
- main.tsxのtext-gray-500はM1でPageSpinnerに置換済みのため変更不要

## Test plan
- [x] lint PASS
- [x] 全220テストPASS
- [x] build成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)