### PR TITLE
feat: コース間ロック機能（1-2）

### DIFF
--- a/apps/web/src/contexts/LearningContext.tsx
+++ b/apps/web/src/contexts/LearningContext.tsx
@@ -1,17 +1,21 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
 import { useAuth } from './AuthContext'
 import { getLearningStats, type LearningStats } from '../services/statsService'
-import { getCompletedStepCount } from '../services/progressService'
+import { getAllStepProgress, isStepCompleted } from '../services/progressService'
 
 interface LearningContextType {
     stats: LearningStats | null
+    completedStepIds: ReadonlySet<string>
     completedStepsCount: number
     isLoadingStats: boolean
     refreshStats: () => Promise<void>
 }
 
+const EMPTY_SET: ReadonlySet<string> = new Set()
+
 const LearningContext = createContext<LearningContextType>({
     stats: null,
+    completedStepIds: EMPTY_SET,
     completedStepsCount: 0,
     isLoadingStats: true,
     refreshStats: async () => { },
@@ -20,24 +24,29 @@ const LearningContext = createContext<LearningContextType>({
 export function LearningProvider({ children }: { children: ReactNode }) {
     const { user } = useAuth()
     const [stats, setStats] = useState<LearningStats | null>(null)
-    const [completedStepsCount, setCompletedStepsCount] = useState(0)
+    const [completedStepIds, setCompletedStepIds] = useState<ReadonlySet<string>>(EMPTY_SET)
     const [isLoadingStats, setIsLoadingStats] = useState(true)
+
+    const completedStepsCount = completedStepIds.size
 
     const refreshStats = useCallback(async () => {
         if (!user) {
             setStats(null)
-            setCompletedStepsCount(0)
+            setCompletedStepIds(EMPTY_SET)
             setIsLoadingStats(false)
             return
         }
 
         try {
-            const [currentStats, count] = await Promise.all([
+            const [currentStats, progresses] = await Promise.all([
                 getLearningStats(user.id),
-                getCompletedStepCount(user.id)
+                getAllStepProgress(user.id),
             ])
             setStats(currentStats)
-            setCompletedStepsCount(count)
+            const ids = new Set(
+                progresses.filter(isStepCompleted).map((p) => p.step_id),
+            )
+            setCompletedStepIds(ids)
         } catch (err) {
             console.error('Failed to load learning stats:', err)
         } finally {
@@ -59,8 +68,8 @@ export function LearningProvider({ children }: { children: ReactNode }) {
     }, [refreshStats])
 
     const value = useMemo(
-        () => ({ stats, completedStepsCount, isLoadingStats, refreshStats }),
-        [stats, completedStepsCount, isLoadingStats, refreshStats],
+        () => ({ stats, completedStepIds, completedStepsCount, isLoadingStats, refreshStats }),
+        [stats, completedStepIds, completedStepsCount, isLoadingStats, refreshStats],
     )
 
     return (

--- a/apps/web/src/features/learning/hooks/__tests__/useLearningStep.test.ts
+++ b/apps/web/src/features/learning/hooks/__tests__/useLearningStep.test.ts
@@ -54,6 +54,7 @@ beforeEach(() => {
 
   mockUseLearningContext.mockReturnValue({
     stats: null,
+    completedStepIds: new Set<string>(),
     completedStepsCount: 99,
     isLoadingStats: false,
     refreshStats: vi.fn().mockResolvedValue(undefined),

--- a/apps/web/src/lib/__tests__/courseLock.test.ts
+++ b/apps/web/src/lib/__tests__/courseLock.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import { getCourseLockStatus, isCourseCompleted } from '../courseLock'
+import { findCourseById } from '../../content/courseData'
+import type { CourseMeta } from '../../content/courseData'
+
+// react-fundamentals のステップ ID（前提なし）
+const FUNDAMENTALS_STEP_IDS = ['usestate-basic', 'events', 'conditional', 'lists']
+
+// react-hooks は react-fundamentals が必須前提
+const hooksCourse = findCourseById('react-hooks')!
+
+// react-fundamentals は前提なし
+const fundamentalsCourse = findCourseById('react-fundamentals')!
+
+describe('getCourseLockStatus', () => {
+  it('前提なしのコースは常に unlocked', () => {
+    const result = getCourseLockStatus(fundamentalsCourse, new Set())
+    expect(result.locked).toBe(false)
+    expect(result).toEqual({ locked: false, warning: null })
+  })
+
+  it('必須前提が未完了ならロック', () => {
+    const result = getCourseLockStatus(hooksCourse, new Set())
+    expect(result.locked).toBe(true)
+    if (result.locked) {
+      expect(result.reason).toContain('React基礎')
+    }
+  })
+
+  it('必須前提が完了済みなら unlocked', () => {
+    const completed = new Set(FUNDAMENTALS_STEP_IDS)
+    const result = getCourseLockStatus(hooksCourse, completed)
+    expect(result.locked).toBe(false)
+  })
+
+  it('推奨前提が未完了なら warning 付きで unlocked', () => {
+    const course: CourseMeta = {
+      id: 'test-course',
+      title: 'テスト',
+      level: 'beginner',
+      steps: [],
+      requiredPrerequisites: [],
+      recommendedPrerequisites: ['react-fundamentals'],
+    }
+
+    const result = getCourseLockStatus(course, new Set())
+    expect(result.locked).toBe(false)
+    if (!result.locked) {
+      expect(result.warning).toContain('React基礎')
+    }
+  })
+
+  it('推奨前提が完了済みなら warning なし', () => {
+    const course: CourseMeta = {
+      id: 'test-course',
+      title: 'テスト',
+      level: 'beginner',
+      steps: [],
+      requiredPrerequisites: [],
+      recommendedPrerequisites: ['react-fundamentals'],
+    }
+
+    const completed = new Set(FUNDAMENTALS_STEP_IDS)
+    const result = getCourseLockStatus(course, completed)
+    expect(result).toEqual({ locked: false, warning: null })
+  })
+
+  it('必須前提が未完了なら推奨より優先してロック', () => {
+    const course: CourseMeta = {
+      id: 'test-course',
+      title: 'テスト',
+      level: 'advanced',
+      steps: [],
+      requiredPrerequisites: ['react-hooks'],
+      recommendedPrerequisites: ['react-fundamentals'],
+    }
+
+    const result = getCourseLockStatus(course, new Set())
+    expect(result.locked).toBe(true)
+  })
+})
+
+describe('isCourseCompleted', () => {
+  it('全ステップ完了で true', () => {
+    const completed = new Set(FUNDAMENTALS_STEP_IDS)
+    expect(isCourseCompleted('react-fundamentals', completed)).toBe(true)
+  })
+
+  it('一部未完了で false', () => {
+    const completed = new Set(['usestate-basic', 'events'])
+    expect(isCourseCompleted('react-fundamentals', completed)).toBe(false)
+  })
+
+  it('空セットで false', () => {
+    expect(isCourseCompleted('react-fundamentals', new Set())).toBe(false)
+  })
+
+  it('存在しないコース ID で false', () => {
+    expect(isCourseCompleted('nonexistent', new Set())).toBe(false)
+  })
+})

--- a/apps/web/src/lib/courseLock.ts
+++ b/apps/web/src/lib/courseLock.ts
@@ -1,0 +1,63 @@
+import { findCourseById, type CourseMeta } from '../content/courseData'
+
+export type CourseLockStatus =
+  | { locked: false; warning: string | null }
+  | { locked: true; reason: string }
+
+/**
+ * コースのロック状態を判定する（D1-3 準拠）
+ *
+ * - 必須前提コースが未完了 → locked: true
+ * - 推奨前提コースが未完了 → locked: false, warning あり
+ * - 前提なし or 全完了 → locked: false, warning なし
+ */
+export function getCourseLockStatus(
+  course: CourseMeta,
+  completedStepIds: ReadonlySet<string>,
+): CourseLockStatus {
+  // 必須前提チェック
+  for (const prereqId of course.requiredPrerequisites) {
+    if (!isCourseCompleted(prereqId, completedStepIds)) {
+      const prereq = findCourseById(prereqId)
+      return {
+        locked: true,
+        reason: `「${prereq?.title ?? prereqId}」を完了すると解放されます`,
+      }
+    }
+  }
+
+  // 推奨前提チェック
+  const warnings: string[] = []
+  for (const prereqId of course.recommendedPrerequisites) {
+    if (!isCourseCompleted(prereqId, completedStepIds)) {
+      const prereq = findCourseById(prereqId)
+      warnings.push(prereq?.title ?? prereqId)
+    }
+  }
+
+  if (warnings.length > 0) {
+    return {
+      locked: false,
+      warning: `「${warnings.join('」「')}」を先に学習することを推奨します`,
+    }
+  }
+
+  return { locked: false, warning: null }
+}
+
+/**
+ * コースが完了しているか判定する
+ * isImplemented: true のステップがすべて completedStepIds に含まれていれば完了
+ */
+export function isCourseCompleted(
+  courseId: string,
+  completedStepIds: ReadonlySet<string>,
+): boolean {
+  const course = findCourseById(courseId)
+  if (!course) return false
+
+  const implementedSteps = course.steps.filter((s) => s.isImplemented)
+  if (implementedSteps.length === 0) return false
+
+  return implementedSteps.every((step) => completedStepIds.has(step.id))
+}


### PR DESCRIPTION
## Summary
- `courseLock.ts`: 必須前提/推奨前提に基づくコースロック判定ロジック（D1-3 準拠）
- `LearningContext`: `completedStepIds: ReadonlySet<string>` を公開し、ロック判定に必要な情報を提供
- ユニットテスト 10 ケース追加（全 264 テスト PASS）

## Test plan
- [x] `npm run typecheck` PASS
- [x] `npm run lint` PASS
- [x] `npm run test` — 264 tests passed
- [x] `npm run build` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)