### PR TITLE
feat: ts-react 4ステップ コンテンツ作成 (4-1)

### DIFF
--- a/apps/web/src/content/typescript-react/steps/index.ts
+++ b/apps/web/src/content/typescript-react/steps/index.ts
@@ -1,0 +1,16 @@
+import type { LearningStepContent } from '@/content/fundamentals/steps'
+import { tsReactPropsStep } from './ts-react-props'
+import { tsReactStateStep } from './ts-react-state'
+import { tsReactHooksStep } from './ts-react-hooks'
+import { tsReactEventsStep } from './ts-react-events'
+
+export const typescriptReactSteps: LearningStepContent[] = [
+  tsReactPropsStep,
+  tsReactStateStep,
+  tsReactHooksStep,
+  tsReactEventsStep,
+]
+
+export function getTypescriptReactStep(stepId: string): LearningStepContent | undefined {
+  return typescriptReactSteps.find((step) => step.id === stepId)
+}

--- a/apps/web/src/content/typescript-react/steps/ts-react-events.ts
+++ b/apps/web/src/content/typescript-react/steps/ts-react-events.ts
@@ -1,0 +1,249 @@
+import type { LearningStepContent } from '@/content/fundamentals/steps'
+
+export const tsReactEventsStep: LearningStepContent = {
+  id: 'ts-react-events',
+  order: 30,
+  title: 'イベント型定義',
+  summary: 'React.ChangeEvent・MouseEvent・FormEvent・KeyboardEventなど、Reactイベントハンドラの型定義を学ぶ。',
+  readMarkdown: `# イベント型定義
+
+## React.ChangeEvent<T>
+
+input/select/textarea の \`onChange\` ハンドラで使います。型引数にHTML要素型を渡します。
+
+\`\`\`tsx
+function TextInput() {
+  const [value, setValue] = React.useState('')
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value)
+  }
+
+  return <input value={value} onChange={handleChange} />
+}
+\`\`\`
+
+select 要素の場合は \`HTMLSelectElement\`、textarea の場合は \`HTMLTextAreaElement\` を使います。
+
+## React.MouseEvent<T>
+
+ボタンなどのクリックイベントハンドラで使います。
+
+\`\`\`tsx
+function ClickButton() {
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+    console.log('クリック座標:', e.clientX, e.clientY)
+  }
+
+  return <button onClick={handleClick}>クリック</button>
+}
+\`\`\`
+
+## React.FormEvent<T>
+
+フォームの \`onSubmit\` ハンドラで使います。
+
+\`\`\`tsx
+function LoginForm() {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    // フォーム送信処理
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <button type="submit">送信</button>
+    </form>
+  )
+}
+\`\`\`
+
+## React.KeyboardEvent<T>
+
+キーボード操作のイベントハンドラで使います。
+
+\`\`\`tsx
+function SearchField() {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      console.log('検索実行')
+    }
+    if (e.key === 'Escape') {
+      console.log('キャンセル')
+    }
+  }
+
+  return <input onKeyDown={handleKeyDown} placeholder="Enterで検索" />
+}
+\`\`\`
+
+## イベントハンドラを変数として宣言する
+
+イベントハンドラをJSX外で定義する場合も型を明示できます。
+
+\`\`\`tsx
+import type { ChangeEventHandler, MouseEventHandler, FormEventHandler } from 'react'
+
+const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+  console.log(e.target.value)
+}
+
+const handleClick: MouseEventHandler<HTMLButtonElement> = (e) => {
+  e.stopPropagation()
+}
+
+const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
+  e.preventDefault()
+}
+\`\`\`
+
+ハンドラ型エイリアス（\`ChangeEventHandler\` など）を使うと、型引数が1つになって簡潔に書けます。
+
+## イベント型の早見表
+
+| イベント | 型 | よく使う要素 |
+|---------|-----|-------------|
+| onChange | ChangeEvent<T> | input, select, textarea |
+| onClick | MouseEvent<T> | button, div |
+| onSubmit | FormEvent<T> | form |
+| onKeyDown/Up/Press | KeyboardEvent<T> | input, div |
+| onFocus/Blur | FocusEvent<T> | input, button |
+`,
+  practiceQuestions: [
+    {
+      id: 'q1',
+      prompt: '`<input onChange={handleChange} />` の handleChange 引数の型は？',
+      answer: 'React.ChangeEvent<HTMLInputElement>',
+      hint: 'input 要素の onChange イベントです。',
+      explanation: 'input の onChange は React.ChangeEvent<HTMLInputElement> 型の引数を受け取ります。e.target.value で入力値を取得できます。',
+      choices: ['React.ChangeEvent<HTMLInputElement>', 'React.InputEvent<HTMLInputElement>', 'Event<HTMLInputElement>', 'React.ChangeEvent<HTMLElement>'],
+    },
+    {
+      id: 'q2',
+      prompt: '`<button onClick={handleClick} />` の handleClick 引数の型は？',
+      answer: 'React.MouseEvent<HTMLButtonElement>',
+      hint: 'button 要素の onClick イベントです。',
+      explanation: 'button の onClick は React.MouseEvent<HTMLButtonElement> 型の引数を受け取ります。e.clientX/Y でクリック座標を取得できます。',
+      choices: ['React.MouseEvent<HTMLButtonElement>', 'React.ClickEvent<HTMLButtonElement>', 'React.MouseEvent<HTMLElement>', 'MouseEvent<HTMLButtonElement>'],
+    },
+    {
+      id: 'q3',
+      prompt: '`<form onSubmit={handleSubmit} />` で `e.preventDefault()` を呼ぶための e の型は？',
+      answer: 'React.FormEvent<HTMLFormElement>',
+      hint: 'form 要素の onSubmit イベントです。',
+      explanation: 'form の onSubmit は React.FormEvent<HTMLFormElement> 型です。e.preventDefault() でデフォルトのフォーム送信（ページリロード）を防ぎます。',
+      choices: ['React.FormEvent<HTMLFormElement>', 'React.SubmitEvent<HTMLFormElement>', 'React.Event<HTMLFormElement>', 'FormEvent'],
+    },
+    {
+      id: 'q4',
+      prompt: '`<input onKeyDown={handler} />` で Enter キーを検出するコードは？',
+      answer: "if (e.key === 'Enter')",
+      hint: 'e.key でキー名を取得できます。',
+      explanation: 'React.KeyboardEvent の e.key プロパティでキー名（"Enter", "Escape" など）を取得できます。',
+      choices: ["if (e.key === 'Enter')", "if (e.keyCode === 13)", "if (e.which === 'enter')", "if (e.code === 'Enter')"],
+    },
+    {
+      id: 'q5',
+      prompt: '`const handleChange: ____<HTMLInputElement> = (e) => { ... }` の ____ に入るハンドラ型エイリアスは？',
+      answer: 'ChangeEventHandler',
+      hint: 'react から import できるハンドラ型エイリアスです。',
+      explanation: 'ChangeEventHandler<T> は React.ChangeEventHandler の型エイリアスです。import type { ChangeEventHandler } from "react" で import できます。',
+      choices: ['ChangeEventHandler', 'ChangeHandler', 'InputHandler', 'EventHandler'],
+    },
+  ],
+  testTask: {
+    instruction: '`handleChange` 関数に正しいイベント型を付けてください。input の onChange ハンドラで、入力値を state にセットします。',
+    starterCode: `import { useState } from 'react'
+
+function TextInput() {
+  const [value, setValue] = useState('')
+
+  const handleChange = (e: React.ChangeEvent<____>) => {
+    setValue(e.target.value)
+  }
+
+  return <input value={value} onChange={handleChange} />
+}`,
+    expectedKeywords: ['HTMLInputElement'],
+    explanation: 'input 要素の onChange ハンドラの引数は React.ChangeEvent<HTMLInputElement> 型です。e.target.value で入力値を取得できます。',
+  },
+  challengeTask: {
+    patterns: [
+      {
+        id: 'ts-react-events-1',
+        prompt: '型付きフォームコンポーネントを実装してください。',
+        requirements: [
+          'name（string）と email（string）を持つ FormData interface を定義する',
+          'useState で FormData を管理する',
+          'input の onChange ハンドラに React.ChangeEvent<HTMLInputElement> 型を使う',
+          'form の onSubmit ハンドラに React.FormEvent<HTMLFormElement> 型を使い、e.preventDefault() を呼ぶ',
+          '送信時にコンソールに FormData を出力する',
+        ],
+        hints: [
+          'スプレッド構文で部分更新: setForm((prev) => ({ ...prev, name: value }))',
+          'input の name 属性と e.target.name を使うと汎用的なハンドラが書けます',
+          'e.target.name as keyof FormData でキーの型安全性を確保できます',
+        ],
+        expectedKeywords: ['FormData', 'ChangeEvent', 'FormEvent', 'preventDefault', 'useState'],
+        starterCode: `import { useState } from 'react'
+
+// TODO: FormData interface を定義してください
+
+function ContactForm() {
+  // TODO: useState で FormData を管理してください
+
+  // TODO: onChange ハンドラを実装してください（型付き）
+
+  // TODO: onSubmit ハンドラを実装してください（型付き）
+
+  return (
+    <form>
+      <input name="name" placeholder="お名前" />
+      <input name="email" type="email" placeholder="メールアドレス" />
+      <button type="submit">送信</button>
+    </form>
+  )
+}`,
+      },
+      {
+        id: 'ts-react-events-2',
+        prompt: 'キーボードイベントを使った検索フィールドを実装してください。',
+        requirements: [
+          'query（string）と results（string[]）を state で管理する',
+          'input の onChange に React.ChangeEvent<HTMLInputElement> 型を使う',
+          'input の onKeyDown に React.KeyboardEvent<HTMLInputElement> 型を使う',
+          'Enter キーで検索実行、Escape キーで入力をクリアする',
+          '検索結果をリスト表示する（ダミーデータで可）',
+        ],
+        hints: [
+          'e.key === "Enter" で Enter キーを検出します',
+          'e.key === "Escape" で Escape キーを検出します',
+          '検索関数は query を元にフィルタリングするモック実装でOKです',
+        ],
+        expectedKeywords: ['ChangeEvent', 'KeyboardEvent', 'Enter', 'Escape', 'useState'],
+        starterCode: `import { useState } from 'react'
+
+const DUMMY_DATA = ['TypeScript', 'React', 'JavaScript', 'CSS', 'HTML', 'Node.js']
+
+function SearchField() {
+  // TODO: query と results の state を宣言してください
+
+  // TODO: onChange ハンドラ（型付き）を実装してください
+
+  // TODO: onKeyDown ハンドラ（型付き）を実装してください
+  // Enter: 検索実行、Escape: クリア
+
+  return (
+    <div>
+      <input placeholder="Enterで検索、Escapeでクリア" />
+      <ul>
+        {/* TODO: results を表示 */}
+      </ul>
+    </div>
+  )
+}`,
+      },
+    ],
+  },
+}

