### PR TITLE
feat: モード完了後の「次のモードへ進む」ボタン追加

### DIFF
--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -291,6 +291,18 @@ export function StepPage() {
               />
             ) : null}
 
+            {activeMode === 'read' && modeStatus.read ? (
+              <div className="mt-4 flex justify-center">
+                <button
+                  className="inline-flex items-center gap-2 rounded-xl bg-amber-400 px-6 py-3 text-base font-bold text-slate-950 shadow-sm transition-all duration-200 hover:bg-amber-500 active:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-300/30"
+                  type="button"
+                  onClick={() => setActiveMode('practice')}
+                >
+                  Practice へ進む →
+                </button>
+              </div>
+            ) : null}
+
             {activeMode === 'practice' ? (
               <PracticeMode
                 stepId={step.id}
@@ -299,8 +311,32 @@ export function StepPage() {
               />
             ) : null}
 
+            {activeMode === 'practice' && modeStatus.practice ? (
+              <div className="mt-4 flex justify-center">
+                <button
+                  className="inline-flex items-center gap-2 rounded-xl bg-sky-500 px-6 py-3 text-base font-bold text-white shadow-sm transition-all duration-200 hover:bg-sky-600 active:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-400/30"
+                  type="button"
+                  onClick={() => setActiveMode('test')}
+                >
+                  Test へ進む →
+                </button>
+              </div>
+            ) : null}
+
             {activeMode === 'test' ? (
               <TestMode stepId={step.id} task={step.testTask} onComplete={() => void handleModeComplete('test')} />
+            ) : null}
+
+            {activeMode === 'test' && modeStatus.test ? (
+              <div className="mt-4 flex justify-center">
+                <button
+                  className="inline-flex items-center gap-2 rounded-xl bg-violet-500 px-6 py-3 text-base font-bold text-white shadow-sm transition-all duration-200 hover:bg-violet-600 active:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-violet-400/30"
+                  type="button"
+                  onClick={() => setActiveMode('challenge')}
+                >
+                  Challenge へ進む →
+                </button>
+              </div>
             ) : null}
 
             {activeMode === 'challenge' ? (


### PR DESCRIPTION
## Summary
- Read/Practice/Test 完了時に次モードへの遷移ボタンを表示
- 各ボタンは次モードのテーマ色（amber/sky/violet）を使用し、視覚的に誘導
- StepPage.tsx のみの変更で、既存の `modeStatus` state を活用

## Test plan
- [x] `npm run typecheck` PASS
- [x] `npm run lint` PASS
- [x] `npm run test` 247 tests PASS
- [x] `npm run build` PASS
- [ ] 手動確認: Read完了後に「Practice へ進む →」ボタン表示・クリックでモード切替
- [ ] 手動確認: Practice全問正解後に「Test へ進む →」ボタン表示
- [ ] 手動確認: Test合格後に「Challenge へ進む →」ボタン表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)