### PR TITLE
feat: TypeScript応用3ステップ (ts-union-narrowing, ts-generics, ts-utility-types)

### DIFF
--- a/apps/web/src/content/typescript/steps/ts-generics.ts
+++ b/apps/web/src/content/typescript/steps/ts-generics.ts
@@ -1,0 +1,216 @@
+import type { LearningStepContent } from '@/content/fundamentals/steps'
+
+export const tsGenericsStep: LearningStepContent = {
+  id: 'ts-generics',
+  order: 25,
+  title: 'ジェネリクス',
+  summary: '型パラメータ<T>・複数型パラメータ・ジェネリックインターフェース・型制約(extends)を学ぶ。',
+  readMarkdown: `# ジェネリクス：再利用可能な型定義
+
+## any との違い
+
+any を使うと型安全性が失われます。ジェネリクスを使うと、型安全性を保ちつつ汎用的な関数を書けます。
+
+\`\`\`ts
+// any を使うと戻り値の型情報が失われる
+function identity_any(value: any): any {
+  return value;
+}
+const result = identity_any("hello"); // result は any 型
+
+// ジェネリクスなら型情報が保たれる
+function identity<T>(value: T): T {
+  return value;
+}
+const result2 = identity("hello"); // result2 は string 型
+const result3 = identity(42);      // result3 は number 型
+\`\`\`
+
+## 型パラメータ \`<T>\`
+
+\`<T>\` は「型を引数として受け取る」仕組みです。T は慣習的な名前で、任意の名前を使えます。
+
+\`\`\`ts
+function getFirst<T>(arr: T[]): T {
+  return arr[0];
+}
+
+const first1 = getFirst([1, 2, 3]);         // number
+const first2 = getFirst(["a", "b", "c"]);   // string
+
+// 型引数を明示することもできる（通常は推論に任せる）
+const first3 = getFirst<boolean>([true, false]); // boolean
+\`\`\`
+
+## 複数の型パラメータ
+
+\`\`\`ts
+function zip<A, B>(arrA: A[], arrB: B[]): [A, B][] {
+  return arrA.map((a, i) => [a, arrB[i]]);
+}
+
+zip([1, 2, 3], ["a", "b", "c"]);
+// [[1, "a"], [2, "b"], [3, "c"]] — 型は [number, string][]
+\`\`\`
+
+## ジェネリックインターフェース
+
+\`\`\`ts
+interface ApiResponse<T> {
+  data: T;
+  status: number;
+  message: string;
+}
+
+// T に具体的な型を当てはめる
+const userResponse: ApiResponse<User> = {
+  data: { id: 1, name: "Alice", email: "alice@example.com" },
+  status: 200,
+  message: "OK",
+};
+
+const stringResponse: ApiResponse<string> = {
+  data: "hello",
+  status: 200,
+  message: "OK",
+};
+\`\`\`
+
+## 型制約（extends）
+
+型パラメータに制約を付けると、特定のプロパティを持つ型のみ受け入れられます。
+
+\`\`\`ts
+// T は必ず { length: number } を持つ型に限定
+function getLength<T extends { length: number }>(value: T): number {
+  return value.length;
+}
+
+getLength("hello");        // 5 — string は length を持つ
+getLength([1, 2, 3]);      // 3 — 配列は length を持つ
+getLength(42);             // エラー！number は length を持たない
+\`\`\`
+
+## 型制約と keyof
+
+\`keyof\` と組み合わせると、オブジェクトのプロパティ名に安全にアクセスできます。
+
+\`\`\`ts
+function getProperty<T, K extends keyof T>(obj: T, key: K): T[K] {
+  return obj[key];
+}
+
+const user = { id: 1, name: "Alice", age: 30 };
+getProperty(user, "name"); // "Alice" — string 型
+getProperty(user, "id");   // 1 — number 型
+getProperty(user, "xyz");  // エラー！user に xyz プロパティはない
+\`\`\`
+`,
+  practiceQuestions: [
+    {
+      id: 'q1',
+      prompt: '`function identity<T>(value: T): T` で T を使う利点は、any を使う場合と比べて何が保たれる？',
+      answer: '型情報',
+      hint: '関数を呼び出した後、戻り値の型が何型かわかることです。',
+      explanation: 'ジェネリクスを使うと、呼び出し時の引数の型が戻り値の型に伝わります。anyでは戻り値がany型になり型安全性が失われます。',
+      choices: ['型情報', 'パフォーマンス', 'nullチェック', 'メモリ管理'],
+    },
+    {
+      id: 'q2',
+      prompt: '`function getFirst<T>(arr: T[]): ____` — 配列の最初の要素を返す関数の戻り値型は？',
+      answer: 'T',
+      hint: '配列の要素と同じ型です。',
+      explanation: '配列が T[] 型なら、その要素は T 型です。戻り値に T を指定することで、入力の型と出力の型が連動します。',
+      choices: ['T', 'T[]', 'any', 'unknown'],
+    },
+    {
+      id: 'q3',
+      prompt: '`function getLength<T extends ____ >` — T を「length プロパティを持つ型」に制限する制約は？',
+      answer: '{ length: number }',
+      hint: '`extends` の後に、T が持つべきプロパティを型として書きます。',
+      explanation: 'extends { length: number } と書くと、T は length プロパティを持つ型（string, 配列など）のみに制限されます。',
+    },
+    {
+      id: 'q4',
+      prompt: '`getFirst([1, 2, 3])` を呼び出すとき、型引数 T の値をTypeScriptはどのように決定する？',
+      answer: '推論',
+      hint: '明示しなくても TypeScript が自動で決めてくれます。',
+      explanation: 'TypeScriptは引数の型から型引数を自動で推論します。[1, 2, 3]はnumber[]なのでTはnumberと推論されます。明示的に<number>と書く必要はありません。',
+      choices: ['推論', '手動指定', 'any変換', 'キャスト'],
+    },
+    {
+      id: 'q5',
+      prompt: '`function getProperty<T, K extends keyof T>(obj: T, key: K)` — K に keyof T の制約を付けることで何を防げる？',
+      answer: '存在しないプロパティへのアクセス',
+      hint: 'obj に存在しないキーを渡したときにコンパイルエラーにできます。',
+      explanation: 'K extends keyof T とすることで、key に T のプロパティ名以外を渡すとコンパイルエラーになります。タイポによるバグを防げます。',
+      choices: ['存在しないプロパティへのアクセス', 'null参照エラー', '無限ループ', '型の循環参照'],
+    },
+  ],
+  testTask: {
+    instruction: '`getFirst` 関数の引数と戻り値に型パラメータ T を使った型注釈を付けてください。',
+    starterCode: `function getFirst<T>(arr: ____): ____ {
+  return arr[0];
+}`,
+    expectedKeywords: ['T[]', 'T'],
+    explanation: '引数は T[] 型の配列、戻り値は T 型の要素です。これで getFirst([1,2,3]) の戻り値が number と推論されるようになります。',
+  },
+  challengeTask: {
+    patterns: [
+      {
+        id: 'ts-generics-1',
+        prompt: '`Result<T>` 型と、それを返すユーティリティ関数を実装してください。',
+        requirements: [
+          '`{ ok: true; value: T } | { ok: false; error: string }` のユニオン型 `Result<T>` を定義する',
+          '`succeed<T>(value: T): Result<T>` 関数を実装する（ok: true を返す）',
+          '`fail<T>(error: string): Result<T>` 関数を実装する（ok: false を返す）',
+          '`unwrap<T>(result: Result<T>): T` 関数を実装する（ok が false の場合は Error をスローする）',
+        ],
+        hints: [
+          'Result<T> はジェネリックな判別共用体です',
+          'unwrap 内で result.ok が false なら throw new Error(result.error)',
+          'ok が true のブランチでは result.value が T 型として使えます',
+        ],
+        expectedKeywords: ['Result', 'succeed', 'fail', 'unwrap', 'ok'],
+        starterCode: `// TODO: Result<T> 型を定義してください
+
+// TODO: succeed, fail, unwrap を実装してください
+
+const r1 = succeed(42);
+const r2 = fail<number>("取得に失敗しました");
+
+console.log(unwrap(r1)); // 42
+try {
+  unwrap(r2);
+} catch (e) {
+  console.log((e as Error).message); // "取得に失敗しました"
+}`,
+      },
+      {
+        id: 'ts-generics-2',
+        prompt: '`<T extends { id: number }>` 制約を使ったユーティリティ関数を実装してください。',
+        requirements: [
+          '`findById<T extends { id: number }>(items: T[], id: number): T | undefined` を実装する',
+          '`groupById<T extends { id: number }>(items: T[]): Record<number, T>` を実装する',
+          '動作確認: ユーザー配列と商品配列でそれぞれ動作することを確認する',
+        ],
+        hints: [
+          '`T extends { id: number }` は id プロパティを持つ任意の型を受け入れます',
+          'findById は Array.find を使います',
+          'groupById は reduce または forEach でオブジェクトを組み立てます',
+        ],
+        expectedKeywords: ['findById', 'groupById', 'extends', 'id', 'Record'],
+        starterCode: `// TODO: findById を実装してください
+
+// TODO: groupById を実装してください
+
+const users = [
+  { id: 1, name: "Alice" },
+  { id: 2, name: "Bob" },
+];
+console.log(findById(users, 1));    // { id: 1, name: "Alice" }
+console.log(groupById(users));      // { 1: { id: 1, name: "Alice" }, 2: { id: 2, name: "Bob" } }`,
+      },
+    ],
+  },
+}

