### PR TITLE
feat: M2-2 正解時の祝福演出を追加

### DIFF
--- a/apps/web/src/features/learning/ChallengeMode.tsx
+++ b/apps/web/src/features/learning/ChallengeMode.tsx
@@ -102,7 +102,7 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
 
         {checked && (
           <p
-            className={`text-sm font-medium ${isPassed ? 'text-emerald-700' : 'text-rose-700'}`}
+            className={`text-sm font-medium ${isPassed ? 'animate-bounceIn text-emerald-700' : 'text-rose-700'}`}
             role="status"
             aria-live="polite"
           >

--- a/apps/web/src/features/learning/PracticeMode.tsx
+++ b/apps/web/src/features/learning/PracticeMode.tsx
@@ -118,7 +118,7 @@ export function PracticeMode({ stepId, questions, onComplete }: PracticeModeProp
 
         {isJudged && (
           <p
-            className={`text-sm font-medium ${isAllCorrect ? 'text-emerald-700' : 'text-rose-700'}`}
+            className={`text-sm font-medium ${isAllCorrect ? 'animate-bounceIn text-emerald-700' : 'text-rose-700'}`}
             role="status"
             aria-live="polite"
           >

--- a/apps/web/src/features/learning/TestMode.tsx
+++ b/apps/web/src/features/learning/TestMode.tsx
@@ -85,7 +85,7 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
 
         {isJudged && (
           <p
-            className={`text-sm font-medium ${isPassed ? 'text-emerald-700' : 'text-rose-700'}`}
+            className={`text-sm font-medium ${isPassed ? 'animate-bounceIn text-emerald-700' : 'text-rose-700'}`}
             role="status"
             aria-live="polite"
           >

--- a/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
@@ -65,6 +65,7 @@ describe('ChallengeMode', () => {
       matchedKeywords: ['useState', 'onClick'],
     })
     expect(screen.getByRole('status').textContent).toContain('Challengeを完了しました')
+    expect(screen.getByRole('status').className).toContain('animate-bounceIn')
   })
 
   it('stepId が変わると入力内容と判定状態をリセットする', async () => {

--- a/apps/web/src/features/learning/__tests__/PracticeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/PracticeMode.test.tsx
@@ -50,6 +50,7 @@ describe('PracticeMode', () => {
     expect(onComplete).toHaveBeenCalledTimes(1)
     expect(removeFromReviewList).toHaveBeenCalledWith('step-a')
     expect(screen.getByRole('status').textContent).toContain('Practiceを完了しました')
+    expect(screen.getByRole('status').className).toContain('animate-bounceIn')
     expect(screen.getByText('ヒント1')).toBeTruthy()
 
     rerender(<PracticeMode stepId="step-b" questions={secondQuestions} onComplete={onComplete} />)

--- a/apps/web/src/features/learning/__tests__/TestMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/TestMode.test.tsx
@@ -50,6 +50,7 @@ describe('TestMode', () => {
     expect(onComplete).toHaveBeenCalledTimes(1)
     expect(removeFromReviewList).toHaveBeenCalledWith('step-a')
     expect(screen.getByRole('status').textContent).toContain('テスト合格')
+    expect(screen.getByRole('status').className).toContain('animate-bounceIn')
 
     rerender(<TestMode stepId="step-b" task={secondTask} onComplete={onComplete} />)
 

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, Navigate, useNavigate, useParams } from 'react-router-dom'
 import { BookOpen, Check, Code2, PenLine, Trophy } from 'lucide-react'
 import { ErrorBanner } from '../components/ErrorBanner'
@@ -80,6 +80,15 @@ export function StepPage() {
   const { completedStepsCount, isLoadingStats } = useLearningContext()
   const navigate = useNavigate()
   const [activeMode, setActiveMode] = useState<LearningMode>('read')
+  const [pulseModes, setPulseModes] = useState<Record<LearningMode, boolean>>({
+    read: false,
+    practice: false,
+    test: false,
+    challenge: false,
+  })
+  const challengeCompleteRef = useRef<HTMLDivElement | null>(null)
+  const previousModeStatusRef = useRef<Record<LearningMode, boolean> | null>(null)
+  const pulseTimeoutsRef = useRef<number[]>([])
   const saveChallengeSubmission = useChallengeSubmission(stepId)
   const recentChallengeSubmissions = useRecentChallengeSubmissions(stepId)
   const handleChallengeSubmitResult = useCallback(
@@ -115,6 +124,57 @@ export function StepPage() {
   const ActiveModeIcon = activeModeMeta.icon
 
   useDocumentTitle(step?.title ?? 'ステップ')
+
+  useEffect(() => {
+    if (!previousModeStatusRef.current) {
+      previousModeStatusRef.current = modeStatus
+      return
+    }
+
+    const previousModeStatus = previousModeStatusRef.current
+    const newlyCompletedModes = (Object.keys(modeStatus) as LearningMode[]).filter(
+      (mode) => !previousModeStatus[mode] && modeStatus[mode],
+    )
+
+    if (newlyCompletedModes.length > 0) {
+      setPulseModes((current) => {
+        const next = { ...current }
+
+        for (const mode of newlyCompletedModes) {
+          next[mode] = true
+        }
+
+        return next
+      })
+
+      for (const mode of newlyCompletedModes) {
+        const timeoutId = window.setTimeout(() => {
+          setPulseModes((current) => ({
+            ...current,
+            [mode]: false,
+          }))
+        }, 750)
+
+        pulseTimeoutsRef.current.push(timeoutId)
+      }
+    }
+
+    if (!previousModeStatus.challenge && modeStatus.challenge) {
+      challengeCompleteRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    }
+
+    previousModeStatusRef.current = modeStatus
+  }, [modeStatus])
+
+  useEffect(() => {
+    const timeoutIds = pulseTimeoutsRef.current
+
+    return () => {
+      for (const timeoutId of timeoutIds) {
+        window.clearTimeout(timeoutId)
+      }
+    }
+  }, [])
 
   async function handleSignOut() {
     const errorMessage = await signOut()
@@ -191,7 +251,7 @@ export function StepPage() {
                             : isDone
                               ? mode.doneClassName
                               : 'border-slate-200 bg-slate-100 text-slate-500 hover:border-slate-300 hover:bg-slate-200 hover:text-slate-700'
-                        }`}
+                        } ${pulseModes[mode.id] ? 'animate-pulseMint' : ''}`}
                         type="button"
                         aria-label={mode.label}
                         aria-current={isActive ? 'step' : undefined}
@@ -280,7 +340,7 @@ export function StepPage() {
             ) : null}
 
             {modeStatus.challenge ? (
-              <div className="mt-6 rounded-xl border border-emerald-200 bg-emerald-50 p-4">
+              <div ref={challengeCompleteRef} className="mt-6 rounded-xl border border-emerald-200 bg-emerald-50 p-4">
                 <p className="text-sm font-medium text-emerald-800">
                   {nextStep
                     ? `チャレンジ完了です。次は「${nextStep.title}」へ進めます。`

--- a/apps/web/src/pages/__tests__/StepPage.test.tsx
+++ b/apps/web/src/pages/__tests__/StepPage.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { StepPage } from '../StepPage'
 
 const useChallengeSubmissionMock = vi.fn()
@@ -107,6 +107,14 @@ function mockLearningStep() {
 }
 
 describe('StepPage', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
   it('モード切り替え時に説明カードが切り替わる', async () => {
     const user = userEvent.setup()
 
@@ -172,5 +180,181 @@ describe('StepPage', () => {
     expect(screen.getByText('Latest Submission')).toBeTruthy()
     expect(screen.getByText('合格')).toBeTruthy()
     expect(screen.getByText('const [count, setCount] = useState(0);')).toBeTruthy()
+  })
+
+  it('Challenge 完了時に完了バナーまでスムーズスクロールする', async () => {
+    const scrollIntoViewMock = vi.fn()
+    const user = userEvent.setup()
+    let learningStepState = {
+      step: {
+        id: 'usestate-basic',
+        title: 'useState基礎',
+        summary: 'summary',
+        readMarkdown: '# read',
+        practiceQuestions: [],
+        testTask: {
+          instruction: 'instruction',
+          starterCode: 'const value = ____;',
+          expectedKeywords: ['value'],
+        },
+        challengeTask: {
+          patterns: [
+            {
+              id: 'pattern-1',
+              prompt: 'challenge',
+              requirements: [],
+              hints: [],
+              expectedKeywords: ['useState'],
+              starterCode: 'const [count, setCount] = useState(0);',
+            },
+          ],
+        },
+        order: 1,
+      },
+      isUnavailableStep: false,
+      modeStatus: {
+        read: true,
+        practice: true,
+        test: true,
+        challenge: false,
+      },
+      syncMessage: null,
+      toastMessage: null,
+      nextStep: {
+        id: 'events',
+        title: 'イベント処理',
+      },
+      sidebarTitle: 'React基礎',
+      sidebarSteps: [],
+      isStepCompleted: false,
+      handleModeComplete: vi.fn(),
+    }
+
+    Object.defineProperty(window.HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: scrollIntoViewMock,
+    })
+
+    useChallengeSubmissionMock.mockReturnValue(vi.fn())
+    useRecentChallengeSubmissionsMock.mockReturnValue({
+      submissions: [],
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+    })
+    useLearningStepMock.mockImplementation(() => learningStepState)
+
+    const view = render(
+      <MemoryRouter initialEntries={['/step/usestate-basic']}>
+        <Routes>
+          <Route path="/step/:stepId" element={<StepPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await user.click(screen.getAllByRole('button', { name: 'Challenge' })[0])
+
+    learningStepState = {
+      ...learningStepState,
+      modeStatus: {
+        ...learningStepState.modeStatus,
+        challenge: true,
+      },
+      isStepCompleted: true,
+    }
+
+    view.rerender(
+      <MemoryRouter initialEntries={['/step/usestate-basic']}>
+        <Routes>
+          <Route path="/step/:stepId" element={<StepPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'nearest' })
+    })
+    expect(screen.getByText('チャレンジ完了です。次は「イベント処理」へ進めます。')).toBeTruthy()
+  })
+
+  it('完了したモードが増えたときにステッパーへ pulse 演出を付与する', async () => {
+    let learningStepState = {
+      step: {
+        id: 'usestate-basic',
+        title: 'useState基礎',
+        summary: 'summary',
+        readMarkdown: '# read',
+        practiceQuestions: [],
+        testTask: {
+          instruction: 'instruction',
+          starterCode: 'const value = ____;',
+          expectedKeywords: ['value'],
+        },
+        challengeTask: {
+          patterns: [
+            {
+              id: 'pattern-1',
+              prompt: 'challenge',
+              requirements: [],
+              hints: [],
+              expectedKeywords: ['useState'],
+              starterCode: 'const [count, setCount] = useState(0);',
+            },
+          ],
+        },
+        order: 1,
+      },
+      isUnavailableStep: false,
+      modeStatus: {
+        read: true,
+        practice: false,
+        test: false,
+        challenge: false,
+      },
+      syncMessage: null,
+      toastMessage: null,
+      nextStep: undefined,
+      sidebarTitle: 'React基礎',
+      sidebarSteps: [],
+      isStepCompleted: false,
+      handleModeComplete: vi.fn(),
+    }
+
+    useChallengeSubmissionMock.mockReturnValue(vi.fn())
+    useRecentChallengeSubmissionsMock.mockReturnValue({
+      submissions: [],
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+    })
+    useLearningStepMock.mockImplementation(() => learningStepState)
+
+    const view = render(
+      <MemoryRouter initialEntries={['/step/usestate-basic']}>
+        <Routes>
+          <Route path="/step/:stepId" element={<StepPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    learningStepState = {
+      ...learningStepState,
+      modeStatus: {
+        ...learningStepState.modeStatus,
+        practice: true,
+      },
+    }
+
+    view.rerender(
+      <MemoryRouter initialEntries={['/step/usestate-basic']}>
+        <Routes>
+          <Route path="/step/:stepId" element={<StepPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Practice' })[0].className).toContain('animate-pulseMint')
+    })
   })
 })

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -44,4 +44,49 @@ body {
   .animate-fadeIn {
     animation: fadeIn 300ms ease-out;
   }
+
+  @keyframes bounceIn {
+    0% {
+      opacity: 0;
+      transform: scale(0.3);
+    }
+
+    50% {
+      transform: scale(1.05);
+    }
+
+    70% {
+      transform: scale(0.9);
+    }
+
+    100% {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  .animate-bounceIn {
+    animation: bounceIn 500ms ease-out;
+  }
+
+  @keyframes pulseMint {
+    0% {
+      box-shadow: 0 0 0 0 rgba(45, 212, 191, 0.45);
+      transform: scale(1);
+    }
+
+    50% {
+      box-shadow: 0 0 0 10px rgba(45, 212, 191, 0);
+      transform: scale(1.04);
+    }
+
+    100% {
+      box-shadow: 0 0 0 0 rgba(45, 212, 191, 0);
+      transform: scale(1);
+    }
+  }
+
+  .animate-pulseMint {
+    animation: pulseMint 700ms ease-out;
+  }
 }


### PR DESCRIPTION
概要: Practice/Test/Challenge の成功表示と StepPage の完了演出を追加。\n検証: typecheck / lint / test / build pass\nIssue要否: 不要。roadmap09 の既存タスク内で完結するため。