--- a/apps/web/src/content/typescript-react/steps/ts-react-hooks.ts
+++ b/apps/web/src/content/typescript-react/steps/ts-react-hooks.ts
@@ -1,0 +1,271 @@
+import type { LearningStepContent } from '@/content/fundamentals/steps'
+
+export const tsReactHooksStep: LearningStepContent = {
+  id: 'ts-react-hooks',
+  order: 29,
+  title: 'Hooks型定義',
+  summary: 'useRef<T>のDOM参照・useContextの型付きコンテキスト・カスタムフックの戻り値型・forwardRefなど、型安全なHooks活用を学ぶ。',
+  readMarkdown: `# Hooks型定義
+
+## useRef<T> — DOM要素参照
+
+\`useRef\` をDOM要素参照に使うときは、HTML要素の型を型引数に渡します。
+
+\`\`\`tsx
+import { useRef } from 'react'
+
+function SearchInput() {
+  // HTMLInputElement を型引数に指定
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  function focusInput() {
+    // current は HTMLInputElement | null 型
+    inputRef.current?.focus()
+  }
+
+  return (
+    <div>
+      <input ref={inputRef} type="text" />
+      <button onClick={focusInput}>フォーカス</button>
+    </div>
+  )
+}
+\`\`\`
+
+初期値 \`null\` と型引数 \`HTMLInputElement\` の組み合わせで、\`current\` の型は \`HTMLInputElement | null\` になります。
+
+## useRef<T> — 可変値保持（レンダリングなし）
+
+DOM参照ではなくタイマーIDなど「再レンダリングを起こさない可変値」を保持する使い方もあります。
+
+\`\`\`tsx
+const timerRef = useRef<number | null>(null)
+
+function startTimer() {
+  timerRef.current = window.setInterval(() => {
+    // 処理
+  }, 1000)
+}
+
+function stopTimer() {
+  if (timerRef.current !== null) {
+    clearInterval(timerRef.current)
+  }
+}
+\`\`\`
+
+## useContext と型付きコンテキスト
+
+\`createContext\` に型引数を渡してコンテキストを型安全にします。
+
+\`\`\`tsx
+import { createContext, useContext, useState } from 'react'
+
+interface ThemeContextType {
+  theme: 'light' | 'dark'
+  toggleTheme: () => void
+}
+
+// createContext の型引数で型を確定
+const ThemeContext = createContext<ThemeContextType | null>(null)
+
+// カスタムフックで null チェックをラップ
+function useTheme(): ThemeContextType {
+  const ctx = useContext(ThemeContext)
+  if (ctx === null) throw new Error('ThemeProvider の外で useTheme を使っています')
+  return ctx
+}
+
+function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light')
+  const toggleTheme = () => setTheme((t) => (t === 'light' ? 'dark' : 'light'))
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+\`\`\`
+
+## カスタムフックの戻り値型
+
+カスタムフックの戻り値はタプルまたはオブジェクトで型を定義します。
+
+\`\`\`tsx
+// オブジェクト形式（フィールドが多い場合）
+function useCounter(initial: number) {
+  const [count, setCount] = useState(initial)
+  const increment = () => setCount((c) => c + 1)
+  const decrement = () => setCount((c) => c - 1)
+  const reset = () => setCount(initial)
+  return { count, increment, decrement, reset }
+}
+
+// 戻り値型を明示する場合
+interface UseCounterReturn {
+  count: number
+  increment: () => void
+  decrement: () => void
+  reset: () => void
+}
+
+function useCounter2(initial: number): UseCounterReturn {
+  // ...
+}
+\`\`\`
+
+## forwardRef<T, P>
+
+親コンポーネントから子の DOM 要素に ref を渡すには \`forwardRef\` を使います。
+
+\`\`\`tsx
+import { forwardRef } from 'react'
+
+interface InputProps {
+  label: string
+  placeholder?: string
+}
+
+// forwardRef<DOM要素型, Props型>
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ label, placeholder }, ref) => (
+    <div>
+      <label>{label}</label>
+      <input ref={ref} placeholder={placeholder} />
+    </div>
+  )
+)
+
+// 使う側
+function Form() {
+  const inputRef = useRef<HTMLInputElement>(null)
+  return <Input ref={inputRef} label="名前" />
+}
+\`\`\`
+`,
+  practiceQuestions: [
+    {
+      id: 'q1',
+      prompt: '`const ref = useRef<____>(null)` — input 要素を参照するときの型引数は？',
+      answer: 'HTMLInputElement',
+      hint: 'HTMLInputElement は input タグのDOM型です。',
+      explanation: 'input 要素への ref には useRef<HTMLInputElement>(null) を使います。current の型は HTMLInputElement | null になります。',
+      choices: ['HTMLInputElement', 'HTMLElement', 'InputElement', 'Element'],
+    },
+    {
+      id: 'q2',
+      prompt: '`const ref = useRef<HTMLButtonElement>(null)` — ref.current?.click() の `?.` は何のため？',
+      answer: 'current が null の可能性があるため',
+      hint: 'refの初期値はnullです。',
+      explanation: 'useRef<T>(null) の current は T | null 型なので、null チェックをせずにアクセスするとコンパイルエラーになります。オプショナルチェーン `?.` で安全にアクセスできます。',
+      choices: ['current が null の可能性があるため', 'TypeScriptの文法上必須のため', 'clickメソッドが存在しないため', 'async処理のため'],
+    },
+    {
+      id: 'q3',
+      prompt: '`createContext<ThemeContextType | null>(null)` で null を初期値にする理由は？',
+      answer: 'Provider の外で使われたことを検知するため',
+      hint: 'null チェックでエラーを投げる実装と組み合わせます。',
+      explanation: 'createContext の初期値を null にし、useContext で取得した値が null なら「Provider の外で使われている」と判断してエラーを投げる設計です。',
+      choices: ['Provider の外で使われたことを検知するため', 'TypeScript の仕様上必須のため', 'パフォーマンス最適化のため', 'null セーフにするため'],
+    },
+    {
+      id: 'q4',
+      prompt: 'カスタムフックが `{ count, increment }` を返す場合、呼び出し側で count を取得するには？',
+      answer: 'const { count, increment } = useCounter(0)',
+      hint: 'オブジェクト分割代入を使います。',
+      explanation: 'カスタムフックがオブジェクトを返す場合は分割代入で取得します。const { count, increment } = useCounter(0) のように書きます。',
+      choices: ['const { count, increment } = useCounter(0)', 'const [count, increment] = useCounter(0)', 'const count = useCounter(0).count', 'const count, increment = useCounter(0)'],
+    },
+    {
+      id: 'q5',
+      prompt: '`forwardRef<HTMLInputElement, InputProps>` の第1型引数と第2型引数はそれぞれ何？',
+      answer: 'ref の参照先DOM型 / コンポーネントのProps型',
+      hint: 'forwardRef は ref 型と Props 型の2つを受け取ります。',
+      explanation: 'forwardRef<T, P> の T は ref.current の型（DOM要素型）、P はコンポーネントの Props 型です。',
+      choices: ['ref の参照先DOM型 / コンポーネントのProps型', 'Props型 / ref の参照先DOM型', '親コンポーネント型 / 子コンポーネント型', '戻り値型 / 引数型'],
+    },
+  ],
+  testTask: {
+    instruction: 'input 要素に自動フォーカスする AutoFocusInput を実装してください。useRef を使って input への参照を取得し、マウント時に focus() を呼びます。',
+    starterCode: `import { useRef, useEffect } from 'react'
+
+function AutoFocusInput() {
+  const ref = useRef<____>(null)
+
+  useEffect(() => {
+    ref.current?.focus()
+  }, [])
+
+  return <input ref={ref} placeholder="自動フォーカス" />
+}`,
+    expectedKeywords: ['HTMLInputElement'],
+    explanation: 'input 要素への ref は useRef<HTMLInputElement>(null) で定義します。useEffect 内で ref.current?.focus() を呼ぶと、マウント時に自動フォーカスされます。',
+  },
+  challengeTask: {
+    patterns: [
+      {
+        id: 'ts-react-hooks-1',
+        prompt: '型付き ThemeContext を設計・実装してください。',
+        requirements: [
+          'theme（"light" | "dark"）と toggleTheme（() => void）を持つ ThemeContextType interface を定義する',
+          'createContext<ThemeContextType | null>(null) でコンテキストを作成する',
+          'null チェック付きの useTheme カスタムフックを実装する',
+          'ThemeProvider コンポーネントを実装する',
+        ],
+        hints: [
+          'createContext の初期値は null にします',
+          'useContext の戻り値が null のとき Error を throw します',
+          'useState<"light" | "dark"> で theme を管理します',
+        ],
+        expectedKeywords: ['ThemeContextType', 'createContext', 'useTheme', 'ThemeProvider', 'toggleTheme'],
+        starterCode: `import { createContext, useContext, useState } from 'react'
+import type { ReactNode } from 'react'
+
+// TODO: ThemeContextType interface を定義してください
+
+// TODO: ThemeContext を createContext で作成してください
+
+// TODO: useTheme カスタムフック（null チェック付き）を実装してください
+
+// TODO: ThemeProvider コンポーネントを実装してください
+function ThemeProvider({ children }: { children: ReactNode }) {
+  // TODO: theme state と toggleTheme を実装
+}`,
+      },
+      {
+        id: 'ts-react-hooks-2',
+        prompt: 'useLocalStorage カスタムフックを型安全に実装してください。',
+        requirements: [
+          'ジェネリクス型引数 T を持つ `useLocalStorage<T>(key: string, initialValue: T)` 関数を実装する',
+          '戻り値は [T, (value: T) => void] のタプル型にする',
+          'localStorage から読み込み・書き込みを行う',
+          'localStorage が利用できない場合は initialValue を使う',
+        ],
+        hints: [
+          'function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T) => void]',
+          'JSON.parse / JSON.stringify でシリアライズします',
+          'try/catch で localStorage の読み込みエラーを処理します',
+        ],
+        expectedKeywords: ['useLocalStorage', 'localStorage', 'JSON', 'useState'],
+        starterCode: `import { useState } from 'react'
+
+// TODO: useLocalStorage<T> カスタムフックを実装してください
+function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T) => void] {
+  // TODO: 実装
+}
+
+// 動作確認
+function App() {
+  const [name, setName] = useLocalStorage<string>('name', '')
+  const [count, setCount] = useLocalStorage<number>('count', 0)
+  return (
+    <div>
+      <input value={name} onChange={(e) => setName(e.target.value)} />
+      <button onClick={() => setCount(count + 1)}>{count}</button>
+    </div>
+  )
+}`,
+      },
+    ],
+  },
+}

