### PR TITLE
feat: M4 仕上げ調整を反映

### DIFF
--- a/apps/web/src/features/dashboard/components/DashboardSidebar.tsx
+++ b/apps/web/src/features/dashboard/components/DashboardSidebar.tsx
@@ -84,11 +84,11 @@ export function DashboardSidebar() {
         <div className="space-y-4 p-5">
           <div className="grid grid-cols-2 gap-3">
             <div className="rounded-xl border border-orange-100 bg-orange-50 p-3 text-center">
-              <p className="text-[10px] font-bold uppercase tracking-wide text-orange-600">連続学習</p>
+              <p className="text-xs font-bold uppercase tracking-wide text-orange-600">連続学習</p>
               <p className="mt-1 text-2xl font-black text-orange-700">{stats?.current_streak ?? 0}日</p>
             </div>
             <div className="rounded-xl border border-indigo-100 bg-indigo-50 p-3 text-center">
-              <p className="text-[10px] font-bold uppercase tracking-wide text-indigo-600">合計ポイント</p>
+              <p className="text-xs font-bold uppercase tracking-wide text-indigo-600">合計ポイント</p>
               <p className="mt-1 text-2xl font-black text-indigo-700">{stats?.total_points ?? 0}pt</p>
             </div>
           </div>
@@ -140,7 +140,7 @@ export function DashboardSidebar() {
       </section>
 
       <section className="rounded-2xl bg-gradient-to-br from-indigo-600 to-sky-600 p-5 text-white shadow-sm">
-        <p className="mb-2 inline-block rounded bg-white/20 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide">
+        <p className="mb-2 inline-block rounded bg-white/20 px-2 py-0.5 text-xs font-bold uppercase tracking-wide">
           Bonus Challenge
         </p>
         <h3 className="font-bold">MVPでは未提供です</h3>


### PR DESCRIPTION
概要: roadmap09 M4-1 の細部調整を main に統合。DashboardSidebar のラベルサイズを WCAG 寄りに調整し、favicon と ReadMode のブランドリンク色は既存実装を確認済み。\n検証: typecheck / lint / test / build pass\nIssue要否: 不要。roadmap09 の既存マイルストーン統合作業のため。