### PR TITLE
feat: CATEGORIES 3層構造に一括移行

### DIFF
--- a/apps/web/src/content/__tests__/stepWalkthrough.test.ts
+++ b/apps/web/src/content/__tests__/stepWalkthrough.test.ts
@@ -12,11 +12,24 @@
  * 4. order の連続性（1〜20 が重複なく揃っている）
  * 5. courseData の順序と content の order が一致する
  * 6. getNextStep ナビゲーションが全ステップで正しく動作する
- * 7. course-4-complete / all-complete の実績判定が正しい
+ * 7. コース完了 / all-complete の実績判定が正しい
+ * 8. CATEGORIES 3層構造の整合性
  */
 
 import { describe, it, expect } from 'vitest'
-import { COURSES, TOTAL_STEP_COUNT, IMPLEMENTED_STEP_COUNT, getNextStep, findStepMeta } from '../courseData'
+import {
+  CATEGORIES,
+  getAllCourses,
+  getAllSteps,
+  TOTAL_STEP_COUNT,
+  IMPLEMENTED_STEP_COUNT,
+  getNextStep,
+  findStepById,
+  findCourseById,
+  findCategoryById,
+  findCourseByStepId,
+  findCategoryByStepId,
+} from '../courseData'
 import { fundamentalsSteps, getFundamentalsStep } from '../fundamentals/steps'
 import { intermediateSteps, getIntermediateStep } from '../intermediate/steps'
 import { advancedSteps, getAdvancedStep } from '../advanced/steps'
@@ -32,7 +45,7 @@ const allContentSteps: LearningStepContent[] = [
 ].sort((a, b) => a.order - b.order)
 
 // courseData の全ステップ（フラット）
-const allCourseSteps = COURSES.flatMap((c) => c.steps)
+const allCourseSteps = getAllSteps()
 
 // ─────────────────────────────────────────
 // 1. courseData 整合性
@@ -160,42 +173,42 @@ describe('order と courseData の整合性', () => {
     }
   })
 
