### PR TITLE
feat: テスト合格後のライブプレビューUI実装（全20ステップ）

### DIFF
--- a/apps/web/src/features/learning/TestMode.tsx
+++ b/apps/web/src/features/learning/TestMode.tsx
@@ -1,8 +1,9 @@
-import { Fragment, useEffect, useMemo, useState } from 'react'
+import { Fragment, Suspense, useEffect, useMemo, useState } from 'react'
 import { Button } from '../../components/Button'
 import type { TestTask } from '../../content/fundamentals/steps'
 import { addToReviewList, removeFromReviewList } from '../../services/reviewListService'
 import { previewByStepId } from './testModePreview'
+import { previewComponentByStepId } from './previews'
 
 interface TestModeProps {
   stepId: string
@@ -110,6 +111,20 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
         <div className="mt-4 rounded-lg border border-emerald-300 bg-emerald-50 p-4">
           <p className="text-sm font-semibold text-emerald-800">{preview.title}</p>
           <p className="mt-1 text-sm text-emerald-700">{preview.description}</p>
+          {previewComponentByStepId[stepId] ? (
+            <div className="mt-3 rounded-md border border-emerald-200 bg-white p-4">
+              <Suspense
+                fallback={
+                  <p className="text-xs text-slate-400">プレビューを読み込み中…</p>
+                }
+              >
+                {(() => {
+                  const PreviewComponent = previewComponentByStepId[stepId]
+                  return <PreviewComponent />
+                })()}
+              </Suspense>
+            </div>
+          ) : null}
         </div>
       ) : null}
     </section>

