### PR TITLE
feat: ページ別タイトル設定

### DIFF
--- a/apps/web/src/hooks/useDocumentTitle.ts
+++ b/apps/web/src/hooks/useDocumentTitle.ts
@@ -1,0 +1,9 @@
+import { useEffect } from 'react'
+
+const SUFFIX = ' | Coden'
+
+export function useDocumentTitle(title: string) {
+  useEffect(() => {
+    document.title = title + SUFFIX
+  }, [title])
+}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { ConfigErrorView } from '../components/ConfigErrorView'
 import { ErrorBanner } from '../components/ErrorBanner'
 import { getFirstImplementedStep, IMPLEMENTED_STEP_COUNT } from '../content/courseData'
@@ -15,6 +16,7 @@ import { getProfile } from '../services/profileService'
 import { getDisplayName } from '../shared/utils/getDisplayName'
 
 export function DashboardPage() {
+  useDocumentTitle('ダッシュボード')
   const { user, signOut } = useAuth()
   const { completedStepsCount } = useLearningContext()
   const navigate = useNavigate()

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useMemo, useState } from 'react'
 import { Link, Navigate, useLocation } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { Button } from '../components/Button'
 import { ConfigErrorView } from '../components/ConfigErrorView'
 import { ErrorBanner } from '../components/ErrorBanner'
@@ -18,6 +19,8 @@ export function LoginPage() {
     const state = location.state as { from?: string } | null
     return state?.from ?? '/'
   }, [location.state])
+
+  useDocumentTitle('ログイン')
 
   if (user) {
     return <Navigate to={redirectPath} replace />

--- a/apps/web/src/pages/NotFoundPage.tsx
+++ b/apps/web/src/pages/NotFoundPage.tsx
@@ -1,6 +1,9 @@
 import { Link } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 export function NotFoundPage() {
+  useDocumentTitle('ページが見つかりません')
+
   return (
     <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 px-6 py-16">
       <header className="space-y-3">

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import { Lock, Trophy } from 'lucide-react'
 import { Link, useNavigate } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { ConfigErrorView } from '../components/ConfigErrorView'
 import { ErrorBanner } from '../components/ErrorBanner'
 import { useAchievementContext } from '../contexts/AchievementContext'
@@ -15,6 +16,7 @@ import { formatDateTime, formatStudyDate } from '../shared/utils/dateTime'
 import { getDisplayName } from '../shared/utils/getDisplayName'
 
 export function ProfilePage() {
+  useDocumentTitle('プロフィール')
   const { user, signOut } = useAuth()
   const { stats, completedStepsCount } = useLearningContext()
   const { unlockedBadgeIds, isChecking } = useAchievementContext()

--- a/apps/web/src/pages/SignUpPage.tsx
+++ b/apps/web/src/pages/SignUpPage.tsx
@@ -1,5 +1,6 @@
 import { FormEvent, useMemo, useState } from 'react'
 import { Link, Navigate, useNavigate } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { Button } from '../components/Button'
 import { ConfigErrorView } from '../components/ConfigErrorView'
 import { ErrorBanner } from '../components/ErrorBanner'
@@ -30,6 +31,8 @@ export function SignUpPage() {
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   const isDisabled = useMemo(() => isSubmitting || Boolean(supabaseConfigError), [isSubmitting])
+
+  useDocumentTitle('アカウント作成')
 
   if (user) {
     return <Navigate to="/" replace />

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react'
 import { Link, Navigate, useNavigate, useParams } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { Check } from 'lucide-react'
 import { ErrorBanner } from '../components/ErrorBanner'
 import { LearningSidebar } from '../components/LearningSidebar'
@@ -47,6 +48,7 @@ export function StepPage() {
   } = useLearningStep(stepId)
 
   const headerDisplayName = useMemo(() => getDisplayName(user), [user])
+  useDocumentTitle(step?.title ?? 'ステップ')
 
   const modeButtons: { id: LearningMode; label: string }[] = useMemo(
     () => [


### PR DESCRIPTION
## Summary
- `useDocumentTitle` カスタムフックを作成（`document.title` を直接設定）
- `react-helmet-async` はReact 19との型互換性問題があったため不採用
- 全6ページに `ページ名 | Coden` 形式のタイトルを設定:
  - LoginPage: `ログイン | Coden`
  - SignUpPage: `アカウント作成 | Coden`
  - DashboardPage: `ダッシュボード | Coden`
  - StepPage: `{step.title} | Coden`
  - ProfilePage: `プロフィール | Coden`
  - NotFoundPage: `ページが見つかりません | Coden`

## Test plan
- [x] lint / test (220) / build 全パス
- [ ] 各ページ遷移時にブラウザタブのタイトルが変わることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)