--- a/apps/web/src/content/typescript-react/steps/ts-react-props.ts
+++ b/apps/web/src/content/typescript-react/steps/ts-react-props.ts
@@ -1,0 +1,215 @@
+import type { LearningStepContent } from '@/content/fundamentals/steps'
+
+export const tsReactPropsStep: LearningStepContent = {
+  id: 'ts-react-props',
+  order: 27,
+  title: 'Props型定義',
+  summary: 'interfaceを使ったProps型定義・children型・オプショナルProps・ComponentProps活用など、型安全なコンポーネント設計を学ぶ。',
+  readMarkdown: `# Props型定義
+
+## interfaceでPropsを定義する
+
+ReactコンポーネントのpropsをTypeScriptで型安全にするには、**interface**または**type**でProps型を定義します。
+
+\`\`\`tsx
+interface ButtonProps {
+  label: string
+  onClick: () => void
+}
+
+function Button({ label, onClick }: ButtonProps) {
+  return <button onClick={onClick}>{label}</button>
+}
+\`\`\`
+
+## オプショナルProps
+
+\`?\` を付けるとpropsを省略可能にできます。
+
+\`\`\`tsx
+interface CardProps {
+  title: string
+  description?: string  // 省略可能
+  variant?: 'primary' | 'secondary'
+}
+
+function Card({ title, description, variant = 'primary' }: CardProps) {
+  return (
+    <div className={variant}>
+      <h2>{title}</h2>
+      {description && <p>{description}</p>}
+    </div>
+  )
+}
+\`\`\`
+
+## children型
+
+子要素を受け取る場合は \`React.ReactNode\` を使います。
+
+\`\`\`tsx
+import type { ReactNode } from 'react'
+
+interface ContainerProps {
+  children: ReactNode
+  className?: string
+}
+
+function Container({ children, className }: ContainerProps) {
+  return <div className={className}>{children}</div>
+}
+\`\`\`
+
+\`React.FC\` 型を使う書き方もありますが、現在は Props 型を直接関数引数に書くスタイルが推奨されます。
+
+## ComponentProps<typeof X> でProps型を再利用
+
+既存コンポーネントのProps型を再利用したい場合は \`ComponentProps\` が便利です。
+
+\`\`\`tsx
+import type { ComponentProps } from 'react'
+
+// ネイティブ要素のProps型を取得
+type NativeButtonProps = ComponentProps<'button'>
+
+// カスタムコンポーネントのProps型を取得
+type MyButtonProps = ComponentProps<typeof Button>
+
+// 既存Propsを拡張する
+interface EnhancedButtonProps extends ComponentProps<'button'> {
+  isLoading?: boolean
+}
+\`\`\`
+
+## 関数型Propsのコールバック
+
+イベントハンドラなどのコールバックPropsには関数型を明示します。
+
+\`\`\`tsx
+interface SearchProps {
+  onSearch: (query: string) => void
+  onClear?: () => void
+}
+
+function SearchBar({ onSearch, onClear }: SearchProps) {
+  return (
+    <div>
+      <input onChange={(e) => onSearch(e.target.value)} />
+      {onClear && <button onClick={onClear}>クリア</button>}
+    </div>
+  )
+}
+\`\`\`
+`,
+  practiceQuestions: [
+    {
+      id: 'q1',
+      prompt: '`interface UserProps { name: ____ }` — name プロパティの型は？',
+      answer: 'string',
+      hint: '名前は文字列です。',
+      explanation: 'ユーザー名などの文字列データはstring型で表します。',
+      choices: ['string', 'number', 'boolean', 'text'],
+    },
+    {
+      id: 'q2',
+      prompt: 'Propsを省略可能にするには、プロパティ名の後に何を付ける？',
+      answer: '?',
+      hint: 'TypeScriptのオプショナル記号です。',
+      explanation: '`description?: string` のように `?` を付けると省略可能なPropsになります。',
+      choices: ['?', '!', '|', '&'],
+    },
+    {
+      id: 'q3',
+      prompt: '子要素 `children` を受け取るときに使う型は？',
+      answer: 'React.ReactNode',
+      hint: 'Reactで描画できるものすべてを表す型です。',
+      explanation: 'React.ReactNode（または import した ReactNode）は、文字列・数値・JSX・null など React がレンダリングできる値をすべて含む型です。',
+      choices: ['React.ReactNode', 'React.Element', 'JSX.Element', 'React.Component'],
+    },
+    {
+      id: 'q4',
+      prompt: '`ComponentProps<typeof Button>` は何を取得する？',
+      answer: 'ButtonコンポーネントのProps型',
+      hint: '既存コンポーネントの型情報を再利用するユーティリティです。',
+      explanation: 'ComponentProps<typeof X> は X コンポーネントが受け取る Props の型を取得します。型を再定義せず再利用できます。',
+      choices: ['ButtonコンポーネントのProps型', 'buttonタグのイベント型', 'Buttonの戻り値型', 'Buttonのref型'],
+    },
+    {
+      id: 'q5',
+      prompt: '`interface CardProps extends ComponentProps<____>` でdivタグの全Propsを継承するには？',
+      answer: "'div'",
+      hint: 'HTML要素名を文字列で渡します。',
+      explanation: "ComponentProps<'div'> のようにHTML要素名を文字列で指定すると、そのネイティブ要素のProps型（className, id, style など）を取得できます。",
+      choices: ["'div'", "'Div'", 'div', 'HTMLDivElement'],
+    },
+  ],
+  testTask: {
+    instruction: 'Button コンポーネントの Props interface を完成させてください。label は文字列、onClick はクリック時に呼ばれるコールバックです。',
+    starterCode: `interface ButtonProps {
+  label: ____
+  onClick: () => void
+}
+
+function Button({ label, onClick }: ButtonProps) {
+  return <button onClick={onClick}>{label}</button>
+}`,
+    expectedKeywords: ['label'],
+    explanation: 'label は string 型、onClick は () => void 型として定義します。interface で Props を定義することでコンポーネントの入力仕様が明確になります。',
+  },
+  challengeTask: {
+    patterns: [
+      {
+        id: 'ts-react-props-1',
+        prompt: 'Card コンポーネントの Props 型を設計してください。',
+        requirements: [
+          'title（必須・文字列）、description（省略可能・文字列）、children（省略可能・ReactNode）を持つ CardProps interface を定義する',
+          'CardProps を使った Card コンポーネントを実装する',
+          'description がある場合のみ <p> タグで表示する',
+        ],
+        hints: [
+          'オプショナルプロパティには ? を付けます',
+          'children の型は React.ReactNode または ReactNode（import後）を使います',
+          '条件付きレンダリングは `{prop && <element />}` パターンが便利です',
+        ],
+        expectedKeywords: ['CardProps', 'title', 'description', 'children', 'ReactNode'],
+        starterCode: `import type { ReactNode } from 'react'
+
+// TODO: CardProps interface を定義してください
+
+// TODO: Card コンポーネントを実装してください
+function Card({ title, description, children }: CardProps) {
+  // TODO: 実装
+}
+
+// 動作確認
+// <Card title="React学習">本文テキスト</Card>
+// <Card title="TypeScript" description="型安全な開発" />`,
+      },
+      {
+        id: 'ts-react-props-2',
+        prompt: 'ネイティブ button の全Props を継承した IconButton を実装してください。',
+        requirements: [
+          'ComponentProps<"button"> を継承した IconButtonProps を定義する',
+          'icon（文字列）と label（文字列）プロパティを追加する',
+          'ボタンのすべてのネイティブProps（disabled, type など）が使えることを確認する',
+        ],
+        hints: [
+          'interface IconButtonProps extends ComponentProps<"button"> { ... }',
+          'スプレッド構文 {...rest} でネイティブPropsを button 要素に渡せます',
+        ],
+        expectedKeywords: ['IconButtonProps', 'ComponentProps', 'icon', 'label'],
+        starterCode: `import type { ComponentProps } from 'react'
+
+// TODO: IconButtonProps を定義してください
+
+// TODO: IconButton コンポーネントを実装してください
+function IconButton({ icon, label, ...rest }: IconButtonProps) {
+  // TODO: 実装
+}
+
+// 動作確認（disabled などネイティブPropsが使える）
+// <IconButton icon="★" label="お気に入り" disabled />`,
+      },
+    ],
+  },
+}