--- a/apps/web/src/features/learning/previews/ApiCounterGetPreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiCounterGetPreview.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react'
+
+export default function ApiCounterGetPreview() {
+  const [count, setCount] = useState<number | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setCount(42)
+      setLoading(false)
+    }, 600)
+    return () => clearTimeout(id)
+  }, [])
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs font-medium text-slate-500">GET /api/counter</p>
+      {loading ? (
+        <p className="text-sm text-slate-400 animate-pulse">取得中…</p>
+      ) : (
+        <p className="text-2xl font-bold text-slate-800">{count}</p>
+      )}
+      <button
+        className="rounded-lg bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-700 active:scale-95"
+        onClick={() => {
+          setLoading(true)
+          setTimeout(() => {
+            setCount(42)
+            setLoading(false)
+          }, 600)
+        }}
+      >
+        再取得
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/ApiCounterPostPreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiCounterPostPreview.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react'
+
+export default function ApiCounterPostPreview() {
+  const [count, setCount] = useState(0)
+  const [sending, setSending] = useState(false)
+
+  function handleIncrement() {
+    setSending(true)
+    setTimeout(() => {
+      setCount((c) => c + 1)
+      setSending(false)
+    }, 400)
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs font-medium text-slate-500">POST /api/counter</p>
+      <p className="text-2xl font-bold text-slate-800">{count}</p>
+      <button
+        className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95 disabled:opacity-50"
+        onClick={handleIncrement}
+        disabled={sending}
+      >
+        {sending ? '送信中…' : '+1 (POST)'}
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/ApiCustomHookPreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiCustomHookPreview.tsx
@@ -1,0 +1,73 @@
+import { useCallback, useState } from 'react'
+
+type Task = { id: number; title: string; done: boolean }
+
+function useTasks(initialTasks: Task[]) {
+  const [tasks, setTasks] = useState<Task[]>(initialTasks)
+
+  const addTask = useCallback((title: string) => {
+    setTasks((prev) => [...prev, { id: Date.now(), title, done: false }])
+  }, [])
+
+  const toggleTask = useCallback((id: number) => {
+    setTasks((prev) => prev.map((t) => (t.id === id ? { ...t, done: !t.done } : t)))
+  }, [])
+
+  const deleteTask = useCallback((id: number) => {
+    setTasks((prev) => prev.filter((t) => t.id !== id))
+  }, [])
+
+  return { tasks, addTask, toggleTask, deleteTask }
+}
+
+export default function ApiCustomHookPreview() {
+  const { tasks, addTask, toggleTask, deleteTask } = useTasks([
+    { id: 1, title: 'サンプルタスク', done: false },
+  ])
+  const [input, setInput] = useState('')
+
+  function handleAdd() {
+    const trimmed = input.trim()
+    if (trimmed) {
+      addTask(trimmed)
+      setInput('')
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs font-medium text-slate-500">useTasks カスタムフック</p>
+      <ul className="space-y-1">
+        {tasks.map((t) => (
+          <li key={t.id} className="flex items-center gap-2 text-sm">
+            <button
+              className={`text-xs ${t.done ? 'text-emerald-500' : 'text-slate-300'}`}
+              onClick={() => toggleTask(t.id)}
+            >
+              {t.done ? '✓' : '○'}
+            </button>
+            <span className={t.done ? 'text-slate-400 line-through' : 'text-slate-700'}>{t.title}</span>
+            <button className="text-xs text-rose-400 hover:text-rose-600" onClick={() => deleteTask(t.id)}>
+              ✗
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="flex gap-2">
+        <input
+          className="rounded border border-slate-300 px-2 py-1 text-sm"
+          placeholder="新しいタスク"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleAdd()}
+        />
+        <button
+          className="rounded-lg bg-emerald-600 px-3 py-1 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95"
+          onClick={handleAdd}
+        >
+          追加
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/ApiErrorLoadingPreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiErrorLoadingPreview.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react'
+
+type Status = 'idle' | 'loading' | 'success' | 'error'
+
+export default function ApiErrorLoadingPreview() {
+  const [status, setStatus] = useState<Status>('idle')
+
+  function simulateSuccess() {
+    setStatus('loading')
+    setTimeout(() => setStatus('success'), 1000)
+  }
+
+  function simulateError() {
+    setStatus('loading')
+    setTimeout(() => setStatus('error'), 1000)
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs font-medium text-slate-500">非同期UIの状態管理</p>
+
+      <div className="min-h-[48px] rounded-md border border-slate-200 px-3 py-2">
+        {status === 'idle' && <p className="text-sm text-slate-400">ボタンを押してリクエストを送信</p>}
+        {status === 'loading' && <p className="text-sm text-blue-500 animate-pulse">読み込み中…</p>}
+        {status === 'success' && <p className="text-sm font-medium text-emerald-700">データの取得に成功しました</p>}
+        {status === 'error' && (
+          <div>
+            <p className="text-sm font-medium text-rose-700">エラーが発生しました</p>
+            <p className="text-xs text-rose-500">ネットワークエラー: 接続がタイムアウトしました</p>
+          </div>
+        )}
+      </div>
+
+      <div className="flex gap-2">
+        <button
+          className="rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95 disabled:opacity-50"
+          onClick={simulateSuccess}
+          disabled={status === 'loading'}
+        >
+          成功パターン
+        </button>
+        <button
+          className="rounded-lg bg-rose-600 px-3 py-2 text-sm font-medium text-white hover:bg-rose-700 active:scale-95 disabled:opacity-50"
+          onClick={simulateError}
+          disabled={status === 'loading'}
+        >
+          エラーパターン
+        </button>
+        {(status === 'success' || status === 'error') && (
+          <button
+            className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-600 hover:bg-slate-100"
+            onClick={() => setStatus('idle')}
+          >
+            リセット
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/ApiFetchPreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiFetchPreview.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react'
+
+type User = { id: number; name: string; email: string }
+
+const mockUsers: User[] = [
+  { id: 1, name: '田中太郎', email: 'tanaka@example.com' },
+  { id: 2, name: '鈴木花子', email: 'suzuki@example.com' },
+  { id: 3, name: '佐藤次郎', email: 'sato@example.com' },
+]
+
+export default function ApiFetchPreview() {
+  const [users, setUsers] = useState<User[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setUsers(mockUsers)
+      setLoading(false)
+    }, 800)
+    return () => clearTimeout(id)
+  }, [])
+
+  function handleRefresh() {
+    setLoading(true)
+    setUsers([])
+    setTimeout(() => {
+      setUsers(mockUsers)
+      setLoading(false)
+    }, 800)
+  }
+
+  return (
+    <div className="space-y-3">
+      {loading ? (
+        <p className="text-sm text-slate-500 animate-pulse">データを読み込み中…</p>
+      ) : (
+        <ul className="space-y-1">
+          {users.map((u) => (
+            <li key={u.id} className="text-sm text-slate-700">
+              <span className="font-medium">{u.name}</span>{' '}
+              <span className="text-xs text-slate-400">{u.email}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+      <button
+        className="rounded-lg bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-700 active:scale-95"
+        onClick={handleRefresh}
+      >
+        再取得
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/ApiTaskCreatePreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiTaskCreatePreview.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+
+type Task = { id: number; title: string }
+
+export default function ApiTaskCreatePreview() {
+  const [tasks, setTasks] = useState<Task[]>([{ id: 1, title: '既存タスク' }])
+  const [input, setInput] = useState('')
+  const [sending, setSending] = useState(false)
+
+  function handleCreate() {
+    const trimmed = input.trim()
+    if (!trimmed) return
+    setSending(true)
+    setTimeout(() => {
+      setTasks((prev) => [...prev, { id: Date.now(), title: trimmed }])
+      setInput('')
+      setSending(false)
+    }, 400)
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs font-medium text-slate-500">POST /api/tasks</p>
+      <ul className="space-y-1">
+        {tasks.map((t) => (
+          <li key={t.id} className="text-sm text-slate-700">• {t.title}</li>
+        ))}
+      </ul>
+      <div className="flex gap-2">
+        <input
+          className="rounded border border-slate-300 px-2 py-1 text-sm"
+          placeholder="新しいタスク"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+        />
+        <button
+          className="rounded-lg bg-emerald-600 px-3 py-1 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95 disabled:opacity-50"
+          onClick={handleCreate}
+          disabled={sending}
+        >
+          {sending ? '作成中…' : '作成'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/ApiTaskDeletePreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiTaskDeletePreview.tsx
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+
+type Task = { id: number; title: string }
+
+const initial: Task[] = [
+  { id: 1, title: '買い物に行く' },
+  { id: 2, title: 'レポートを書く' },
+  { id: 3, title: 'コードレビュー' },
+]
+
+export default function ApiTaskDeletePreview() {
+  const [tasks, setTasks] = useState<Task[]>(initial)
+  const [deleting, setDeleting] = useState<number | null>(null)
+
+  function handleDelete(id: number) {
+    setDeleting(id)
+    setTimeout(() => {
+      setTasks((prev) => prev.filter((t) => t.id !== id))
+      setDeleting(null)
+    }, 400)
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs font-medium text-slate-500">DELETE /api/tasks/:id</p>
+      {tasks.length === 0 ? (
+        <p className="text-sm text-slate-400">タスクがありません</p>
+      ) : (
+        <ul className="space-y-1">
+          {tasks.map((t) => (
+            <li key={t.id} className="flex items-center gap-2 text-sm">
+              <span className="text-slate-700">{t.title}</span>
+              <button
+                className="text-xs text-rose-400 hover:text-rose-600 disabled:opacity-50"
+                onClick={() => handleDelete(t.id)}
+                disabled={deleting === t.id}
+              >
+                {deleting === t.id ? '削除中…' : '削除'}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {tasks.length < initial.length && (
+        <button
+          className="rounded-lg border border-slate-300 px-3 py-1 text-sm text-slate-600 hover:bg-slate-100"
+          onClick={() => setTasks(initial)}
+        >
+          リセット
+        </button>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/ApiTaskListPreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiTaskListPreview.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react'
+
+type Task = { id: number; title: string; done: boolean }
+
+const mockTasks: Task[] = [
+  { id: 1, title: '買い物に行く', done: false },
+  { id: 2, title: 'レポートを書く', done: true },
+  { id: 3, title: 'コードレビュー', done: false },
+]
+
+export default function ApiTaskListPreview() {
+  const [tasks, setTasks] = useState<Task[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setTasks(mockTasks)
+      setLoading(false)
+    }, 700)
+    return () => clearTimeout(id)
+  }, [])
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs font-medium text-slate-500">GET /api/tasks</p>
+      {loading ? (
+        <p className="text-sm text-slate-400 animate-pulse">読み込み中…</p>
+      ) : (
+        <ul className="space-y-1">
+          {tasks.map((t) => (
+            <li key={t.id} className="flex items-center gap-2 text-sm">
+              <span className={t.done ? 'text-emerald-500' : 'text-slate-300'}>{t.done ? '✓' : '○'}</span>
+              <span className={t.done ? 'text-slate-400 line-through' : 'text-slate-700'}>{t.title}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/ApiTaskUpdatePreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiTaskUpdatePreview.tsx
@@ -1,0 +1,42 @@
+import { useState } from 'react'
+
+type Task = { id: number; title: string; done: boolean }
+
+const initial: Task[] = [
+  { id: 1, title: '買い物に行く', done: false },
+  { id: 2, title: 'レポートを書く', done: false },
+  { id: 3, title: 'コードレビュー', done: true },
+]
+
+export default function ApiTaskUpdatePreview() {
+  const [tasks, setTasks] = useState<Task[]>(initial)
+  const [updating, setUpdating] = useState<number | null>(null)
+
+  function handleToggle(id: number) {
+    setUpdating(id)
+    setTimeout(() => {
+      setTasks((prev) => prev.map((t) => (t.id === id ? { ...t, done: !t.done } : t)))
+      setUpdating(null)
+    }, 400)
+  }
+
+  return (
+    <div className="space-y-3">
+      <p className="text-xs font-medium text-slate-500">PUT /api/tasks/:id</p>
+      <ul className="space-y-1">
+        {tasks.map((t) => (
+          <li key={t.id} className="flex items-center gap-2 text-sm">
+            <button
+              className={`rounded px-2 py-0.5 text-xs font-medium ${t.done ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-600'} ${updating === t.id ? 'opacity-50' : 'hover:opacity-80'}`}
+              onClick={() => handleToggle(t.id)}
+              disabled={updating === t.id}
+            >
+              {t.done ? '完了' : '未完了'}
+            </button>
+            <span className={t.done ? 'text-slate-400 line-through' : 'text-slate-700'}>{t.title}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/ConditionalPreview.tsx
+++ b/apps/web/src/features/learning/previews/ConditionalPreview.tsx
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+
+export default function ConditionalPreview() {
+  const [isLoggedIn, setIsLoggedIn] = useState(false)
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-md border border-slate-200 bg-white px-3 py-2">
+        {isLoggedIn ? (
+          <p className="text-sm font-medium text-emerald-700">ようこそ、ユーザーさん！</p>
+        ) : (
+          <p className="text-sm text-slate-500">ログインしていません。</p>
+        )}
+      </div>
+      <button
+        className={`rounded-lg px-4 py-2 text-sm font-medium text-white active:scale-95 ${isLoggedIn ? 'bg-rose-600 hover:bg-rose-700' : 'bg-emerald-600 hover:bg-emerald-700'}`}
+        onClick={() => setIsLoggedIn((v) => !v)}
+      >
+        {isLoggedIn ? 'ログアウト' : 'ログイン'}
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/ContextPreview.tsx
+++ b/apps/web/src/features/learning/previews/ContextPreview.tsx
@@ -1,0 +1,47 @@
+import { createContext, useContext, useState } from 'react'
+
+const ThemeContext = createContext<'light' | 'dark'>('light')
+
+function ThemedCard() {
+  const theme = useContext(ThemeContext)
+  return (
+    <div
+      className={`rounded-md border px-3 py-2 text-sm ${theme === 'dark' ? 'border-slate-600 bg-slate-800 text-white' : 'border-slate-200 bg-white text-slate-800'}`}
+    >
+      現在のテーマ: <span className="font-semibold">{theme}</span>
+    </div>
+  )
+}
+
+function ThemedBadge() {
+  const theme = useContext(ThemeContext)
+  return (
+    <span
+      className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${theme === 'dark' ? 'bg-indigo-500 text-white' : 'bg-indigo-100 text-indigo-700'}`}
+    >
+      Badge
+    </span>
+  )
+}
+
+export default function ContextPreview() {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light')
+
+  return (
+    <ThemeContext.Provider value={theme}>
+      <div className="space-y-3">
+        <div className="flex items-center gap-3">
+          <ThemedCard />
+          <ThemedBadge />
+        </div>
+        <button
+          className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 active:scale-95"
+          onClick={() => setTheme((t) => (t === 'light' ? 'dark' : 'light'))}
+        >
+          テーマ切替
+        </button>
+        <p className="text-xs text-slate-500">Context で複数コンポーネントにテーマを共有</p>
+      </div>
+    </ThemeContext.Provider>
+  )
+}

--- a/apps/web/src/features/learning/previews/CounterPreview.tsx
+++ b/apps/web/src/features/learning/previews/CounterPreview.tsx
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+
+export default function CounterPreview() {
+  const [count, setCount] = useState(0)
+
+  return (
+    <div className="space-y-3">
+      <p className="text-2xl font-bold text-slate-800">{count}</p>
+      <div className="flex gap-2">
+        <button
+          className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95"
+          onClick={() => setCount((c) => c + 1)}
+        >
+          +1
+        </button>
+        <button
+          className="rounded-lg bg-slate-600 px-4 py-2 text-sm font-medium text-white hover:bg-slate-700 active:scale-95"
+          onClick={() => setCount((c) => c - 1)}
+        >
+          -1
+        </button>
+        <button
+          className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 active:scale-95"
+          onClick={() => setCount(0)}
+        >
+          リセット
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/CustomHookPreview.tsx
+++ b/apps/web/src/features/learning/previews/CustomHookPreview.tsx
@@ -1,0 +1,37 @@
+import { useState, useCallback } from 'react'
+
+function useToggle(initial = false): [boolean, () => void] {
+  const [value, setValue] = useState(initial)
+  const toggle = useCallback(() => setValue((v) => !v), [])
+  return [value, toggle]
+}
+
+export default function CustomHookPreview() {
+  const [isDark, toggleDark] = useToggle(false)
+  const [isOpen, toggleOpen] = useToggle(false)
+
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-3">
+        <button
+          className={`rounded-lg px-4 py-2 text-sm font-medium active:scale-95 ${isDark ? 'bg-slate-800 text-white' : 'bg-slate-200 text-slate-800'}`}
+          onClick={toggleDark}
+        >
+          {isDark ? '🌙 Dark' : '☀️ Light'}
+        </button>
+        <button
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 active:scale-95"
+          onClick={toggleOpen}
+        >
+          {isOpen ? 'パネルを閉じる' : 'パネルを開く'}
+        </button>
+      </div>
+      {isOpen && (
+        <div className={`rounded-md border px-3 py-2 text-sm ${isDark ? 'border-slate-600 bg-slate-800 text-white' : 'border-slate-200 bg-white text-slate-700'}`}>
+          useToggle フックで状態管理を再利用しています
+        </div>
+      )}
+      <p className="text-xs text-slate-500">同じ useToggle を2箇所で使用</p>
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/EffectPreview.tsx
+++ b/apps/web/src/features/learning/previews/EffectPreview.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+
+export default function EffectPreview() {
+  const [seconds, setSeconds] = useState(0)
+  const [running, setRunning] = useState(false)
+
+  useEffect(() => {
+    if (!running) return
+    const id = setInterval(() => setSeconds((s) => s + 1), 1000)
+    return () => clearInterval(id)
+  }, [running])
+
+  return (
+    <div className="space-y-3">
+      <p className="text-2xl font-mono font-bold text-slate-800">{seconds}s</p>
+      <div className="flex gap-2">
+        <button
+          className={`rounded-lg px-4 py-2 text-sm font-medium text-white active:scale-95 ${running ? 'bg-amber-600 hover:bg-amber-700' : 'bg-emerald-600 hover:bg-emerald-700'}`}
+          onClick={() => setRunning((r) => !r)}
+        >
+          {running ? '停止' : '開始'}
+        </button>
+        <button
+          className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 active:scale-95"
+          onClick={() => {
+            setRunning(false)
+            setSeconds(0)
+          }}
+        >
+          リセット
+        </button>
+      </div>
+      <p className="text-xs text-slate-500">useEffect でタイマーの副作用を管理しています</p>
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/EventPreview.tsx
+++ b/apps/web/src/features/learning/previews/EventPreview.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react'
+
+export default function EventPreview() {
+  const [message, setMessage] = useState('ボタンをクリックしてみましょう')
+  const [hovered, setHovered] = useState(false)
+
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-slate-700">{message}</p>
+      <div className="flex gap-2">
+        <button
+          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 active:scale-95"
+          onClick={() => setMessage('クリックされました！')}
+        >
+          Click
+        </button>
+        <button
+          className={`rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors ${hovered ? 'bg-purple-600' : 'bg-slate-500'}`}
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
+        >
+          Hover me
+        </button>
+      </div>
+      {hovered && <p className="text-xs text-purple-600">ホバー中です！</p>}
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/FormPreview.tsx
+++ b/apps/web/src/features/learning/previews/FormPreview.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react'
+
+export default function FormPreview() {
+  const [name, setName] = useState('')
+  const [email, setEmail] = useState('')
+  const [submitted, setSubmitted] = useState(false)
+
+  const isValid = name.trim().length > 0 && email.includes('@')
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (isValid) setSubmitted(true)
+  }
+
+  if (submitted) {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-emerald-700">送信完了！</p>
+        <p className="text-xs text-slate-600">名前: {name} / メール: {email}</p>
+        <button
+          className="rounded-lg border border-slate-300 px-3 py-1 text-sm text-slate-700 hover:bg-slate-100"
+          onClick={() => {
+            setName('')
+            setEmail('')
+            setSubmitted(false)
+          }}
+        >
+          リセット
+        </button>
+      </div>
+    )
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <div>
+        <label className="block text-xs font-medium text-slate-600">名前</label>
+        <input
+          className="mt-1 w-full rounded border border-slate-300 px-2 py-1 text-sm"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block text-xs font-medium text-slate-600">メール</label>
+        <input
+          className="mt-1 w-full rounded border border-slate-300 px-2 py-1 text-sm"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+      </div>
+      <button
+        type="submit"
+        disabled={!isValid}
+        className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        送信
+      </button>
+      {!isValid && (name.length > 0 || email.length > 0) && (
+        <p className="text-xs text-amber-600">名前と有効なメールアドレスを入力してください</p>
+      )}
+    </form>
+  )
+}

--- a/apps/web/src/features/learning/previews/ListPreview.tsx
+++ b/apps/web/src/features/learning/previews/ListPreview.tsx
@@ -1,0 +1,50 @@
+import { useState } from 'react'
+
+const initialFruits = ['りんご', 'バナナ', 'オレンジ']
+
+export default function ListPreview() {
+  const [fruits, setFruits] = useState(initialFruits)
+  const [input, setInput] = useState('')
+
+  function handleAdd() {
+    const trimmed = input.trim()
+    if (trimmed) {
+      setFruits((prev) => [...prev, trimmed])
+      setInput('')
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <ul className="space-y-1">
+        {fruits.map((fruit, i) => (
+          <li key={i} className="flex items-center gap-2 text-sm text-slate-700">
+            <span className="text-emerald-500">•</span>
+            {fruit}
+            <button
+              className="text-xs text-rose-400 hover:text-rose-600"
+              onClick={() => setFruits((prev) => prev.filter((_, j) => j !== i))}
+            >
+              削除
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div className="flex gap-2">
+        <input
+          className="rounded border border-slate-300 px-2 py-1 text-sm"
+          placeholder="フルーツ名"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleAdd()}
+        />
+        <button
+          className="rounded-lg bg-emerald-600 px-3 py-1 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95"
+          onClick={handleAdd}
+        >
+          追加
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/PerformancePreview.tsx
+++ b/apps/web/src/features/learning/previews/PerformancePreview.tsx
@@ -1,0 +1,37 @@
+import { useMemo, useState } from 'react'
+
+function heavyCompute(n: number): number {
+  let result = 0
+  for (let i = 0; i < n * 100; i++) result += i
+  return result
+}
+
+export default function PerformancePreview() {
+  const [count, setCount] = useState(10)
+  const [color, setColor] = useState('emerald')
+
+  const computed = useMemo(() => heavyCompute(count), [count])
+
+  return (
+    <div className="space-y-3">
+      <div className={`rounded-md border px-3 py-2 text-sm ${color === 'emerald' ? 'border-emerald-200 bg-emerald-50 text-emerald-800' : 'border-blue-200 bg-blue-50 text-blue-800'}`}>
+        計算結果: <span className="font-bold">{computed.toLocaleString()}</span>
+      </div>
+      <div className="flex gap-2">
+        <button
+          className="rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95"
+          onClick={() => setCount((c) => c + 10)}
+        >
+          計算量を増やす ({count})
+        </button>
+        <button
+          className="rounded-lg bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 active:scale-95"
+          onClick={() => setColor((c) => (c === 'emerald' ? 'blue' : 'emerald'))}
+        >
+          色を切替
+        </button>
+      </div>
+      <p className="text-xs text-slate-500">色を切替えても useMemo で再計算をスキップ</p>
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/ReducerPreview.tsx
+++ b/apps/web/src/features/learning/previews/ReducerPreview.tsx
@@ -1,0 +1,50 @@
+import { useReducer } from 'react'
+
+type State = { count: number; history: string[] }
+type Action = { type: 'increment' } | { type: 'decrement' } | { type: 'reset' }
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'increment':
+      return { count: state.count + 1, history: [...state.history, '+1'] }
+    case 'decrement':
+      return { count: state.count - 1, history: [...state.history, '-1'] }
+    case 'reset':
+      return { count: 0, history: [...state.history, 'reset'] }
+  }
+}
+
+export default function ReducerPreview() {
+  const [state, dispatch] = useReducer(reducer, { count: 0, history: [] })
+
+  return (
+    <div className="space-y-3">
+      <p className="text-2xl font-bold text-slate-800">{state.count}</p>
+      <div className="flex gap-2">
+        <button
+          className="rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95"
+          onClick={() => dispatch({ type: 'increment' })}
+        >
+          +1
+        </button>
+        <button
+          className="rounded-lg bg-slate-600 px-3 py-2 text-sm font-medium text-white hover:bg-slate-700 active:scale-95"
+          onClick={() => dispatch({ type: 'decrement' })}
+        >
+          -1
+        </button>
+        <button
+          className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 active:scale-95"
+          onClick={() => dispatch({ type: 'reset' })}
+        >
+          リセット
+        </button>
+      </div>
+      {state.history.length > 0 && (
+        <p className="text-xs text-slate-500">
+          履歴: {state.history.slice(-5).join(' → ')}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/TestingPreview.tsx
+++ b/apps/web/src/features/learning/previews/TestingPreview.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react'
+
+export default function TestingPreview() {
+  const [result, setResult] = useState<'idle' | 'pass' | 'fail'>('idle')
+  const [running, setRunning] = useState(false)
+
+  function runTests() {
+    setRunning(true)
+    setResult('idle')
+    setTimeout(() => {
+      setResult('pass')
+      setRunning(false)
+    }, 1200)
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="rounded-md border border-slate-200 bg-slate-900 p-3 font-mono text-xs text-slate-300">
+        <p>describe(&quot;Counter&quot;, () =&gt; {'{'}</p>
+        <p className="ml-4">it(&quot;increments on click&quot;, () =&gt; {'{'}</p>
+        <p className="ml-8">render(&lt;Counter /&gt;);</p>
+        <p className="ml-8">fireEvent.click(screen.getByText(&quot;+1&quot;));</p>
+        <p className="ml-8">expect(screen.getByText(&quot;1&quot;)).toBeInTheDocument();</p>
+        <p className="ml-4">{'}'});</p>
+        <p>{'}'});</p>
+      </div>
+      <div className="flex items-center gap-3">
+        <button
+          className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95 disabled:opacity-50"
+          onClick={runTests}
+          disabled={running}
+        >
+          {running ? 'テスト実行中…' : 'テストを実行'}
+        </button>
+        {result === 'pass' && (
+          <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700">
+            PASS ✓
+          </span>
+        )}
+        {result === 'fail' && (
+          <span className="rounded-full bg-rose-100 px-2 py-0.5 text-xs font-medium text-rose-700">
+            FAIL ✗
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/features/learning/previews/index.ts
+++ b/apps/web/src/features/learning/previews/index.ts
@@ -1,0 +1,25 @@
+import { lazy } from 'react'
+import type { ComponentType } from 'react'
+
+export const previewComponentByStepId: Record<string, React.LazyExoticComponent<ComponentType>> = {
+  'usestate-basic': lazy(() => import('./CounterPreview')),
+  events: lazy(() => import('./EventPreview')),
+  conditional: lazy(() => import('./ConditionalPreview')),
+  lists: lazy(() => import('./ListPreview')),
+  useeffect: lazy(() => import('./EffectPreview')),
+  forms: lazy(() => import('./FormPreview')),
+  usecontext: lazy(() => import('./ContextPreview')),
+  usereducer: lazy(() => import('./ReducerPreview')),
+  'custom-hooks': lazy(() => import('./CustomHookPreview')),
+  'api-fetch': lazy(() => import('./ApiFetchPreview')),
+  performance: lazy(() => import('./PerformancePreview')),
+  testing: lazy(() => import('./TestingPreview')),
+  'api-counter-get': lazy(() => import('./ApiCounterGetPreview')),
+  'api-counter-post': lazy(() => import('./ApiCounterPostPreview')),
+  'api-tasks-list': lazy(() => import('./ApiTaskListPreview')),
+  'api-tasks-create': lazy(() => import('./ApiTaskCreatePreview')),
+  'api-tasks-update': lazy(() => import('./ApiTaskUpdatePreview')),
+  'api-tasks-delete': lazy(() => import('./ApiTaskDeletePreview')),
+  'api-custom-hook': lazy(() => import('./ApiCustomHookPreview')),
+  'api-error-loading': lazy(() => import('./ApiErrorLoadingPreview')),
+}


### PR DESCRIPTION
## Summary
- テストモード合格後に、stepId ごとのインタラクティブなライブプレビューコンポーネントを表示
- 全20ステップ分のプレビューを `previews/` ディレクトリに追加（React.lazy で遅延読み込み）
- API系ステップはモックデータで動作シミュレート（実API呼び出しなし）

## 変更内容
- `TestMode.tsx`: Suspense + lazy コンポーネント表示を既存の emerald ボックス内に追加
- `previews/index.ts`: stepId → lazy component マッピング
- `previews/*.tsx`: 20個のインタラクティブプレビューコンポーネント（各15〜50行）

## Test plan
- [x] `npm run typecheck` — PASS
- [x] `npm run lint` — PASS
- [x] `npm run test` — 247 tests PASS
- [x] `npm run build` — 成功（プレビューが個別チャンクとして分割されることを確認）

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)