### PR TITLE
feat: M3-1 LearningSidebar のモバイル折りたたみを追加

### DIFF
--- a/apps/web/src/components/LearningSidebar.tsx
+++ b/apps/web/src/components/LearningSidebar.tsx
@@ -1,5 +1,6 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Lock } from 'lucide-react'
+import { ChevronDown, Lock } from 'lucide-react'
 import type { LearningStepContent } from '../content/fundamentals/steps'
 import { useLearningContext } from '../contexts/LearningContext'
 
@@ -11,56 +12,76 @@ interface LearningSidebarProps {
 
 export function LearningSidebar({ courseTitle, currentStepId, steps }: LearningSidebarProps) {
   const { completedStepsCount, isLoadingStats } = useLearningContext()
+  const [isCollapsed, setIsCollapsed] = useState(true)
 
   return (
     <aside className="w-full rounded-2xl border border-slate-200 bg-white p-4 shadow-sm lg:w-72" aria-label="学習コースナビゲーション">
-      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">{courseTitle}</p>
-      <ul className="mt-3 space-y-2" aria-label={courseTitle}>
-        {steps.map((step) => {
-          const isCurrent = step.id === currentStepId
-          const isLocked = !isLoadingStats && step.order > completedStepsCount + 1
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">{courseTitle}</p>
+        <button
+          className="inline-flex items-center gap-1 rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 lg:hidden"
+          type="button"
+          aria-expanded={!isCollapsed}
+          aria-controls="learning-sidebar-list"
+          onClick={() => setIsCollapsed((current) => !current)}
+        >
+          {isCollapsed ? 'コース一覧を見る' : 'コース一覧を隠す'}
+          <ChevronDown className={`h-3.5 w-3.5 transition-transform ${isCollapsed ? '' : 'rotate-180'}`} />
+        </button>
+      </div>
 
-          const content = (
-            <>
-              <p className="text-xs text-slate-500">
-                STEP {step.order} {isLocked ? <Lock className="inline-block h-3 w-3" /> : ''}
-              </p>
-              <p className="font-medium">{step.title}</p>
-            </>
-          )
+      <div
+        id="learning-sidebar-list"
+        className={`overflow-hidden transition-[max-height,opacity] duration-300 ease-out lg:max-h-none lg:overflow-visible ${isCollapsed ? 'max-h-0 opacity-0 lg:opacity-100' : 'mt-3 max-h-[80vh] opacity-100'
+          }`}
+      >
+        <ul className="space-y-2 pt-3 lg:pt-0" aria-label={courseTitle}>
+          {steps.map((step) => {
+            const isCurrent = step.id === currentStepId
+            const isLocked = !isLoadingStats && step.order > completedStepsCount + 1
 
-          const baseClass = `block rounded-lg border px-3 py-2 text-sm transition`
+            const content = (
+              <>
+                <p className="text-xs text-slate-500">
+                  STEP {step.order} {isLocked ? <Lock className="inline-block h-3 w-3" /> : ''}
+                </p>
+                <p className="font-medium">{step.title}</p>
+              </>
+            )
 
-          if (isLocked) {
+            const baseClass = `block rounded-lg border px-3 py-2 text-sm transition`
+
+            if (isLocked) {
+              return (
+                <li key={step.id}>
+                  <div
+                    className={`${baseClass} border-slate-200 bg-slate-50 text-slate-400 opacity-60`}
+                    aria-disabled="true"
+                  >
+                    {content}
+                  </div>
+                </li>
+              )
+            }
+
             return (
               <li key={step.id}>
-                <div
-                  className={`${baseClass} border-slate-200 bg-slate-50 text-slate-400 opacity-60`}
-                  aria-disabled="true"
+                <Link
+                  className={`${baseClass} ${isCurrent
+                    ? 'border-primary-mint bg-secondary-bg text-primary-dark'
+                    : 'border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50'
+                    }`}
+                  to={`/step/${step.id}`}
+                  replace
+                  aria-current={isCurrent ? 'page' : undefined}
                 >
                   {content}
-                </div>
+                </Link>
               </li>
             )
-          }
-
-          return (
-            <li key={step.id}>
-              <Link
-                className={`${baseClass} ${isCurrent
-                  ? 'border-primary-mint bg-secondary-bg text-primary-dark'
-                  : 'border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50'
-                  }`}
-                to={`/step/${step.id}`}
-                replace
-                aria-current={isCurrent ? 'page' : undefined}
-              >
-                {content}
-              </Link>
-            </li>
-          )
-        })}
-      </ul>
+          })}
+        </ul>
+      </div>
     </aside>
   )
 }

--- a/apps/web/src/components/__tests__/LearningSidebar.test.tsx
+++ b/apps/web/src/components/__tests__/LearningSidebar.test.tsx
@@ -1,0 +1,129 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { LearningSidebar } from '../LearningSidebar'
+import type { LearningStepContent } from '@/content/fundamentals/steps'
+
+vi.mock('@/contexts/LearningContext', () => ({
+  useLearningContext: () => ({
+    completedStepsCount: 1,
+    isLoadingStats: false,
+  }),
+}))
+
+const steps: LearningStepContent[] = [
+  {
+    id: 'usestate-basic',
+    order: 1,
+    title: 'useState基礎',
+    summary: 'summary',
+    readMarkdown: '# read',
+    practiceQuestions: [],
+    testTask: {
+      instruction: 'instruction',
+      starterCode: 'const value = ____;',
+      expectedKeywords: ['value'],
+    },
+    challengeTask: {
+      patterns: [
+        {
+          id: 'pattern-1',
+          prompt: 'challenge',
+          requirements: [],
+          hints: [],
+          expectedKeywords: ['useState'],
+          starterCode: 'const [count, setCount] = useState(0);',
+        },
+      ],
+    },
+  },
+  {
+    id: 'events',
+    order: 2,
+    title: 'イベント処理',
+    summary: 'summary',
+    readMarkdown: '# read',
+    practiceQuestions: [],
+    testTask: {
+      instruction: 'instruction',
+      starterCode: 'const value = ____;',
+      expectedKeywords: ['value'],
+    },
+    challengeTask: {
+      patterns: [
+        {
+          id: 'pattern-2',
+          prompt: 'challenge',
+          requirements: [],
+          hints: [],
+          expectedKeywords: ['useState'],
+          starterCode: 'const [count, setCount] = useState(0);',
+        },
+      ],
+    },
+  },
+  {
+    id: 'conditional',
+    order: 3,
+    title: '条件分岐',
+    summary: 'summary',
+    readMarkdown: '# read',
+    practiceQuestions: [],
+    testTask: {
+      instruction: 'instruction',
+      starterCode: 'const value = ____;',
+      expectedKeywords: ['value'],
+    },
+    challengeTask: {
+      patterns: [
+        {
+          id: 'pattern-3',
+          prompt: 'challenge',
+          requirements: [],
+          hints: [],
+          expectedKeywords: ['useState'],
+          starterCode: 'const [count, setCount] = useState(0);',
+        },
+      ],
+    },
+  },
+]
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('LearningSidebar', () => {
+  it('モバイルではデフォルトで折りたたまれ、トグルで展開できる', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <MemoryRouter>
+        <LearningSidebar courseTitle="React基礎" currentStepId="usestate-basic" steps={[...steps]} />
+      </MemoryRouter>,
+    )
+
+    const toggle = screen.getByRole('button', { name: 'コース一覧を見る' })
+    const panel = document.getElementById('learning-sidebar-list')
+
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(panel?.className).toContain('max-h-0')
+
+    await user.click(toggle)
+
+    expect(screen.getByRole('button', { name: 'コース一覧を隠す' }).getAttribute('aria-expanded')).toBe('true')
+    expect(panel?.className).toContain('max-h-[80vh]')
+    expect(screen.getByRole('link', { name: /useState基礎/ }).getAttribute('href')).toBe('/step/usestate-basic')
+  })
+
+  it('未解放ステップはロック状態で表示する', () => {
+    render(
+      <MemoryRouter>
+        <LearningSidebar courseTitle="React基礎" currentStepId="events" steps={[...steps]} />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getAllByText('条件分岐')[0].closest('[aria-disabled="true"]')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
概要: LearningSidebar をモバイル既定で折りたたみ、トグルボタンと遷移アニメーションを追加。\n検証: typecheck / lint / test / build pass\nIssue要否: 不要。roadmap09 の既存タスク内で完結するため。