--- a/apps/web/src/content/typescript/steps/ts-union-narrowing.ts
+++ b/apps/web/src/content/typescript/steps/ts-union-narrowing.ts
@@ -1,0 +1,246 @@
+import type { LearningStepContent } from '@/content/fundamentals/steps'
+
+export const tsUnionNarrowingStep: LearningStepContent = {
+  id: 'ts-union-narrowing',
+  order: 24,
+  title: 'ユニオン型と型ガード',
+  summary: 'ユニオン型・型ガード（typeof/in/instanceof）・判別共用体・never型による網羅性チェックを学ぶ。',
+  readMarkdown: `# ユニオン型と型ガード
+
+## ユニオン型：複数の型を受け入れる
+
+\`|\` を使って「この型またはあの型」を表現できます。
+
+\`\`\`ts
+function formatId(id: string | number): string {
+  return String(id);
+}
+
+formatId("abc-123"); // OK
+formatId(42);        // OK
+formatId(true);      // エラー！boolean はユニオンにない
+\`\`\`
+
+## なぜ型ガードが必要か？
+
+ユニオン型の変数には、共通するメソッドしか呼べません。
+
+\`\`\`ts
+function process(value: string | number) {
+  value.toUpperCase(); // エラー！number に toUpperCase はない
+  value.toFixed(2);    // エラー！string に toFixed はない
+}
+\`\`\`
+
+型ガードで型を絞り込む（narrow）ことで、安全にメソッドを呼べます。
+
+## typeof ガード
+
+プリミティブ型の絞り込みに使います。
+
+\`\`\`ts
+function process(value: string | number): string {
+  if (typeof value === "string") {
+    return value.toUpperCase(); // ここでは string 確定
+  }
+  return value.toFixed(2); // ここでは number 確定
+}
+\`\`\`
+
+## truthiness ガード
+
+null / undefined を除外できます。
+
+\`\`\`ts
+function greet(name: string | null): string {
+  if (name) {
+    return \`Hello, \${name}!\`; // name は string 確定
+  }
+  return "Hello, Guest!";
+}
+\`\`\`
+
+## in ガード
+
+オブジェクト型のプロパティ存在チェックに使います。
+
+\`\`\`ts
+interface Cat { meow(): void }
+interface Dog { bark(): void }
+
+function makeSound(animal: Cat | Dog): void {
+  if ("meow" in animal) {
+    animal.meow(); // Cat 確定
+  } else {
+    animal.bark(); // Dog 確定
+  }
+}
+\`\`\`
+
+## instanceof ガード
+
+クラスのインスタンス確認に使います。
+
+\`\`\`ts
+function formatError(error: Error | string): string {
+  if (error instanceof Error) {
+    return error.message; // Error 確定
+  }
+  return error; // string 確定
+}
+\`\`\`
+
+## 判別共用体（Discriminated Union）
+
+共通の**リテラル型プロパティ**を持つユニオン型です。switch 文と組み合わせると強力です。
+
+\`\`\`ts
+type Shape =
+  | { kind: "circle"; radius: number }
+  | { kind: "rectangle"; width: number; height: number };
+
+function getArea(shape: Shape): number {
+  switch (shape.kind) {
+    case "circle":
+      return Math.PI * shape.radius ** 2; // radius が使える
+    case "rectangle":
+      return shape.width * shape.height;  // width/height が使える
+  }
+}
+\`\`\`
+
+## never 型と網羅性チェック
+
+\`never\` は「到達不能」を表す型です。判別共用体の switch 文でケース漏れを検出できます。
+
+\`\`\`ts
+function assertNever(x: never): never {
+  throw new Error(\`Unexpected value: \${JSON.stringify(x)}\`);
+}
+
+function getArea(shape: Shape): number {
+  switch (shape.kind) {
+    case "circle":    return Math.PI * shape.radius ** 2;
+    case "rectangle": return shape.width * shape.height;
+    default:          return assertNever(shape); // ケース漏れがあるとコンパイルエラー
+  }
+}
+\`\`\`
+`,
+  practiceQuestions: [
+    {
+      id: 'q1',
+      prompt: '`function f(v: string | number)` 内で `v.toUpperCase()` を呼ぶとエラーになる。正しく呼ぶには `if (____ v === "string")` のように型ガードが必要。空欄は？',
+      answer: 'typeof',
+      hint: 'プリミティブ型を判定するJavaScriptの演算子です。',
+      explanation: 'typeofはプリミティブ型（string/number/boolean等）を実行時に確認する演算子です。TypeScriptはtypeofの結果を使って型を絞り込みます。',
+      choices: ['typeof', 'instanceof', 'in', 'is'],
+    },
+    {
+      id: 'q2',
+      prompt: 'オブジェクトにプロパティが存在するか確認する型ガードの構文は `"propName" ____ obj` の形。空欄は？',
+      answer: 'in',
+      hint: '「〜の中に」を意味する2文字の英単語です。',
+      explanation: '`"propName" in obj` はオブジェクトに指定したプロパティが存在するかチェックします。TypeScriptはこの結果で型を絞り込みます。',
+      choices: ['in', 'of', 'has', 'instanceof'],
+    },
+    {
+      id: 'q3',
+      prompt: '判別共用体で各型を区別するための「共通のリテラル型プロパティ」を一般的に何と呼ぶ？',
+      answer: 'タグ',
+      hint: '「種類」「識別子」を意味する、kind や type という名前がよく使われます。',
+      explanation: '判別共用体では kind, type, tag などの共通プロパティにリテラル型を使い、switch文でそれぞれを区別します。このプロパティを「タグ（discriminant）」と呼びます。',
+      choices: ['タグ', 'キー', 'ラベル', 'フラグ'],
+    },
+    {
+      id: 'q4',
+      prompt: '`never` 型を使った `assertNever(x: never)` 関数をswitch のdefaultケースに置くと、何を防げる？',
+      answer: 'ケース漏れ',
+      hint: '新しい型のバリアントを追加したとき、対応を忘れると困るのは？',
+      explanation: 'assertNeverをdefaultに置くと、新しいケース（例: triangle）を追加してswitch文を更新し忘れた場合にコンパイルエラーが発生します。これを「網羅性チェック（exhaustive check）」と呼びます。',
+      choices: ['ケース漏れ', '型の変換', 'null参照', 'スタックオーバーフロー'],
+    },
+    {
+      id: 'q5',
+      prompt: '`if (error instanceof Error)` の型ガードで絞り込める型は？',
+      answer: 'Error',
+      hint: '`instanceof` は何のインスタンスかを確認します。',
+      explanation: 'instanceofはクラスのインスタンスかどうかを確認します。trueのブランチではそのクラスの型として扱われます。',
+      choices: ['Error', 'string', 'object', 'unknown'],
+    },
+  ],
+  testTask: {
+    instruction: '`processValue` 関数内で `typeof` を使って型ガードを追加し、string の場合は大文字に変換してください。',
+    starterCode: `function processValue(value: string | number): string {
+  if (____ value === 'string') {
+    return value.toUpperCase();
+  }
+  return String(value);
+}`,
+    expectedKeywords: ['typeof'],
+    explanation: '`typeof value === "string"` で型ガードを適用すると、if ブロック内では value が string 型として扱われ、.toUpperCase() を安全に呼び出せます。',
+  },
+  challengeTask: {
+    patterns: [
+      {
+        id: 'ts-union-narrowing-1',
+        prompt: 'APIレスポンスを表す判別共用体を設計してください。',
+        requirements: [
+          '`{ status: "success"; data: string }` と `{ status: "error"; message: string }` のユニオン型 `ApiResponse` を定義する',
+          '`handleResponse(res: ApiResponse): string` 関数を実装する',
+          'status で分岐し、success なら `"データ: " + res.data`、error なら `"エラー: " + res.message` を返す',
+        ],
+        hints: [
+          '判別共用体は共通のリテラル型プロパティ（ここでは status）で型を絞り込みます',
+          'switch (res.status) または if (res.status === "success") で分岐できます',
+        ],
+        expectedKeywords: ['ApiResponse', 'success', 'error', 'handleResponse'],
+        starterCode: `// TODO: ApiResponse 型を定義してください
+
+// TODO: handleResponse 関数を実装してください
+function handleResponse(res: ApiResponse): string {
+  // TODO: status で分岐して実装
+}
+
+const ok: ApiResponse = { status: "success", data: "ユーザー情報" };
+const ng: ApiResponse = { status: "error", message: "認証エラー" };
+console.log(handleResponse(ok)); // "データ: ユーザー情報"
+console.log(handleResponse(ng)); // "エラー: 認証エラー"`,
+      },
+      {
+        id: 'ts-union-narrowing-2',
+        prompt: '図形の面積を計算する関数を、網羅性チェック付きで実装してください。',
+        requirements: [
+          '`{ kind: "circle"; radius: number }` と `{ kind: "rectangle"; width: number; height: number }` のユニオン型 `Shape` を定義する',
+          '`getArea(shape: Shape): number` を switch 文で実装する',
+          'default ケースに `assertNever(shape)` を置いて網羅性チェックをする',
+          '`function assertNever(x: never): never { throw new Error(...) }` を実装する',
+        ],
+        hints: [
+          'circle の面積: Math.PI * radius ** 2',
+          'rectangle の面積: width * height',
+          'assertNever の引数に never 型を指定することで、ケース漏れをコンパイル時に検出できます',
+        ],
+        expectedKeywords: ['Shape', 'circle', 'rectangle', 'getArea', 'assertNever', 'never'],
+        starterCode: `// TODO: Shape 型を定義してください
+
+// TODO: assertNever 関数を実装してください
+function assertNever(x: never): never {
+  throw new Error(\`Unexpected shape: \${JSON.stringify(x)}\`);
+}
+
+// TODO: getArea 関数を switch 文で実装してください
+function getArea(shape: Shape): number {
+  switch (shape.kind) {
+    // TODO: circle, rectangle のケースを実装
+    default:
+      return assertNever(shape);
+  }
+}
+
+console.log(getArea({ kind: "circle", radius: 5 }));               // ~78.54
+console.log(getArea({ kind: "rectangle", width: 4, height: 6 }));  // 24`,
+      },
+    ],
+  },
+}

