### PR TITLE
chore: package-lock の peer フラグ差分を反映

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7053,6 +7053,7 @@
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",


### PR DESCRIPTION
概要: package-lock.json の未反映差分 1 行を main に正規反映します。	ypecheck lint 	est uild pass。Issue不要: 単一 tracked file の差分正規化のため。