### PR TITLE
feat: Prismダークテーマ適用とmonospaceフォント定義

### DIFF
--- a/apps/web/src/features/learning/ReadMode.tsx
+++ b/apps/web/src/features/learning/ReadMode.tsx
@@ -7,7 +7,7 @@ import 'prismjs/components/prism-javascript'
 import 'prismjs/components/prism-jsx'
 import 'prismjs/components/prism-typescript'
 import 'prismjs/components/prism-tsx'
-import 'prismjs/themes/prism.css'
+import 'prismjs/themes/prism-okaidia.css'
 
 interface ReadModeProps {
   markdown: string
@@ -74,7 +74,7 @@ export function ReadMode({ markdown, onComplete, isCompleted }: ReadModeProps) {
                       コードをコピー
                     </button>
                   </div>
-                  <pre className="m-0 overflow-x-auto p-4 text-sm">
+                  <pre className="m-0 overflow-x-auto p-4 font-mono text-sm">
                     <code className={`language-${language}`} {...props}>
                       {codeText}
                     </code>

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -15,6 +15,7 @@ export default {
       fontFamily: {
         sans: ['"Noto Sans JP"', 'sans-serif'],
         display: ['Nunito', 'sans-serif'],
+        mono: ['"Fira Code"', '"JetBrains Mono"', 'Consolas', 'ui-monospace', 'SFMono-Regular', 'monospace'],
       },
       backgroundImage: {
         'mint-gradient': 'linear-gradient(135deg, #2CC295 0%, #4FD1C5 100%)',


### PR DESCRIPTION
## Summary
- ReadMode の Prism テーマを `prism.css`（ライト）→ `prism-okaidia.css`（ダーク）に変更し、`bg-slate-900` 背景との整合性を確保
- `tailwind.config.js` に `fontFamily.mono` を定義（Fira Code → JetBrains Mono → Consolas → ui-monospace → SFMono-Regular → monospace）
- ReadMode コードブロックの `<pre>` に `font-mono` クラスを適用（TestMode は既に適用済み、ChallengeMode は Monaco Editor が独自管理）

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run test` 通過（220テスト）
- [x] `npm run build` 通過
- [ ] ブラウザでReadModeのコードブロックがダークテーマ(Monokai風)で表示されることを確認
- [ ] コードブロックのフォントがmonospaceフォントスタックで表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)