### PR TITLE
feat: 絵文字をSVGアイコンに置換

### DIFF
--- a/apps/web/src/components/LearningSidebar.tsx
+++ b/apps/web/src/components/LearningSidebar.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { Lock } from 'lucide-react'
 import type { LearningStepContent } from '../content/fundamentals/steps'
 import { useLearningContext } from '../contexts/LearningContext'
 
@@ -22,7 +23,7 @@ export function LearningSidebar({ courseTitle, currentStepId, steps }: LearningS
           const content = (
             <>
               <p className="text-xs text-slate-500">
-                STEP {step.order} {isLocked ? '🔒' : ''}
+                STEP {step.order} {isLocked ? <Lock className="inline-block h-3 w-3" /> : ''}
               </p>
               <p className="font-medium">{step.title}</p>
             </>

--- a/apps/web/src/contexts/AchievementContext.tsx
+++ b/apps/web/src/contexts/AchievementContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react'
+import { Trophy } from 'lucide-react'
 import { BADGE_DEFINITIONS, checkAndUnlockAchievements, getUnlockedAchievements, type BadgeId } from '../services/achievementService'
 import { useAuth } from './AuthContext'
 
@@ -87,8 +88,8 @@ export function AchievementProvider({ children }: { children: ReactNode }) {
       {badgeDef ? (
         <div className="fixed bottom-5 right-5 z-50 animate-bounce rounded-xl border-2 border-amber-300 bg-amber-50 px-4 py-3 shadow-xl">
           <div className="flex items-center gap-3">
-            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-amber-200 text-xl shadow-inner">
-              🏆
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-amber-200 shadow-inner">
+              <Trophy className="h-5 w-5 text-amber-700" />
             </div>
             <div>
               <p className="text-xs font-bold text-amber-600">新しいバッジを獲得しました！</p>

--- a/apps/web/src/features/dashboard/components/AppHeader.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeader.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
-import { Menu, X } from 'lucide-react'
+import { Flame, Gem, Menu, X } from 'lucide-react'
 import { getFirstImplementedStep } from '@/content/courseData'
 import { useLearningContext } from '@/contexts/LearningContext'
 
@@ -85,10 +85,10 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
 
         <div className="flex items-center gap-3">
           <div className="hidden rounded-full border border-amber-300/30 bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-700 sm:block">
-            💎 {stats?.total_points ?? 0} Pt
+            <Gem className="inline-block h-3.5 w-3.5" /> {stats?.total_points ?? 0} Pt
           </div>
           <div className="hidden rounded-full border border-primary-mint/30 bg-secondary-bg px-3 py-1 text-xs font-semibold text-primary-dark sm:block">
-            🔥 {stats?.current_streak ?? 0}日連続
+            <Flame className="inline-block h-3.5 w-3.5" /> {stats?.current_streak ?? 0}日連続
           </div>
           <div className="hidden text-sm font-medium text-slate-600 sm:block">{displayName}</div>
           <button
@@ -144,10 +144,10 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
               <div className="text-sm font-medium text-slate-900">{displayName}</div>
               <div className="mt-1.5 flex items-center gap-2">
                 <span className="rounded-full border border-amber-300/30 bg-amber-50 px-2 py-0.5 text-xs font-semibold text-amber-700">
-                  💎 {stats?.total_points ?? 0} Pt
+                  <Gem className="inline-block h-3.5 w-3.5" /> {stats?.total_points ?? 0} Pt
                 </span>
                 <span className="rounded-full border border-primary-mint/30 bg-secondary-bg px-2 py-0.5 text-xs font-semibold text-primary-dark">
-                  🔥 {stats?.current_streak ?? 0}日連続
+                  <Flame className="inline-block h-3.5 w-3.5" /> {stats?.current_streak ?? 0}日連続
                 </span>
               </div>
             </div>

--- a/apps/web/src/features/dashboard/components/DashboardSidebar.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardSidebar.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { CheckCircle2, Flame, Lock, Monitor } from 'lucide-react'
 import { Spinner } from '@/components/Spinner'
 import { useAuth } from '@/contexts/AuthContext'
 import { useLearningContext } from '@/contexts/LearningContext'
@@ -110,11 +111,11 @@ export function DashboardSidebar() {
           <div>
             <p className="mb-2 text-xs font-bold uppercase tracking-wide text-text-light">獲得バッジ</p>
             <div className="flex items-center justify-between text-xl">
-              <span className="grid h-10 w-10 place-items-center rounded-full border border-yellow-200 bg-yellow-100">✅</span>
-              <span className="grid h-10 w-10 place-items-center rounded-full border border-orange-200 bg-orange-100">🔥</span>
-              <span className="grid h-10 w-10 place-items-center rounded-full border border-blue-200 bg-blue-100">💻</span>
-              <span className="grid h-10 w-10 place-items-center rounded-full border border-slate-300 bg-slate-100 text-slate-400">
-                🔒
+              <span className="grid h-10 w-10 place-items-center rounded-full border border-yellow-200 bg-yellow-100"><CheckCircle2 className="h-5 w-5 text-yellow-700" /></span>
+              <span className="grid h-10 w-10 place-items-center rounded-full border border-orange-200 bg-orange-100"><Flame className="h-5 w-5 text-orange-700" /></span>
+              <span className="grid h-10 w-10 place-items-center rounded-full border border-blue-200 bg-blue-100"><Monitor className="h-5 w-5 text-blue-700" /></span>
+              <span className="grid h-10 w-10 place-items-center rounded-full border border-slate-300 bg-slate-100">
+                <Lock className="h-5 w-5 text-slate-400" />
               </span>
             </div>
           </div>

--- a/apps/web/src/features/dashboard/components/LearningOverviewCard.tsx
+++ b/apps/web/src/features/dashboard/components/LearningOverviewCard.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { BookOpen, CheckCircle2, Lock, PenLine } from 'lucide-react'
 import { COURSES, TOTAL_STEP_COUNT, type CourseMeta, type StepMeta } from '@/content/courseData'
 
 const LEVEL_LABEL: Record<CourseMeta['level'], string> = {
@@ -36,13 +37,19 @@ function StepRow({ step, isInProgress, isDone, isLockedByProgress }: StepRowProp
       ? { label: '完了', cls: 'bg-emerald-100 text-emerald-700' }
       : { label: isUnimplemented ? '準備中' : 'ロック中', cls: 'bg-slate-200 text-slate-500' }
 
-  const icon = isLocked ? '🔒' : isDone ? '✅' : isInProgress ? '📖' : '📝'
+  const icon = isLocked
+    ? <Lock className="h-4 w-4 text-slate-400" />
+    : isDone
+      ? <CheckCircle2 className="h-4 w-4 text-emerald-600" />
+      : isInProgress
+        ? <BookOpen className="h-4 w-4 text-primary-mint" />
+        : <PenLine className="h-4 w-4 text-slate-500" />
 
   const inner = (
     <li className={`rounded-xl border p-4 ${borderBg} ${isLocked ? 'opacity-60' : ''}`}>
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-start gap-2">
-          <span className="mt-0.5 shrink-0 text-base">{icon}</span>
+          <span className="mt-0.5 shrink-0">{icon}</span>
           <div>
             <p className={`font-semibold ${isLocked ? 'text-text-light' : 'text-text-dark'}`}>
               Step {step.order}: {step.title}

--- a/apps/web/src/features/dashboard/components/WelcomeBanner.tsx
+++ b/apps/web/src/features/dashboard/components/WelcomeBanner.tsx
@@ -13,7 +13,9 @@ export function WelcomeBanner({ displayName }: WelcomeBannerProps) {
             Reactマスターへの道を進めましょう。今日の1ステップが次の実装力につながります。
           </p>
         </div>
-        <div className="grid h-20 w-20 place-items-center rounded-full border border-white/30 bg-white/20 text-4xl">🤖</div>
+        <div className="grid h-20 w-20 place-items-center rounded-full border border-white/30 bg-white/20">
+          <img src="/coden_logo.png" alt="Coden" className="h-12 w-12 object-contain" />
+        </div>
       </div>
       <div className="absolute -right-10 -top-10 h-32 w-32 rounded-full bg-white/10 blur-2xl" />
       <div className="absolute -bottom-10 -left-10 h-32 w-32 rounded-full bg-white/10 blur-2xl" />

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
+import { Lock, Trophy } from 'lucide-react'
 import { Link, useNavigate } from 'react-router-dom'
 import { ConfigErrorView } from '../components/ConfigErrorView'
 import { ErrorBanner } from '../components/ErrorBanner'
@@ -198,7 +199,7 @@ export function ProfilePage() {
                 >
                   <div className="flex items-start justify-between gap-2">
                     <h3 className={`text-sm font-bold ${unlocked ? 'text-amber-900' : 'text-slate-600'}`}>{badge.name}</h3>
-                    <span className="text-lg">{unlocked ? '🏆' : '🔒'}</span>
+                    <span className="text-lg">{unlocked ? <Trophy className="h-5 w-5 text-amber-600" /> : <Lock className="h-5 w-5 text-slate-400" />}</span>
                   </div>
                   <p className={`mt-1 text-xs ${unlocked ? 'text-amber-700' : 'text-slate-500'}`}>{badge.description}</p>
                 </article>


### PR DESCRIPTION
## Summary
- 装飾的な絵文字（🔒✅📖📝🔥💎🏆💻🤖）をlucide-reactのSVGアイコンに統一置換
- WelcomeBannerの🤖はcoden_logo.png画像に変更
- 学習モード判定絵文字（🎉❌⚠️）はカラー多様性の補助として維持
- 7ファイル変更、全220テスト通過

## 対象ファイル
- AppHeader.tsx: 💎→Gem, 🔥→Flame
- DashboardSidebar.tsx: ✅→CheckCircle2, 🔥→Flame, 💻→Monitor, 🔒→Lock
- LearningOverviewCard.tsx: 🔒→Lock, ✅→CheckCircle2, 📖→BookOpen, 📝→PenLine
- LearningSidebar.tsx: 🔒→Lock
- WelcomeBanner.tsx: 🤖→coden_logo.png
- ProfilePage.tsx: 🏆→Trophy, 🔒→Lock
- AchievementContext.tsx: 🏆→Trophy

## Test plan
- [x] lint / test (220) / build 全パス
- [ ] ダッシュボード・サイドバー・プロフィールでアイコン表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)