--- a/apps/web/src/content/typescript/steps/ts-utility-types.ts
+++ b/apps/web/src/content/typescript/steps/ts-utility-types.ts
@@ -1,0 +1,257 @@
+import type { LearningStepContent } from '@/content/fundamentals/steps'
+
+export const tsUtilityTypesStep: LearningStepContent = {
+  id: 'ts-utility-types',
+  order: 26,
+  title: 'ユーティリティ型',
+  summary: 'Partial/Required/Readonly/Pick/Omit/Record/ReturnType/Parameters など、TypeScript組み込みのユーティリティ型を学ぶ。',
+  readMarkdown: `# ユーティリティ型：既存の型を変換する
+
+TypeScriptには型を変換・加工するための組み込みユーティリティ型が揃っています。
+
+## Partial<T>：全プロパティを省略可能に
+
+\`\`\`ts
+interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+type UserUpdate = Partial<User>;
+// { id?: number; name?: string; email?: string }
+
+function updateUser(id: number, updates: Partial<User>) {
+  // updates には User の一部のプロパティだけ渡せる
+}
+updateUser(1, { name: "Bob" }); // OK（idもemailも省略可能）
+\`\`\`
+
+## Required<T>：全プロパティを必須に
+
+Partial の逆で、すべての ? を除去します。
+
+\`\`\`ts
+interface Config {
+  host?: string;
+  port?: number;
+}
+
+type StrictConfig = Required<Config>;
+// { host: string; port: number } — 必須になる
+\`\`\`
+
+## Readonly<T>：全プロパティを読み取り専用に
+
+\`\`\`ts
+type ReadonlyUser = Readonly<User>;
+// { readonly id: number; readonly name: string; readonly email: string }
+
+const user: ReadonlyUser = { id: 1, name: "Alice", email: "alice@example.com" };
+user.name = "Bob"; // エラー！
+\`\`\`
+
+## Pick<T, K>：指定プロパティだけを抽出
+
+\`\`\`ts
+type UserPreview = Pick<User, "id" | "name">;
+// { id: number; name: string }
+
+// Omit と使い分け: 残す数が少ない → Pick、削る数が少ない → Omit
+\`\`\`
+
+## Omit<T, K>：指定プロパティを除外
+
+\`\`\`ts
+type PublicUser = Omit<User, "email">;
+// { id: number; name: string } — email が除外される
+
+type NewUser = Omit<User, "id">;
+// { name: string; email: string } — id を除外（新規作成時に使う）
+\`\`\`
+
+## Record<K, V>：キーと値の型を指定したオブジェクト型
+
+\`\`\`ts
+type Role = "admin" | "editor" | "viewer";
+type Permission = "read" | "write" | "delete";
+
+type RolePermissions = Record<Role, Permission[]>;
+// { admin: Permission[]; editor: Permission[]; viewer: Permission[] }
+
+const permissions: RolePermissions = {
+  admin:  ["read", "write", "delete"],
+  editor: ["read", "write"],
+  viewer: ["read"],
+};
+\`\`\`
+
+## ReturnType<T>：関数の戻り値型を取得
+
+\`\`\`ts
+function getUser() {
+  return { id: 1, name: "Alice" };
+}
+
+type UserShape = ReturnType<typeof getUser>;
+// { id: number; name: string }
+
+// 関数の戻り値型を別の場所で再利用したい場合に便利
+\`\`\`
+
+## Parameters<T>：関数の引数型をタプルで取得
+
+\`\`\`ts
+function createPost(title: string, content: string, tags: string[]) { /* ... */ }
+
+type CreatePostArgs = Parameters<typeof createPost>;
+// [string, string, string[]]
+
+type FirstArg = Parameters<typeof createPost>[0];
+// string （title の型）
+\`\`\`
+
+## 組み合わせて使う
+
+\`\`\`ts
+// フォームの入力状態: 全フィールドを省略可能＋読み取り専用
+type FormState = Readonly<Partial<User>>;
+
+// DBに保存済みのユーザー: id は必須、他は Partial
+type StoredUser = Required<Pick<User, "id">> & Partial<Omit<User, "id">>;
+\`\`\`
+`,
+  practiceQuestions: [
+    {
+      id: 'q1',
+      prompt: 'フォームの更新処理で「User の一部のフィールドだけ受け取りたい」場合、使うべきユーティリティ型は？',
+      answer: 'Partial',
+      hint: '「部分的な」を意味する英単語です。',
+      explanation: 'Partial<T>はすべてのプロパティを省略可能（?）にします。フォーム更新やオプション引数に便利です。',
+      choices: ['Partial', 'Required', 'Pick', 'Omit'],
+    },
+    {
+      id: 'q2',
+      prompt: '`Pick<User, "id" | "name">` の結果として得られる型のプロパティは？',
+      answer: 'id と name',
+      hint: '第2引数で指定したプロパティ名が残ります。',
+      explanation: 'Pick<T, K>はTの中からKで指定したプロパティだけを抽出した型を作ります。',
+      choices: ['id と name', 'id と email', 'name と email', 'id のみ'],
+    },
+    {
+      id: 'q3',
+      prompt: '`Record<"admin" | "user", string[]>` はどのような型になる？',
+      answer: '{ admin: string[]; user: string[] }',
+      hint: 'Record<K, V> はキーがK、値がVのオブジェクト型です。',
+      explanation: 'Record<K, V>はキーの型KとバリューのVを組み合わせたオブジェクト型を作ります。',
+      choices: [
+        '{ admin: string[]; user: string[] }',
+        'string[][]',
+        'Map<string, string[]>',
+        '{ [key: string]: string[] }',
+      ],
+    },
+    {
+      id: 'q4',
+      prompt: '`ReturnType<typeof someFunc>` が有用なのは、どのような場面？',
+      answer: '関数の戻り値型を別の場所で再利用したいとき',
+      hint: '関数の実装を変えたとき、それに依存する型が自動で更新される利点があります。',
+      explanation: 'ReturnType<T>は関数の戻り値型を取得します。関数の実装が変わると型も自動的に更新されるため、型の二重管理を避けられます。',
+      choices: [
+        '関数の戻り値型を別の場所で再利用したいとき',
+        '関数の引数を省略可能にしたいとき',
+        '非同期関数の型を定義したいとき',
+        '関数をオーバーロードしたいとき',
+      ],
+    },
+    {
+      id: 'q5',
+      prompt: '`Omit<User, "password">` が有用なのは、どのような場面？',
+      answer: '機密情報を除いた公開用の型を作るとき',
+      hint: 'セキュリティ上、外部に見せてはいけないフィールドを除外します。',
+      explanation: 'Omit<T, K>はTからKを除外した型を作ります。パスワードなどの機密フィールドを除いたPublicUser型を作る際によく使われます。',
+      choices: [
+        '機密情報を除いた公開用の型を作るとき',
+        'フィールドを追加するとき',
+        'すべてのフィールドを必須にするとき',
+        'ユニオン型を作るとき',
+      ],
+    },
+  ],
+  testTask: {
+    instruction: '`UpdateUser` 型を定義してください。`User` の全プロパティを省略可能にするユーティリティ型を使います。',
+    starterCode: `interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+type UpdateUser = ____<User>`,
+    expectedKeywords: ['Partial'],
+    explanation: 'Partial<User>はUserの全プロパティをオプショナル（?付き）にした型を作ります。これでフォーム更新時に一部フィールドだけ渡せるようになります。',
+  },
+  challengeTask: {
+    patterns: [
+      {
+        id: 'ts-utility-types-1',
+        prompt: '`Omit` を使ってプロフィール公開用の型を設計してください。',
+        requirements: [
+          '`id: number`, `name: string`, `email: string`, `passwordHash: string`, `role: "admin" | "user"` を持つ `UserRecord` を定義する',
+          '`Omit` で `passwordHash` を除いた `PublicProfile` 型を定義する',
+          '`toPublicProfile(user: UserRecord): PublicProfile` 関数を実装する',
+        ],
+        hints: [
+          'Omit<UserRecord, "passwordHash"> で passwordHash を除外できます',
+          'toPublicProfile は UserRecord から passwordHash を除いたオブジェクトを返します',
+          '`const { passwordHash: _, ...rest } = user` でスプレッドを使って除外できます',
+        ],
+        expectedKeywords: ['UserRecord', 'PublicProfile', 'Omit', 'passwordHash', 'toPublicProfile'],
+        starterCode: `// TODO: UserRecord 型を定義してください
+
+// TODO: Omit を使って PublicProfile 型を定義してください
+
+// TODO: toPublicProfile 関数を実装してください
+function toPublicProfile(user: UserRecord): PublicProfile {
+  // TODO: passwordHash を除いたオブジェクトを返す
+}
+
+const user: UserRecord = {
+  id: 1,
+  name: "Alice",
+  email: "alice@example.com",
+  passwordHash: "hash_secret",
+  role: "user",
+};
+const profile = toPublicProfile(user);
+console.log(profile); // { id: 1, name: "Alice", email: "alice@example.com", role: "user" }`,
+      },
+      {
+        id: 'ts-utility-types-2',
+        prompt: '`Record` を使ってロール別権限マップを設計してください。',
+        requirements: [
+          '`"admin" | "editor" | "viewer"` のユニオン型 `Role` を定義する',
+          '`"read" | "write" | "delete"` のユニオン型 `Permission` を定義する',
+          '`Record<Role, Permission[]>` 型の `rolePermissions` オブジェクトを定義する',
+          '`hasPermission(role: Role, perm: Permission): boolean` 関数を実装する',
+        ],
+        hints: [
+          'rolePermissions の値は admin: ["read","write","delete"], editor: ["read","write"], viewer: ["read"] とする',
+          'hasPermission は rolePermissions[role].includes(perm) で判定できます',
+        ],
+        expectedKeywords: ['Role', 'Permission', 'Record', 'rolePermissions', 'hasPermission'],
+        starterCode: `// TODO: Role と Permission 型を定義してください
+
+// TODO: Record<Role, Permission[]> 型の rolePermissions を定義してください
+
+// TODO: hasPermission 関数を実装してください
+function hasPermission(role: Role, perm: Permission): boolean {
+  // TODO: 実装
+}
+
+console.log(hasPermission("admin", "delete"));  // true
+console.log(hasPermission("viewer", "write"));  // false
+console.log(hasPermission("editor", "read"));   // true`,
+      },
+    ],
+  },
+}


### PR DESCRIPTION
## Summary

- `ts-union-narrowing` (order:24): ユニオン型・typeof/in/instanceofガード・判別共用体・never型による網羅性チェック
- `ts-generics` (order:25): 型パラメータ・複数型パラメータ・ジェネリックinterface・型制約extends・keyof
- `ts-utility-types` (order:26): Partial/Required/Readonly/Pick/Omit/Record/ReturnType/Parameters

## Test plan
- [x] typecheck: PASS
- [x] lint: PASS
- [ ] 3-3 の統合後に stepWalkthrough テストで確認予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)