### PR TITLE
chore: vercel.json 追加

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "apps/web/dist",
+  "installCommand": "npm install",
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ]
+}


### PR DESCRIPTION
## 概要
Vercel デプロイ用の vercel.json をプロジェクトルートに追加。

## 変更内容
- `vercel.json` 新規作成
  - buildCommand: `npm run build`（ルート package.json → workspace 経由）
  - outputDirectory: `apps/web/dist`
  - installCommand: `npm install`
  - SPA リライト: `/(.*) → /index.html`

## Issue要否
不要: roadmap10 タスク 1-1 として定義済み。単一ファイル追加のみ。

## 検証結果
- typecheck / test / build: 既存 CI に影響なし（設定ファイル追加のみ）