-  it('course-1: order 1-4 が fundamentalsSteps に含まれる', () => {
-    const course1 = COURSES.find((c) => c.id === 'course-1')!
-    for (const meta of course1.steps) {
+  it('react-fundamentals: order 1-4 が fundamentalsSteps に含まれる', () => {
+    const course = findCourseById('react-fundamentals')!
+    for (const meta of course.steps) {
       expect(getFundamentalsStep(meta.id), `${meta.id} が fundamentalsSteps にない`).toBeDefined()
     }
   })
 
-  it('course-2: order 5-8 が intermediateSteps に含まれる', () => {
-    const course2 = COURSES.find((c) => c.id === 'course-2')!
-    for (const meta of course2.steps) {
+  it('react-hooks: order 5-8 が intermediateSteps に含まれる', () => {
+    const course = findCourseById('react-hooks')!
+    for (const meta of course.steps) {
       expect(getIntermediateStep(meta.id), `${meta.id} が intermediateSteps にない`).toBeDefined()
     }
   })
 
-  it('course-3: order 9-12 が advancedSteps に含まれる', () => {
-    const course3 = COURSES.find((c) => c.id === 'course-3')!
-    for (const meta of course3.steps) {
+  it('react-advanced: order 9-12 が advancedSteps に含まれる', () => {
+    const course = findCourseById('react-advanced')!
+    for (const meta of course.steps) {
       expect(getAdvancedStep(meta.id), `${meta.id} が advancedSteps にない`).toBeDefined()
     }
   })
 
-  it('course-4: order 13-20 が apiPracticeSteps に含まれる', () => {
-    const course4 = COURSES.find((c) => c.id === 'course-4')!
-    for (const meta of course4.steps) {
+  it('react-api: order 13-20 が apiPracticeSteps に含まれる', () => {
+    const course = findCourseById('react-api')!
+    for (const meta of course.steps) {
       expect(getApiPracticeStep(meta.id), `${meta.id} が apiPracticeSteps にない`).toBeDefined()
     }
   })
 })
 
 // ─────────────────────────────────────────
-// 5. ナビゲーション（getNextStep / findStepMeta）
+// 5. ナビゲーション（getNextStep / findStepById）
 // ─────────────────────────────────────────
 describe('ナビゲーション整合性', () => {
-  it('findStepMeta が全20 stepId を解決できる', () => {
+  it('findStepById が全20 stepId を解決できる', () => {
     for (const step of allCourseSteps) {
-      const meta = findStepMeta(step.id)
+      const meta = findStepById(step.id)
       expect(meta, `${step.id} の stepMeta が見つからない`).toBeDefined()
       expect(meta?.id).toBe(step.id)
     }
@@ -217,29 +230,28 @@ describe('ナビゲーション整合性', () => {
 })
 
 // ─────────────────────────────────────────
-// 6. course-4 / all-complete バッジ判定ロジック検証
+// 6. コース完了 / all-complete バッジ判定ロジック検証
 // ─────────────────────────────────────────
 describe('実績バッジ判定のデータ整合性', () => {
-  it('course-4 の全8ステップが isImplemented: true', () => {
-    const course4 = COURSES.find((c) => c.id === 'course-4')!
-    expect(course4.steps).toHaveLength(8)
-    expect(course4.steps.every((s) => s.isImplemented)).toBe(true)
+  it('react-api の全8ステップが isImplemented: true', () => {
+    const course = findCourseById('react-api')!
+    expect(course.steps).toHaveLength(8)
+    expect(course.steps.every((s) => s.isImplemented)).toBe(true)
   })
 
-  it('course-4 の全ステップに apiPracticeSteps コンテンツが存在する', () => {
-    const course4 = COURSES.find((c) => c.id === 'course-4')!
-    for (const step of course4.steps) {
+  it('react-api の全ステップに apiPracticeSteps コンテンツが存在する', () => {
+    const course = findCourseById('react-api')!
+    for (const step of course.steps) {
       expect(getApiPracticeStep(step.id), `${step.id} のコンテンツがない`).toBeDefined()
     }
   })
 
   it('全20ステップの stepId が all-complete 判定に必要な配列に含まれる', () => {
-    // achievementService の ALL_STEP_IDS と同等の計算
-    const allStepIds = new Set(COURSES.flatMap((c) => c.steps.map((s) => s.id)))
+    const allStepIds = new Set(getAllSteps().map((s) => s.id))
     expect(allStepIds.size).toBe(20)
 
     for (const step of allContentSteps) {
-      expect(allStepIds.has(step.id), `${step.id} が ALL_STEP_IDS に含まれない`).toBe(true)
+      expect(allStepIds.has(step.id), `${step.id} が getAllSteps() に含まれない`).toBe(true)
     }
   })
 })
@@ -247,7 +259,7 @@ describe('実績バッジ判定のデータ整合性', () => {
 // ─────────────────────────────────────────
 // 7. コース間境界 / API連携コースの API 文法検証
 // ─────────────────────────────────────────
-describe('API連携コース（course-4）コンテンツ固有検証', () => {
+describe('API連携コース（react-api）コンテンツ固有検証', () => {
   const course4Steps = apiPracticeSteps.sort((a, b) => a.order - b.order)
 
   it('api-tasks-update: PATCH が expectedKeywords に含まれる', () => {
@@ -270,9 +282,63 @@ describe('API連携コース（course-4）コンテンツ固有検証', () => {
     expect(step.testTask.expectedKeywords).toContain('dispatch')
   })
 
-  it('course-4 の各ステップの starterCode に ____ ブランクが含まれる', () => {
+  it('react-api の各ステップの starterCode に ____ ブランクが含まれる', () => {
     for (const step of course4Steps) {
       expect(step.testTask.starterCode, `${step.id}: starterCode に ____ がない`).toContain('____')
+    }
+  })
+})
+
+// ─────────────────────────────────────────
+// 8. CATEGORIES 3層構造の整合性
+// ─────────────────────────────────────────
+describe('CATEGORIES 3層構造', () => {
+  it('react カテゴリに4コースが含まれる', () => {
+    const react = findCategoryById('react')!
+    expect(react.courses).toHaveLength(4)
+    expect(react.courses.map((c) => c.id)).toEqual([
+      'react-fundamentals',
+      'react-hooks',
+      'react-advanced',
+      'react-api',
+    ])
+  })
+
+  it('typescript カテゴリに2コースが含まれる', () => {
+    const ts = findCategoryById('typescript')!
+    expect(ts.courses).toHaveLength(2)
+    expect(ts.courses.map((c) => c.id)).toEqual(['ts-basics', 'ts-react'])
+  })
+
+  it('getAllCourses が全6コースを返す', () => {
+    expect(getAllCourses()).toHaveLength(6)
+  })
+
+  it('findCourseByStepId が正しいコースを返す', () => {
+    expect(findCourseByStepId('usestate-basic')?.id).toBe('react-fundamentals')
+    expect(findCourseByStepId('useeffect')?.id).toBe('react-hooks')
+    expect(findCourseByStepId('custom-hooks')?.id).toBe('react-advanced')
+    expect(findCourseByStepId('api-counter-get')?.id).toBe('react-api')
+  })
+
+  it('findCategoryByStepId が正しいカテゴリを返す', () => {
+    expect(findCategoryByStepId('usestate-basic')?.id).toBe('react')
+    expect(findCategoryByStepId('api-counter-get')?.id).toBe('react')
+  })
+
+  it('各カテゴリが id / title / description / icon を持つ', () => {
+    for (const cat of CATEGORIES) {
+      expect(cat.id).toBeTruthy()
+      expect(cat.title).toBeTruthy()
+      expect(cat.description).toBeTruthy()
+      expect(cat.icon).toBeTruthy()
+    }
+  })
+
+  it('各コースが requiredPrerequisites / recommendedPrerequisites を持つ', () => {
+    for (const course of getAllCourses()) {
+      expect(Array.isArray(course.requiredPrerequisites)).toBe(true)
+      expect(Array.isArray(course.recommendedPrerequisites)).toBe(true)
     }
   })
 })

--- a/apps/web/src/content/courseData.ts
+++ b/apps/web/src/content/courseData.ts
@@ -13,201 +13,311 @@ export interface CourseMeta {
   title: string
   level: CourseLevel
   steps: StepMeta[]
+  /** 必須前提コース ID（未完了→コース全体ロック） */
+  requiredPrerequisites: string[]
+  /** 推奨前提コース ID（未完了→警告のみ） */
+  recommendedPrerequisites: string[]
 }
 
-export const COURSES: CourseMeta[] = [
+export interface CategoryMeta {
+  id: string
+  title: string
+  description: string
+  icon: string
+  courses: CourseMeta[]
+}
+
+// ─────────────────────────────────────────
+// CATEGORIES: v2 の3層構造データ
+// ─────────────────────────────────────────
+export const CATEGORIES: CategoryMeta[] = [
   {
-    id: 'course-1',
-    title: 'React基礎',
-    level: 'beginner',
-    steps: [
+    id: 'react',
+    title: 'React',
+    description: 'Reactの基礎から実践まで、段階的に学べるコース群',
+    icon: 'Atom',
+    courses: [
       {
-        id: 'usestate-basic',
-        order: 1,
-        title: 'useState基礎',
-        description: '状態管理の基本を学び、コンポーネントに記憶を持たせる方法を理解します。',
-        isImplemented: true,
+        id: 'react-fundamentals',
+        title: 'React基礎',
+        level: 'beginner',
+        requiredPrerequisites: [],
+        recommendedPrerequisites: [],
+        steps: [
+          {
+            id: 'usestate-basic',
+            order: 1,
+            title: 'useState基礎',
+            description: '状態管理の基本を学び、コンポーネントに記憶を持たせる方法を理解します。',
+            isImplemented: true,
+          },
+          {
+            id: 'events',
+            order: 2,
+            title: 'イベント処理',
+            description: 'クリックや入力イベントを扱い、ユーザー操作に反応する実装を行います。',
+            isImplemented: true,
+          },
+          {
+            id: 'conditional',
+            order: 3,
+            title: '条件付きレンダリング',
+            description: '条件に応じた表示切り替えで、UIの分岐を実装します。',
+            isImplemented: true,
+          },
+          {
+            id: 'lists',
+            order: 4,
+            title: 'リスト表示',
+            description: '配列データを効率的に描画し、keyの基本を理解します。',
+            isImplemented: true,
+          },
+        ],
       },
       {
-        id: 'events',
-        order: 2,
-        title: 'イベント処理',
-        description: 'クリックや入力イベントを扱い、ユーザー操作に反応する実装を行います。',
-        isImplemented: true,
+        id: 'react-hooks',
+        title: 'React応用',
+        level: 'intermediate',
+        requiredPrerequisites: ['react-fundamentals'],
+        recommendedPrerequisites: [],
+        steps: [
+          {
+            id: 'useeffect',
+            order: 5,
+            title: 'useEffect',
+            description: '副作用とライフサイクルを理解し、データ取得や購読処理を実装します。',
+            isImplemented: true,
+          },
+          {
+            id: 'forms',
+            order: 6,
+            title: 'フォーム処理',
+            description: '入力値の管理とバリデーションを実装し、実用的なフォームを作ります。',
+            isImplemented: true,
+          },
+          {
+            id: 'usecontext',
+            order: 7,
+            title: 'useContext',
+            description: 'コンテキストAPIでグローバル状態を管理し、prop drillingを解消します。',
+            isImplemented: true,
+          },
+          {
+            id: 'usereducer',
+            order: 8,
+            title: 'useReducer',
+            description: '複雑な状態ロジックをreducerパターンで整理します。',
+            isImplemented: true,
+          },
+        ],
       },
       {
-        id: 'conditional',
-        order: 3,
-        title: '条件付きレンダリング',
-        description: '条件に応じた表示切り替えで、UIの分岐を実装します。',
-        isImplemented: true,
+        id: 'react-advanced',
+        title: 'React実践',
+        level: 'advanced',
+        requiredPrerequisites: ['react-hooks'],
+        recommendedPrerequisites: [],
+        steps: [
+          {
+            id: 'custom-hooks',
+            order: 9,
+            title: 'カスタムHooks',
+            description: '再利用可能なロジックをカスタムHookとして切り出します。',
+            isImplemented: true,
+          },
+          {
+            id: 'api-fetch',
+            order: 10,
+            title: 'API連携',
+            description: 'データ取得とローディング状態の管理を実践します。',
+            isImplemented: true,
+          },
+          {
+            id: 'performance',
+            order: 11,
+            title: 'パフォーマンス最適化',
+            description: 'useMemo/useCallbackで不要な再レンダリングを防ぎます。',
+            isImplemented: true,
+          },
+          {
+            id: 'testing',
+            order: 12,
+            title: 'テスト入門',
+            description: 'React Testing Libraryでコンポーネントのテストを書きます。',
+            isImplemented: true,
+          },
+        ],
       },
       {
-        id: 'lists',
-        order: 4,
-        title: 'リスト表示',
-        description: '配列データを効率的に描画し、keyの基本を理解します。',
-        isImplemented: true,
+        id: 'react-api',
+        title: 'API連携実践',
+        level: 'intermediate',
+        requiredPrerequisites: ['react-fundamentals'],
+        recommendedPrerequisites: ['react-hooks'],
+        steps: [
+          {
+            id: 'api-counter-get',
+            order: 13,
+            title: 'カウンターAPI (GET)',
+            description: 'APIからデータを取得し、画面に表示する基本パターンを学びます。',
+            isImplemented: true,
+          },
+          {
+            id: 'api-counter-post',
+            order: 14,
+            title: 'カウンターAPI (POST)',
+            description: 'APIにデータを送信し、サーバーの状態を更新します。',
+            isImplemented: true,
+          },
+          {
+            id: 'api-tasks-list',
+            order: 15,
+            title: 'タスク一覧 (GET)',
+            description: 'リストデータを取得して一覧表示するパターンを実装します。',
+            isImplemented: true,
+          },
+          {
+            id: 'api-tasks-create',
+            order: 16,
+            title: 'タスク追加 (POST)',
+            description: 'フォームからデータを送信し、リストに追加する処理を実装します。',
+            isImplemented: true,
+          },
+          {
+            id: 'api-tasks-update',
+            order: 17,
+            title: 'タスク更新 (PATCH)',
+            description: '完了状態の切り替えなど、既存データの更新処理を実装します。',
+            isImplemented: true,
+          },
+          {
+            id: 'api-tasks-delete',
+            order: 18,
+            title: 'タスク削除 (DELETE)',
+            description: 'APIで削除処理を行い、リストから即時除去するUIを実装します。',
+            isImplemented: true,
+          },
+          {
+            id: 'api-custom-hook',
+            order: 19,
+            title: 'useTasksフック',
+            description: 'API操作をカスタムフックに集約し、コンポーネントをシンプルに保ちます。',
+            isImplemented: true,
+          },
+          {
+            id: 'api-error-loading',
+            order: 20,
+            title: 'エラー/ローディングUI',
+            description: 'APIの通信状態に応じたUI表示を実装し、UXを向上させます。',
+            isImplemented: true,
+          },
+        ],
       },
     ],
   },
   {
-    id: 'course-2',
-    title: 'React応用',
-    level: 'intermediate',
-    steps: [
+    id: 'typescript',
+    title: 'TypeScript',
+    description: 'TypeScriptの型システムを基礎から学び、React開発に活かす',
+    icon: 'FileCode',
+    courses: [
       {
-        id: 'useeffect',
-        order: 5,
-        title: 'useEffect',
-        description: '副作用とライフサイクルを理解し、データ取得や購読処理を実装します。',
-        isImplemented: true,
+        id: 'ts-basics',
+        title: 'TypeScript基礎',
+        level: 'beginner',
+        requiredPrerequisites: [],
+        recommendedPrerequisites: [],
+        steps: [],
       },
       {
-        id: 'forms',
-        order: 6,
-        title: 'フォーム処理',
-        description: '入力値の管理とバリデーションを実装し、実用的なフォームを作ります。',
-        isImplemented: true,
-      },
-      {
-        id: 'usecontext',
-        order: 7,
-        title: 'useContext',
-        description: 'コンテキストAPIでグローバル状態を管理し、prop drillingを解消します。',
-        isImplemented: true,
-      },
-      {
-        id: 'usereducer',
-        order: 8,
-        title: 'useReducer',
-        description: '複雑な状態ロジックをreducerパターンで整理します。',
-        isImplemented: true,
-      },
-    ],
-  },
-  {
-    id: 'course-3',
-    title: 'React実践',
-    level: 'advanced',
-    steps: [
-      {
-        id: 'custom-hooks',
-        order: 9,
-        title: 'カスタムHooks',
-        description: '再利用可能なロジックをカスタムHookとして切り出します。',
-        isImplemented: true,
-      },
-      {
-        id: 'api-fetch',
-        order: 10,
-        title: 'API連携',
-        description: 'データ取得とローディング状態の管理を実践します。',
-        isImplemented: true,
-      },
-      {
-        id: 'performance',
-        order: 11,
-        title: 'パフォーマンス最適化',
-        description: 'useMemo/useCallbackで不要な再レンダリングを防ぎます。',
-        isImplemented: true,
-      },
-      {
-        id: 'testing',
-        order: 12,
-        title: 'テスト入門',
-        description: 'React Testing Libraryでコンポーネントのテストを書きます。',
-        isImplemented: true,
-      },
-    ],
-  },
-  {
-    id: 'course-4',
-    title: 'API連携実践',
-    level: 'intermediate',
-    steps: [
-      {
-        id: 'api-counter-get',
-        order: 13,
-        title: 'カウンターAPI (GET)',
-        description: 'APIからデータを取得し、画面に表示する基本パターンを学びます。',
-        isImplemented: true,
-      },
-      {
-        id: 'api-counter-post',
-        order: 14,
-        title: 'カウンターAPI (POST)',
-        description: 'APIにデータを送信し、サーバーの状態を更新します。',
-        isImplemented: true,
-      },
-      {
-        id: 'api-tasks-list',
-        order: 15,
-        title: 'タスク一覧 (GET)',
-        description: 'リストデータを取得して一覧表示するパターンを実装します。',
-        isImplemented: true,
-      },
-      {
-        id: 'api-tasks-create',
-        order: 16,
-        title: 'タスク追加 (POST)',
-        description: 'フォームからデータを送信し、リストに追加する処理を実装します。',
-        isImplemented: true,
-      },
-      {
-        id: 'api-tasks-update',
-        order: 17,
-        title: 'タスク更新 (PATCH)',
-        description: '完了状態の切り替えなど、既存データの更新処理を実装します。',
-        isImplemented: true,
-      },
-      {
-        id: 'api-tasks-delete',
-        order: 18,
-        title: 'タスク削除 (DELETE)',
-        description: 'APIで削除処理を行い、リストから即時除去するUIを実装します。',
-        isImplemented: true,
-      },
-      {
-        id: 'api-custom-hook',
-        order: 19,
-        title: 'useTasksフック',
-        description: 'API操作をカスタムフックに集約し、コンポーネントをシンプルに保ちます。',
-        isImplemented: true,
-      },
-      {
-        id: 'api-error-loading',
-        order: 20,
-        title: 'エラー/ローディングUI',
-        description: 'APIの通信状態に応じたUI表示を実装し、UXを向上させます。',
-        isImplemented: true,
+        id: 'ts-react',
+        title: 'TypeScript × React',
+        level: 'intermediate',
+        requiredPrerequisites: ['ts-basics'],
+        recommendedPrerequisites: ['react-fundamentals'],
+        steps: [],
       },
     ],
   },
 ]
 
-export const TOTAL_STEP_COUNT = COURSES.reduce((sum, course) => sum + course.steps.length, 0)
+// ─────────────────────────────────────────
+// ヘルパー関数
+// ─────────────────────────────────────────
 
-export const IMPLEMENTED_STEP_COUNT = COURSES.reduce(
-  (sum, course) => sum + course.steps.filter((s) => s.isImplemented).length,
-  0,
-)
+/** 全カテゴリの全コースをフラットに取得 */
+export function getAllCourses(): CourseMeta[] {
+  return CATEGORIES.flatMap((cat) => cat.courses)
+}
 
-export function findStepMeta(stepId: string): StepMeta | undefined {
-  for (const course of COURSES) {
-    const step = course.steps.find((s) => s.id === stepId)
-    if (step) return step
+/** 全カテゴリの全ステップをフラットに取得 */
+export function getAllSteps(): StepMeta[] {
+  return getAllCourses().flatMap((course) => course.steps)
+}
+
+/** ステップIDからステップメタを検索 */
+export function findStepById(stepId: string): StepMeta | undefined {
+  for (const cat of CATEGORIES) {
+    for (const course of cat.courses) {
+      const step = course.steps.find((s) => s.id === stepId)
+      if (step) return step
+    }
   }
   return undefined
 }
 
+/** コースIDからコースメタを検索 */
+export function findCourseById(courseId: string): CourseMeta | undefined {
+  for (const cat of CATEGORIES) {
+    const course = cat.courses.find((c) => c.id === courseId)
+    if (course) return course
+  }
+  return undefined
+}
+
+/** カテゴリIDからカテゴリメタを検索 */
+export function findCategoryById(categoryId: string): CategoryMeta | undefined {
+  return CATEGORIES.find((cat) => cat.id === categoryId)
+}
+
+/** ステップIDが属するコースを検索 */
+export function findCourseByStepId(stepId: string): CourseMeta | undefined {
+  for (const cat of CATEGORIES) {
+    for (const course of cat.courses) {
+      if (course.steps.some((s) => s.id === stepId)) return course
+    }
+  }
+  return undefined
+}
+
+/** ステップIDが属するカテゴリを検索 */
+export function findCategoryByStepId(stepId: string): CategoryMeta | undefined {
+  for (const cat of CATEGORIES) {
+    for (const course of cat.courses) {
+      if (course.steps.some((s) => s.id === stepId)) return cat
+    }
+  }
+  return undefined
+}
+
+// ─────────────────────────────────────────
+// 派生定数（後方互換）
+// ─────────────────────────────────────────
+
+export const TOTAL_STEP_COUNT = getAllSteps().length
+
+export const IMPLEMENTED_STEP_COUNT = getAllSteps().filter((s) => s.isImplemented).length
+
+/** @deprecated findStepById を使用してください */
+export const findStepMeta = findStepById
+
 export function getNextStep(currentStepId: string): StepMeta | undefined {
-  const allSteps = COURSES.flatMap((c) => c.steps)
+  const allSteps = getAllSteps()
   const currentIndex = allSteps.findIndex((s) => s.id === currentStepId)
   if (currentIndex === -1) return undefined
   return allSteps[currentIndex + 1]
 }
 
 export function getFirstImplementedStep(): StepMeta | undefined {
-  return COURSES.flatMap((course) => course.steps).find((step) => step.isImplemented)
+  return getAllSteps().find((step) => step.isImplemented)
 }

--- a/apps/web/src/features/dashboard/components/LearningOverviewCard.tsx
+++ b/apps/web/src/features/dashboard/components/LearningOverviewCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom'
 import { BookOpen, CheckCircle2, Lock, PenLine } from 'lucide-react'
-import { COURSES, TOTAL_STEP_COUNT, type CourseMeta, type StepMeta } from '@/content/courseData'
+import { getAllCourses, TOTAL_STEP_COUNT, type CourseMeta, type StepMeta } from '@/content/courseData'
 
 const LEVEL_LABEL: Record<CourseMeta['level'], string> = {
   beginner: '初級',
@@ -77,7 +77,7 @@ interface LearningOverviewCardProps {
 export function LearningOverviewCard({ completedCount }: LearningOverviewCardProps) {
   const progressPercent = Math.max(0, Math.min(100, Math.round((completedCount / TOTAL_STEP_COUNT) * 100)))
 
-  const implementedSteps = COURSES.flatMap((c) => c.steps.filter((s) => s.isImplemented))
+  const implementedSteps = getAllCourses().flatMap((c) => c.steps.filter((s) => s.isImplemented))
   const inProgressStep = completedCount < implementedSteps.length ? implementedSteps[completedCount] : null
 
   return (
@@ -110,7 +110,7 @@ export function LearningOverviewCard({ completedCount }: LearningOverviewCardPro
       </div>
 
       <div className="space-y-6">
-        {COURSES.map((course) => {
+        {getAllCourses().map((course) => {
           const hasSomeImplemented = course.steps.some((s) => s.isImplemented)
           return (
             <div key={course.id}>

--- a/apps/web/src/features/learning/__tests__/TestMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/TestMode.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TestMode } from '../TestMode'
-import { COURSES } from '../../../content/courseData'
+import { getAllCourses } from '../../../content/courseData'
 import type { TestTask } from '../../../content/fundamentals/steps'
 import { previewByStepId } from '../testModePreview'
 
@@ -60,7 +60,7 @@ describe('TestMode', () => {
   })
 
   it('実装済み全ステップにプレビュー定義が存在する', () => {
-    const implementedStepIds = COURSES.flatMap((course) => course.steps)
+    const implementedStepIds = getAllCourses().flatMap((course) => course.steps)
       .filter((step) => step.isImplemented)
       .map((step) => step.id)
 

--- a/apps/web/src/features/learning/hooks/useLearningStep.ts
+++ b/apps/web/src/features/learning/hooks/useLearningStep.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { COURSES, findStepMeta } from '@/content/courseData'
+import { findStepById, findCourseByStepId } from '@/content/courseData'
 import { fundamentalsSteps, getFundamentalsStep, type LearningMode, type LearningStepContent } from '@/content/fundamentals/steps'
 import { getIntermediateStep, intermediateSteps } from '@/content/intermediate/steps'
 import { advancedSteps, getAdvancedStep } from '@/content/advanced/steps'
@@ -53,7 +53,7 @@ export function useLearningStep(stepId: string): UseLearningStepReturn {
   const [toastMessage, setToastMessage] = useState<string | null>(null)
   const completedOnceRef = useRef(false)
 
-  const stepMeta = findStepMeta(stepId)
+  const stepMeta = findStepById(stepId)
   const step = getFundamentalsStep(stepId) || getIntermediateStep(stepId) || getAdvancedStep(stepId) || getApiPracticeStep(stepId)
   const isUnavailableStep = Boolean(stepMeta && !stepMeta.isImplemented)
 
@@ -63,7 +63,7 @@ export function useLearningStep(stepId: string): UseLearningStepReturn {
   )
 
   const currentCourse = useMemo(
-    () => COURSES.find((course) => course.steps.some((s) => s.id === (step?.id || stepId))),
+    () => findCourseByStepId(step?.id || stepId),
     [step?.id, stepId],
   )
 

--- a/apps/web/src/services/achievementService.ts
+++ b/apps/web/src/services/achievementService.ts
@@ -1,4 +1,4 @@
-import { COURSES } from '../content/courseData'
+import { getAllSteps, findCourseById } from '../content/courseData'
 import { BADGE_POINT_THRESHOLD_HIGH, BADGE_POINT_THRESHOLD_MID, STREAK_THRESHOLD_BRONZE, STREAK_THRESHOLD_GOLD, STREAK_THRESHOLD_SILVER } from '../shared/constants'
 import { supabase } from '../lib/supabaseClient'
 import { fromSupabaseError } from '../shared/errors'
@@ -26,19 +26,19 @@ export const BADGE_DEFINITIONS = [
 export type BadgeId = (typeof BADGE_DEFINITIONS)[number]['id']
 
 const BADGE_ID_SET = new Set<BadgeId>(BADGE_DEFINITIONS.map((badge) => badge.id))
-// all-complete は全20ステップ完了が条件なので未実装ステップも含む
-const ALL_STEP_IDS = COURSES.flatMap((course) => course.steps.map((step) => step.id))
+// all-complete は全ステップ完了が条件なので未実装ステップも含む
+const ALL_STEP_IDS = getAllSteps().map((step) => step.id)
 const COURSE_COMPLETION_RULES: Array<{ badgeId: BadgeId; stepIds: string[] }> = [
-  { badgeId: 'course-1-complete', stepIds: getCourseStepIds('course-1') },
-  { badgeId: 'course-2-complete', stepIds: getCourseStepIds('course-2') },
-  { badgeId: 'course-3-complete', stepIds: getCourseStepIds('course-3') },
-  { badgeId: 'course-4-complete', stepIds: getCourseStepIds('course-4') },
+  { badgeId: 'course-1-complete', stepIds: getCourseStepIds('react-fundamentals') },
+  { badgeId: 'course-2-complete', stepIds: getCourseStepIds('react-hooks') },
+  { badgeId: 'course-3-complete', stepIds: getCourseStepIds('react-advanced') },
+  { badgeId: 'course-4-complete', stepIds: getCourseStepIds('react-api') },
 ]
 
 function getCourseStepIds(courseId: string): string[] {
   // isImplemented: false のステップはバッジ判定対象外とし、未実装コースの誤解禁を防止する
   return (
-    COURSES.find((course) => course.id === courseId)
+    findCourseById(courseId)
       ?.steps.filter((step) => step.isImplemented)
       .map((step) => step.id) ?? []
   )


### PR DESCRIPTION
## Summary
- CategoryMeta 型定義 + CATEGORIES を primary data source に移行
- コース ID リネーム（course-1→react-fundamentals 等）
- ヘルパー関数 7 種作成（getAllCourses, findStepById 等）
- 既存6ファイルの参照を CATEGORIES ベースに更新
- 254 テスト全通過 / typecheck / build pass

## Test plan
- [x] typecheck pass
- [x] lint pass
- [x] 254 テスト全通過（新規 CATEGORIES 整合性テスト 7 件含む）
- [x] build pass