### PR TITLE
feat: 認証ページビジュアル強化と装飾円削除

### DIFF
--- a/apps/web/src/features/dashboard/components/DashboardSidebar.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardSidebar.tsx
@@ -77,7 +77,7 @@ export function DashboardSidebar() {
 
   return (
     <aside className="space-y-5">
-      <section className="relative overflow-hidden rounded-2xl border border-emerald-100 bg-white shadow-sm">
+      <section className="rounded-2xl border border-emerald-100 bg-white shadow-sm">
         <div className="bg-mint-gradient px-5 py-4">
           <h3 className="font-bold text-white">学習ステータス</h3>
         </div>
@@ -120,7 +120,6 @@ export function DashboardSidebar() {
             </div>
           </div>
         </div>
-        <div className="pointer-events-none absolute -bottom-6 -right-6 h-20 w-20 rounded-full bg-yellow-300/20 blur-2xl" />
       </section>
 
       <section className="rounded-2xl border border-slate-100 bg-white p-5 shadow-sm">

--- a/apps/web/src/features/dashboard/components/WelcomeBanner.tsx
+++ b/apps/web/src/features/dashboard/components/WelcomeBanner.tsx
@@ -4,8 +4,8 @@ interface WelcomeBannerProps {
 
 export function WelcomeBanner({ displayName }: WelcomeBannerProps) {
   return (
-    <section className="relative overflow-hidden rounded-3xl bg-mint-gradient px-6 py-8 text-white shadow-glass sm:px-8">
-      <div className="relative z-10 flex flex-wrap items-center justify-between gap-4">
+    <section className="rounded-3xl bg-mint-gradient px-6 py-8 text-white shadow-glass sm:px-8">
+      <div className="flex flex-wrap items-center justify-between gap-4">
         <div className="space-y-2">
           <p className="text-sm font-semibold uppercase tracking-wide text-emerald-50">Welcome back</p>
           <h1 className="font-display text-3xl font-bold leading-tight">こんにちは、{displayName}さん</h1>
@@ -17,8 +17,6 @@ export function WelcomeBanner({ displayName }: WelcomeBannerProps) {
           <img src="/coden_logo.png" alt="Coden" className="h-12 w-12 object-contain" />
         </div>
       </div>
-      <div className="absolute -right-10 -top-10 h-32 w-32 rounded-full bg-white/10 blur-2xl" />
-      <div className="absolute -bottom-10 -left-10 h-32 w-32 rounded-full bg-white/10 blur-2xl" />
     </section>
   )
 }

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -38,7 +38,7 @@ export function LoginPage() {
   }
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 px-6 py-16">
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50 px-6 py-16">
       <header className="space-y-2">
         <div className="flex items-center gap-3">
           <img src="/coden_logo.png" alt="Coden Logo" className="h-12 w-12 object-contain" />
@@ -49,7 +49,7 @@ export function LoginPage() {
 
       {supabaseConfigError ? <ConfigErrorView message={supabaseConfigError} /> : null}
 
-      <form className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm" onSubmit={handleSubmit}>
+      <form className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm" onSubmit={handleSubmit}>
         <label className="block">
           <span className="mb-1 block text-sm font-medium text-slate-700">メールアドレス</span>
           <input

--- a/apps/web/src/pages/SignUpPage.tsx
+++ b/apps/web/src/pages/SignUpPage.tsx
@@ -59,7 +59,7 @@ export function SignUpPage() {
   }
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 px-6 py-16">
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50 px-6 py-16">
       <header className="space-y-2">
         <div className="flex items-center gap-3">
           <img src="/coden_logo.png" alt="Coden Logo" className="h-12 w-12 object-contain" />
@@ -70,7 +70,7 @@ export function SignUpPage() {
 
       {supabaseConfigError ? <ConfigErrorView message={supabaseConfigError} /> : null}
 
-      <form className="space-y-4 rounded-xl border border-slate-200 bg-white p-6 shadow-sm" onSubmit={handleSubmit} noValidate>
+      <form className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm" onSubmit={handleSubmit} noValidate>
         <label className="block">
           <span className="mb-1 block text-sm font-medium text-slate-700">メールアドレス</span>
           <input


### PR DESCRIPTION
## Summary
- Login/SignUpページに `bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50` 背景を適用（ダッシュボードと統一）
- フォームカードを `rounded-xl` → `rounded-2xl` に格上げ
- WelcomeBanner の装飾円（`blur-2xl` x2）を削除し、`relative overflow-hidden` / `relative z-10` を除去
- DashboardSidebar の装飾円（`blur-2xl` x1）を削除し、`relative overflow-hidden` を除去

## Test plan
- [x] lint / test (220) / build 全パス
- [ ] Login/SignUpページでグラデーション背景を目視確認
- [ ] ダッシュボードでWelcomeBanner/DashboardSidebarの表示を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)