### PR TITLE
feat: v2 新規ルート追加とプレースホルダーページ作成

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -11,8 +11,20 @@ import { supabaseConfigError } from './lib/supabaseClient'
 import './styles/globals.css'
 
 // Route-based Code Splitting: 各ページを動的インポートでチャンク分割
+const CodeDoctorPage = lazy(() => import('./pages/CodeDoctorPage').then((m) => ({ default: m.CodeDoctorPage })))
+const CodeReadingPage = lazy(() => import('./pages/CodeReadingPage').then((m) => ({ default: m.CodeReadingPage })))
+const CurriculumPage = lazy(() => import('./pages/CurriculumPage').then((m) => ({ default: m.CurriculumPage })))
+const DailyChallengePage = lazy(() =>
+  import('./pages/DailyChallengePage').then((m) => ({ default: m.DailyChallengePage })),
+)
 const DashboardPage = lazy(() => import('./pages/DashboardPage').then((m) => ({ default: m.DashboardPage })))
 const LoginPage = lazy(() => import('./pages/LoginPage').then((m) => ({ default: m.LoginPage })))
+const MiniProjectDetailPage = lazy(() =>
+  import('./pages/MiniProjectDetailPage').then((m) => ({ default: m.MiniProjectDetailPage })),
+)
+const MiniProjectsPage = lazy(() =>
+  import('./pages/MiniProjectsPage').then((m) => ({ default: m.MiniProjectsPage })),
+)
 const NotFoundPage = lazy(() => import('./pages/NotFoundPage').then((m) => ({ default: m.NotFoundPage })))
 const ProfilePage = lazy(() => import('./pages/ProfilePage').then((m) => ({ default: m.ProfilePage })))
 const SignUpPage = lazy(() => import('./pages/SignUpPage').then((m) => ({ default: m.SignUpPage })))
@@ -70,6 +82,66 @@ const router = createBrowserRouter([
       <ProtectedRoute>
         <Suspense fallback={<PageLoading />}>
           <ProfilePage />
+        </Suspense>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/curriculum',
+    element: (
+      <ProtectedRoute>
+        <Suspense fallback={<PageLoading />}>
+          <CurriculumPage />
+        </Suspense>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/daily',
+    element: (
+      <ProtectedRoute>
+        <Suspense fallback={<PageLoading />}>
+          <DailyChallengePage />
+        </Suspense>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/practice/code-doctor',
+    element: (
+      <ProtectedRoute>
+        <Suspense fallback={<PageLoading />}>
+          <CodeDoctorPage />
+        </Suspense>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/practice/mini-projects',
+    element: (
+      <ProtectedRoute>
+        <Suspense fallback={<PageLoading />}>
+          <MiniProjectsPage />
+        </Suspense>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/practice/mini-projects/:projectId',
+    element: (
+      <ProtectedRoute>
+        <Suspense fallback={<PageLoading />}>
+          <MiniProjectDetailPage />
+        </Suspense>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/practice/code-reading',
+    element: (
+      <ProtectedRoute>
+        <Suspense fallback={<PageLoading />}>
+          <CodeReadingPage />
         </Suspense>
       </ProtectedRoute>
     ),

--- a/apps/web/src/pages/CodeDoctorPage.tsx
+++ b/apps/web/src/pages/CodeDoctorPage.tsx
@@ -1,0 +1,12 @@
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+
+export function CodeDoctorPage() {
+  useDocumentTitle('コードドクター')
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center">
+      <h1 className="text-2xl font-bold text-text-dark">コードドクター</h1>
+      <p className="mt-2 text-text-light">準備中です</p>
+    </div>
+  )
+}

--- a/apps/web/src/pages/CodeReadingPage.tsx
+++ b/apps/web/src/pages/CodeReadingPage.tsx
@@ -1,0 +1,12 @@
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+
+export function CodeReadingPage() {
+  useDocumentTitle('コードリーディング')
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center">
+      <h1 className="text-2xl font-bold text-text-dark">コードリーディング</h1>
+      <p className="mt-2 text-text-light">準備中です</p>
+    </div>
+  )
+}

--- a/apps/web/src/pages/CurriculumPage.tsx
+++ b/apps/web/src/pages/CurriculumPage.tsx
@@ -1,0 +1,12 @@
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+
+export function CurriculumPage() {
+  useDocumentTitle('カリキュラム')
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center">
+      <h1 className="text-2xl font-bold text-text-dark">カリキュラム</h1>
+      <p className="mt-2 text-text-light">準備中です</p>
+    </div>
+  )
+}

--- a/apps/web/src/pages/DailyChallengePage.tsx
+++ b/apps/web/src/pages/DailyChallengePage.tsx
@@ -1,0 +1,12 @@
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+
+export function DailyChallengePage() {
+  useDocumentTitle('デイリーチャレンジ')
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center">
+      <h1 className="text-2xl font-bold text-text-dark">デイリーチャレンジ</h1>
+      <p className="mt-2 text-text-light">準備中です</p>
+    </div>
+  )
+}

--- a/apps/web/src/pages/MiniProjectDetailPage.tsx
+++ b/apps/web/src/pages/MiniProjectDetailPage.tsx
@@ -1,0 +1,14 @@
+import { useParams } from 'react-router-dom'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+
+export function MiniProjectDetailPage() {
+  const { projectId } = useParams<{ projectId: string }>()
+  useDocumentTitle('ミニプロジェクト実装')
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center">
+      <h1 className="text-2xl font-bold text-text-dark">ミニプロジェクト実装</h1>
+      <p className="mt-2 text-text-light">準備中です（ID: {projectId}）</p>
+    </div>
+  )
+}

--- a/apps/web/src/pages/MiniProjectsPage.tsx
+++ b/apps/web/src/pages/MiniProjectsPage.tsx
@@ -1,0 +1,12 @@
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+
+export function MiniProjectsPage() {
+  useDocumentTitle('ミニプロジェクト')
+
+  return (
+    <div className="flex min-h-[60vh] flex-col items-center justify-center">
+      <h1 className="text-2xl font-bold text-text-dark">ミニプロジェクト</h1>
+      <p className="mt-2 text-text-light">準備中です</p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- `/curriculum`, `/daily`, `/practice/code-doctor`, `/practice/mini-projects`, `/practice/mini-projects/:projectId`, `/practice/code-reading` の6ルートを追加
- 全ルートに `React.lazy` + `Suspense` で遅延ロード設定（既存パターン踏襲）
- 各ページに `useDocumentTitle` フック付きプレースホルダーコンポーネントを作成

## Test plan
- [x] `npm run typecheck` PASS
- [x] `npm run lint` PASS
- [x] `npm run build` PASS（新規チャンクが正しく分割されていることを確認）
- [x] テスト失敗3件は `SignUpPage.test.tsx` のベースブランチ由来（本PRの変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)