--- a/apps/web/src/content/typescript-react/steps/ts-react-state.ts
+++ b/apps/web/src/content/typescript-react/steps/ts-react-state.ts
@@ -1,0 +1,247 @@
+import type { LearningStepContent } from '@/content/fundamentals/steps'
+
+export const tsReactStateStep: LearningStepContent = {
+  id: 'ts-react-state',
+  order: 28,
+  title: 'State型定義',
+  summary: 'useState<T>の型注釈・null/undefinedを含む状態・useReducerのAction型定義など、型安全な状態管理を学ぶ。',
+  readMarkdown: `# State型定義
+
+## useState<T> の型注釈
+
+\`useState\` に型引数を渡すと、state と setter の型が確定します。
+
+\`\`\`tsx
+// 型推論に任せる（初期値から自動推論）
+const [count, setCount] = useState(0)           // number
+const [name, setName] = useState('Alice')       // string
+
+// 明示的に型を指定する（初期値が空配列など推論が難しい場合）
+const [items, setItems] = useState<string[]>([])
+const [tags, setTags] = useState<number[]>([])
+\`\`\`
+
+## null/undefined を含む状態
+
+初期値が null の場合は **ユニオン型** で定義します。
+
+\`\`\`tsx
+interface User {
+  id: number
+  name: string
+}
+
+// null を許容するユーザー state
+const [user, setUser] = useState<User | null>(null)
+
+// ロード完了後に値をセット
+function handleLogin(userData: User) {
+  setUser(userData)
+}
+
+// null チェック後に安全にアクセス
+if (user !== null) {
+  console.log(user.name)  // TypeScript は User 型と認識
+}
+\`\`\`
+
+## 複雑な状態オブジェクト
+
+フォームなど複数フィールドを持つ状態も interface で型定義できます。
+
+\`\`\`tsx
+interface FormState {
+  email: string
+  password: string
+  isSubmitting: boolean
+}
+
+const [form, setForm] = useState<FormState>({
+  email: '',
+  password: '',
+  isSubmitting: false,
+})
+
+// 部分更新（スプレッド構文）
+setForm((prev) => ({ ...prev, email: 'test@example.com' }))
+\`\`\`
+
+## useReducer の Action 型定義
+
+\`useReducer\` では Action をユニオン型で定義し、型安全な dispatch を実現します。
+
+\`\`\`tsx
+type CountAction =
+  | { type: 'increment' }
+  | { type: 'decrement' }
+  | { type: 'reset'; payload: number }
+
+function reducer(state: number, action: CountAction): number {
+  switch (action.type) {
+    case 'increment': return state + 1
+    case 'decrement': return state - 1
+    case 'reset':     return action.payload  // payload は number 型と確定
+    default:          return state
+  }
+}
+
+function Counter() {
+  const [count, dispatch] = useReducer(reducer, 0)
+
+  return (
+    <div>
+      <button onClick={() => dispatch({ type: 'increment' })}>+</button>
+      <span>{count}</span>
+      <button onClick={() => dispatch({ type: 'reset', payload: 0 })}>リセット</button>
+    </div>
+  )
+}
+\`\`\`
+
+## 判別共用体（Discriminated Union）によるフォーム状態管理
+
+より厳密な状態管理には判別共用体が有効です。
+
+\`\`\`tsx
+type FormAction =
+  | { type: 'SET_EMAIL'; email: string }
+  | { type: 'SET_PASSWORD'; password: string }
+  | { type: 'SUBMIT' }
+  | { type: 'SUBMIT_SUCCESS' }
+  | { type: 'SUBMIT_ERROR'; error: string }
+\`\`\`
+
+\`type\` フィールドで状態を区別することで、各ケースで必要なデータのみアクセスできます。
+`,
+  practiceQuestions: [
+    {
+      id: 'q1',
+      prompt: '`const [count, setCount] = useState(____)` — 初期値0で number 型の state を作るには？',
+      answer: '0',
+      hint: '数値リテラルを渡すと型推論されます。',
+      explanation: 'useState(0) と書くと TypeScript は count を number 型、setCount を (value: number | (prev: number) => number) => void 型と推論します。',
+      choices: ['0', '"0"', 'number', '<number>0'],
+    },
+    {
+      id: 'q2',
+      prompt: '初期値が空配列 `[]` のとき、string配列のstateを作るには？',
+      answer: 'useState<string[]>([])',
+      hint: '空配列では型が推論できないので明示が必要です。',
+      explanation: 'useState([]) だと TypeScript は never[] と推論してしまいます。useState<string[]>([]) のように型引数を明示します。',
+      choices: ['useState<string[]>([])', 'useState([])', 'useState<string>([])', 'useState<Array>([])'],
+    },
+    {
+      id: 'q3',
+      prompt: 'null を含む User state の型は？',
+      answer: 'User | null',
+      hint: 'ユニオン型で null を許容します。',
+      explanation: 'useState<User | null>(null) とすることで、未ロード時は null、ロード後は User 型の値を持てます。',
+      choices: ['User | null', 'User?', 'Nullable<User>', 'User | undefined'],
+    },
+    {
+      id: 'q4',
+      prompt: 'useReducer の Action 型で `{ type: "reset"; payload: number }` のように定義した場合、`case "reset":` 内で `action.payload` の型は？',
+      answer: 'number',
+      hint: '判別共用体によって型が絞り込まれます。',
+      explanation: 'switch の case "reset": ブランチでは TypeScript が action を `{ type: "reset"; payload: number }` に絞り込むため、action.payload は number 型として扱えます。',
+      choices: ['number', 'string', 'unknown', 'any'],
+    },
+    {
+      id: 'q5',
+      prompt: '`setForm((prev) => ({ ...prev, email: "new@example.com" }))` — この書き方の目的は？',
+      answer: '既存フィールドを保ちながら部分更新する',
+      hint: 'スプレッド構文で既存の値をコピーしています。',
+      explanation: 'スプレッド構文 `...prev` で既存のフィールドをコピーし、変更したいフィールドだけ上書きします。これにより他のフィールドが失われません。',
+      choices: ['既存フィールドを保ちながら部分更新する', '全フィールドをリセットする', 'emailだけのオブジェクトを作る', '非同期で状態を更新する'],
+    },
+  ],
+  testTask: {
+    instruction: '`useState` でユーザー情報（User型またはnull）を管理するstateを宣言してください。初期値はnullです。',
+    starterCode: `interface User {
+  id: number
+  name: string
+}
+
+function UserProfile() {
+  const [user, setUser] = useState<____ | null>(null)
+
+  return <div>{user ? user.name : '未ログイン'}</div>
+}`,
+    expectedKeywords: ['User'],
+    explanation: '`useState<User | null>(null)` とすることで、ユーザー情報がない状態（null）とある状態（User）を型安全に扱えます。',
+  },
+  challengeTask: {
+    patterns: [
+      {
+        id: 'ts-react-state-1',
+        prompt: 'null 許容ユーザー状態を型安全に管理するコンポーネントを実装してください。',
+        requirements: [
+          'id（number）と name（string）と email（string）を持つ User interface を定義する',
+          '`useState<User | null>` でユーザー状態を管理する',
+          'ログイン関数でstateをUserにセット、ログアウト関数でnullにリセットする',
+          'ユーザーがnullのとき「ログインしてください」、そうでないとき名前とメールを表示する',
+        ],
+        hints: [
+          'useState<User | null>(null) で初期値をnullにします',
+          'null チェックで条件付きレンダリングを行います',
+          'setUser(userData) でログイン、setUser(null) でログアウトします',
+        ],
+        expectedKeywords: ['User', 'useState', 'null', 'setUser'],
+        starterCode: `// TODO: User interface を定義してください
+
+function UserProfile() {
+  // TODO: useState で User | null の state を宣言してください
+
+  function handleLogin() {
+    // TODO: ダミーユーザーデータをセット
+    // { id: 1, name: 'Alice', email: 'alice@example.com' }
+  }
+
+  function handleLogout() {
+    // TODO: null にリセット
+  }
+
+  return (
+    <div>
+      {/* TODO: ログイン状態に応じて表示を切り替える */}
+      <button onClick={handleLogin}>ログイン</button>
+      <button onClick={handleLogout}>ログアウト</button>
+    </div>
+  )
+}`,
+      },
+      {
+        id: 'ts-react-state-2',
+        prompt: 'useReducer でフォーム状態を型安全に管理してください。',
+        requirements: [
+          'email（string）と password（string）と error（string | null）を持つ FormState type を定義する',
+          '`SET_EMAIL`、`SET_PASSWORD`、`CLEAR_ERROR` の3種類の Action ユニオン型を定義する',
+          'reducer 関数を実装して各 action に応じて state を更新する',
+          'useReducer を使ったフォームコンポーネントを実装する',
+        ],
+        hints: [
+          'type FormAction = | { type: "SET_EMAIL"; email: string } | ...',
+          'reducer の引数は (state: FormState, action: FormAction): FormState',
+          'switch(action.type) で各ケースを処理します',
+        ],
+        expectedKeywords: ['FormState', 'FormAction', 'useReducer', 'reducer', 'dispatch'],
+        starterCode: `// TODO: FormState type を定義してください
+
+// TODO: FormAction ユニオン型を定義してください
+
+// TODO: reducer 関数を実装してください
+
+function LoginForm() {
+  // TODO: useReducer でフォーム状態を管理してください
+  const initialState = { email: '', password: '', error: null }
+
+  return (
+    <form>
+      {/* TODO: dispatch を使って状態を更新する入力フォームを実装 */}
+    </form>
+  )
+}`,
+      },
+    ],
+  },
+}


### PR DESCRIPTION
## Summary

- `ts-react-props` (order:27): Props interface 定義・children: ReactNode・ComponentProps<T>
- `ts-react-state` (order:28): useState<T>・null許容状態・useReducer Action ユニオン型
- `ts-react-hooks` (order:29): useRef<T> DOM参照・型付きContext・カスタムフック・forwardRef
- `ts-react-events` (order:30): ChangeEvent/MouseEvent/FormEvent/KeyboardEvent イベント型

## Test plan

- [x] typecheck 通過
- [x] lint 通過
- [x] 既存テスト 305件 PASS（stepWalkthrough は ts-react steps: [] のため未カウント）
- [x] ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)