### PR TITLE
feat: React モダン 5-2 コンテンツ作成（use-optimistic/portals/forward-ref）

### DIFF
--- a/apps/web/src/content/react-modern/steps/forward-ref.ts
+++ b/apps/web/src/content/react-modern/steps/forward-ref.ts
@@ -1,0 +1,311 @@
+import type { LearningStepContent } from '@/content/fundamentals/steps'
+
+export const forwardRefStep: LearningStepContent = {
+  id: 'forward-ref',
+  order: 36,
+  title: 'forwardRef と useImperativeHandle',
+  summary: 'forwardRefで親コンポーネントへDOM参照を公開する方法・useImperativeHandleで公開APIをカスタマイズするパターンを学ぶ。',
+  readMarkdown: `# forwardRef と useImperativeHandle
+
+## forwardRef とは
+
+通常、親コンポーネントから子コンポーネントの DOM 要素に \`ref\` を渡すことはできません。\`forwardRef\` を使うと、子コンポーネントが受け取った \`ref\` を内部の DOM 要素に転送（フォワード）できます。
+
+## 基本的な使い方
+
+\`\`\`jsx
+import { forwardRef } from 'react'
+
+// forwardRef でラップすることで、親から ref を受け取れる
+const FancyInput = forwardRef(function FancyInput(props, ref) {
+  return (
+    <input
+      ref={ref}  // ref を input 要素に転送
+      className="fancy-input"
+      {...props}
+    />
+  )
+})
+
+// 親コンポーネントから DOM に直接アクセスできる
+function Form() {
+  const inputRef = useRef(null)
+
+  function handleFocus() {
+    inputRef.current.focus()  // FancyInput 内の <input> が focus される
+  }
+
+  return (
+    <>
+      <FancyInput ref={inputRef} placeholder="入力してください" />
+      <button onClick={handleFocus}>フォーカス</button>
+    </>
+  )
+}
+\`\`\`
+
+## useImperativeHandle — 公開 API のカスタマイズ
+
+\`forwardRef\` だけだと DOM 要素そのものが丸ごと公開されます。\`useImperativeHandle\` を組み合わせると、**公開するメソッドを限定**できます。
+
+\`\`\`jsx
+import { forwardRef, useImperativeHandle, useRef } from 'react'
+
+const FancyInput = forwardRef(function FancyInput(props, ref) {
+  const inputRef = useRef(null)
+
+  // ref に公開するメソッドをカスタマイズ
+  useImperativeHandle(ref, () => ({
+    focus() {
+      inputRef.current.focus()
+    },
+    clear() {
+      inputRef.current.value = ''
+    },
+    // DOM 要素自体は公開しない
+  }))
+
+  return <input ref={inputRef} {...props} />
+})
+
+// 使う側
+function Form() {
+  const inputRef = useRef(null)
+
+  return (
+    <>
+      <FancyInput ref={inputRef} />
+      <button onClick={() => inputRef.current.focus()}>フォーカス</button>
+      <button onClick={() => inputRef.current.clear()}>クリア</button>
+      {/* inputRef.current.value など DOM プロパティには直接アクセスできない */}
+    </>
+  )
+}
+\`\`\`
+
+## TypeScript での型付け
+
+\`forwardRef\` に型引数を渡すことで型安全に使えます。
+
+\`\`\`tsx
+import { forwardRef, useRef } from 'react'
+
+interface InputProps {
+  placeholder?: string
+  className?: string
+}
+
+// forwardRef<転送先DOM型, Props型>
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  function Input({ placeholder, className }, ref) {
+    return (
+      <input
+        ref={ref}
+        placeholder={placeholder}
+        className={className}
+      />
+    )
+  }
+)
+
+// 使う側
+function App() {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  return <Input ref={inputRef} placeholder="入力" />
+}
+\`\`\`
+
+## useImperativeHandle の TypeScript 型付け
+
+\`\`\`tsx
+interface InputHandle {
+  focus: () => void
+  clear: () => void
+}
+
+const Input = forwardRef<InputHandle, InputProps>(
+  function Input(props, ref) {
+    const inputRef = useRef<HTMLInputElement>(null)
+
+    useImperativeHandle(ref, () => ({
+      focus: () => inputRef.current?.focus(),
+      clear: () => {
+        if (inputRef.current) inputRef.current.value = ''
+      },
+    }))
+
+    return <input ref={inputRef} {...props} />
+  }
+)
+
+// 使う側
+const inputRef = useRef<InputHandle>(null)
+inputRef.current?.focus()  // InputHandle の型で補完が効く
+\`\`\`
+
+## forwardRef を使うべき場面
+
+| 用途 | 例 |
+|------|-----|
+| フォーカス制御 | 送信後に入力欄へフォーカスを戻す |
+| スクロール制御 | リスト末尾へスクロール |
+| アニメーション制御 | GSAP など外部ライブラリとの連携 |
+| 再利用可能な UI ライブラリ | ボタン・入力欄などの汎用コンポーネント |
+
+## 注意点
+
+- \`ref\` は prop ではないため、\`props.ref\` でアクセスすることはできません。\`forwardRef\` の第2引数として受け取ります。
+- 必要なければ \`forwardRef\` を使わないほうがシンプルです。DOM へのアクセスが本当に必要な場合に限定して使いましょう。
+`,
+  practiceQuestions: [
+    {
+      id: 'q1',
+      prompt: '`forwardRef` を使う目的は？',
+      answer: '親コンポーネントから子コンポーネント内の DOM 要素に ref を渡すため',
+      hint: '通常は props として ref を渡せません。',
+      explanation: '関数コンポーネントは ref を props として受け取れません。forwardRef でラップすることで、親から渡された ref を子の DOM 要素に転送できます。',
+      choices: ['親コンポーネントから子コンポーネント内の DOM 要素に ref を渡すため', 'コンポーネントをメモ化するため', 'context を転送するため', 'イベントを転送するため'],
+    },
+    {
+      id: 'q2',
+      prompt: '`forwardRef((props, ref) => ...)` の `ref` は何に転送すべき？',
+      answer: '子の DOM 要素の ref prop',
+      hint: '`<input ref={ref} />` のように使います。',
+      explanation: 'forwardRef の第2引数 ref を内部の DOM 要素の ref prop に渡すことで、親が useRef で取得する ref が実際の DOM を指すようになります。',
+      choices: ['子の DOM 要素の ref prop', '親コンポーネントの state', '別の forwardRef コンポーネント', 'useContext の値'],
+    },
+    {
+      id: 'q3',
+      prompt: '`useImperativeHandle(ref, () => ({ focus() {...} }))` の目的は？',
+      answer: '親に公開する ref のメソッドを限定・カスタマイズするため',
+      hint: 'DOM 要素を丸ごと公開しないカプセル化のパターンです。',
+      explanation: 'useImperativeHandle を使うと、DOM 要素を直接公開する代わりに focus や clear などの特定のメソッドだけを公開できます。カプセル化の原則を守れます。',
+      choices: ['親に公開する ref のメソッドを限定・カスタマイズするため', 'ref の型を変換するため', 'ref の更新をバッチ処理するため', 'forwardRef を使わずに ref を転送するため'],
+    },
+    {
+      id: 'q4',
+      prompt: 'TypeScript で `forwardRef<HTMLInputElement, Props>` の第1型引数は何を表す？',
+      answer: '転送先 DOM 要素の型',
+      hint: '`useRef<HTMLInputElement>(null)` と同じ考え方です。',
+      explanation: 'forwardRef の第1型引数は ref が指す DOM 要素の型です。HTMLInputElement, HTMLDivElement など。第2型引数はコンポーネントの Props の型です。',
+      choices: ['転送先 DOM 要素の型', 'コンポーネントの Props の型', '戻り値の JSX 型', 'ref オブジェクトの型'],
+    },
+    {
+      id: 'q5',
+      prompt: '`useImperativeHandle` で独自のハンドル型を定義したとき、親側の `useRef` の型引数は何にすべき？',
+      answer: 'カスタムハンドルのインターフェース型',
+      hint: '`useRef<InputHandle>(null)` のように使います。',
+      explanation: 'useImperativeHandle で { focus, clear } などを公開する場合、親側は useRef<InputHandle>(null) とすることで inputRef.current.focus() などに型補完が効きます。',
+      choices: ['カスタムハンドルのインターフェース型', 'HTMLInputElement', 'null', 'any'],
+    },
+  ],
+  testTask: {
+    instruction: 'FancyInput を forwardRef でラップし、親から input 要素の ref にアクセスできるようにしてください。',
+    starterCode: `import { ____, useRef } from 'react'
+
+const FancyInput = ____(function FancyInput(props, ref) {
+  return <input ref={____} className="fancy" {...props} />
+})
+
+function Form() {
+  const inputRef = useRef(null)
+
+  return (
+    <>
+      <FancyInput ref={inputRef} />
+      <button onClick={() => inputRef.current.focus()}>フォーカス</button>
+    </>
+  )
+}`,
+    expectedKeywords: ['forwardRef'],
+    explanation: 'forwardRef でコンポーネントをラップし、第2引数 ref を input 要素の ref prop に渡します。',
+  },
+  challengeTask: {
+    patterns: [
+      {
+        id: 'forward-ref-1',
+        prompt: 'forwardRef を使ってフォーカスを親からコントロールできる Input コンポーネントを実装してください。',
+        requirements: [
+          'forwardRef を使って Input コンポーネントを作成する',
+          'ref を内部の input 要素に転送する',
+          '親コンポーネントから ref.current.focus() を呼べるようにする',
+          '送信ボタンクリック後に入力欄へフォーカスを戻す',
+        ],
+        hints: [
+          'const Input = forwardRef(function Input(props, ref) { return <input ref={ref} {...props} /> })',
+          '親で const inputRef = useRef(null) を作り、<Input ref={inputRef} /> に渡します',
+          '送信ハンドラの末尾で inputRef.current?.focus() を呼びます',
+        ],
+        expectedKeywords: ['forwardRef', 'ref', 'focus'],
+        starterCode: `import { forwardRef, useRef } from 'react'
+
+// TODO: forwardRef を使って Input を実装する（ref を input に転送）
+function Input(props) {
+  return <input {...props} />
+}
+
+function SearchForm() {
+  const inputRef = useRef(null)
+
+  function handleSubmit(e) {
+    e.preventDefault()
+    const query = e.target.search.value
+    console.log('検索:', query)
+    e.target.reset()
+    // TODO: 送信後に input へフォーカスを戻す
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Input ref={inputRef} name="search" placeholder="検索..." />
+      <button type="submit">検索</button>
+    </form>
+  )
+}`,
+      },
+      {
+        id: 'forward-ref-2',
+        prompt: 'useImperativeHandle を使って公開 API を限定した VideoPlayer コンポーネントを実装してください。',
+        requirements: [
+          'forwardRef と useImperativeHandle を組み合わせる',
+          '公開する API は play() と pause() のみ（video 要素自体は公開しない）',
+          '内部の useRef で video 要素を参照する',
+          '親から ref.current.play() / ref.current.pause() を呼べることを確認する',
+        ],
+        hints: [
+          'const videoRef = useRef(null) で内部参照を作り、<video ref={videoRef} /> に渡す',
+          'useImperativeHandle(ref, () => ({ play: () => videoRef.current.play(), pause: () => videoRef.current.pause() }))',
+          '親側は const playerRef = useRef(null) で playerRef.current.play() を呼ぶ',
+        ],
+        expectedKeywords: ['forwardRef', 'useImperativeHandle', 'play', 'pause'],
+        starterCode: `import { forwardRef, useRef, useImperativeHandle } from 'react'
+
+// TODO: forwardRef + useImperativeHandle で VideoPlayer を実装
+// 公開API: play() と pause() のみ
+const VideoPlayer = forwardRef(function VideoPlayer({ src }, ref) {
+  const videoRef = useRef(null)
+
+  // TODO: useImperativeHandle で play / pause のみ公開する
+
+  return <video ref={videoRef} src={src} />
+})
+
+function App() {
+  const playerRef = useRef(null)
+
+  return (
+    <div>
+      <VideoPlayer
+        ref={playerRef}
+        src="https://example.com/video.mp4"
+      />
+      <button onClick={() => playerRef.current.play()}>再生</button>
+      <button onClick={() => playerRef.current.pause()}>一時停止</button>
+    </div>
+  )
+}`,
+      },
+    ],
+  },
+}

--- a/apps/web/src/content/react-modern/steps/portals.ts
+++ b/apps/web/src/content/react-modern/steps/portals.ts
@@ -1,0 +1,283 @@
+import type { LearningStepContent } from '@/content/fundamentals/steps'
+
+export const portalsStep: LearningStepContent = {
+  id: 'portals',
+  order: 35,
+  title: 'Portals',
+  summary: 'createPortalでDOM階層の外にコンポーネントをレンダリングする方法・モーダルやツールチップへの応用・イベントバブリングの挙動を学ぶ。',
+  readMarkdown: `# Portals
+
+## Portals とは
+
+**Portals** を使うと、コンポーネントを**親 DOM 階層の外の任意の DOM ノード**にレンダリングできます。モーダル・ドロップダウン・ツールチップなど、\`overflow: hidden\` や \`z-index\` の制約から抜け出す必要がある UI に使います。
+
+## createPortal の基本構文
+
+\`\`\`jsx
+import { createPortal } from 'react-dom'
+
+createPortal(children, domNode)
+\`\`\`
+
+- \`children\`: レンダリングする React 要素
+- \`domNode\`: レンダリング先の DOM ノード（\`document.body\` など）
+
+## モーダルへの応用
+
+\`\`\`jsx
+import { createPortal } from 'react-dom'
+
+function Modal({ isOpen, onClose, children }) {
+  if (!isOpen) return null
+
+  return createPortal(
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        {children}
+        <button onClick={onClose}>閉じる</button>
+      </div>
+    </div>,
+    document.body  // <body> 直下にレンダリング
+  )
+}
+
+function App() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <div style={{ overflow: 'hidden' }}>  {/* overflow: hidden でも動作する */}
+      <button onClick={() => setIsOpen(true)}>モーダルを開く</button>
+      <Modal isOpen={isOpen} onClose={() => setIsOpen(false)}>
+        <p>モーダルのコンテンツ</p>
+      </Modal>
+    </div>
+  )
+}
+\`\`\`
+
+## カスタムコンテナへのポータル
+
+\`document.body\` 以外にも、任意の DOM 要素を指定できます。
+
+\`\`\`jsx
+function Tooltip({ text, targetRef }) {
+  const container = document.getElementById('tooltip-container')
+
+  return createPortal(
+    <div className="tooltip">{text}</div>,
+    container
+  )
+}
+\`\`\`
+
+\`\`\`html
+<!-- index.html -->
+<div id="root"></div>
+<div id="tooltip-container"></div>
+\`\`\`
+
+## イベントバブリングの挙動
+
+Portal の重要な特性: **イベントは DOM ツリーではなく React ツリーに沿ってバブリング**します。
+
+\`\`\`jsx
+function App() {
+  function handleClick() {
+    console.log('App がクリックされた')  // Portal 内のクリックでも呼ばれる！
+  }
+
+  return (
+    <div onClick={handleClick}>
+      <Modal>
+        <button>クリック</button>  {/* DOM上は body の子だが、React上は App の子 */}
+      </Modal>
+    </div>
+  )
+}
+\`\`\`
+
+モーダル内でのクリックが親の onClick を誤って発火させてしまう場合は \`e.stopPropagation()\` で防げます。
+
+## useRef と組み合わせたポータル
+
+\`\`\`jsx
+import { useRef, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+function PortalWrapper({ children }) {
+  const [mounted, setMounted] = useState(false)
+  const containerRef = useRef(null)
+
+  useEffect(() => {
+    containerRef.current = document.createElement('div')
+    document.body.appendChild(containerRef.current)
+    setMounted(true)
+
+    return () => {
+      document.body.removeChild(containerRef.current)
+    }
+  }, [])
+
+  if (!mounted) return null
+  return createPortal(children, containerRef.current)
+}
+\`\`\`
+
+クリーンアップで DOM を削除するパターンです。
+
+## Portals を使うべき場面
+
+| 用途 | 理由 |
+|------|------|
+| モーダル・ダイアログ | overflow:hidden / z-index 制約を回避 |
+| ツールチップ | 親要素のスタイルに影響されないレイアウト |
+| ドロップダウンメニュー | 親の位置指定 (position:relative) から独立 |
+| トースト通知 | 画面端への固定表示 |
+`,
+  practiceQuestions: [
+    {
+      id: 'q1',
+      prompt: '`createPortal(children, domNode)` の `domNode` に渡すのは？',
+      answer: 'レンダリング先の実際の DOM ノード',
+      hint: '`document.body` や `document.getElementById(...)` で取得します。',
+      explanation: 'domNode には実際の DOM ノード（HTMLElement）を渡します。document.body や document.getElementById で取得した要素が一般的です。',
+      choices: ['レンダリング先の実際の DOM ノード', 'React コンポーネント', 'CSSセレクタ文字列', 'ref オブジェクト'],
+    },
+    {
+      id: 'q2',
+      prompt: 'Portal を使うと、イベントバブリングはどのツリーに沿って伝播する？',
+      answer: 'React ツリー（DOM ツリーではない）',
+      hint: 'Portal でも React の親子関係は変わりません。',
+      explanation: 'Portal はレンダリング先を変えるだけで、React のコンポーネントツリーの親子関係は維持されます。そのためイベントバブリングは React ツリーに沿って伝播します。',
+      choices: ['React ツリー（DOM ツリーではない）', 'DOM ツリー（React ツリーではない）', 'どちらのツリーにも伝播しない', 'React ツリーと DOM ツリーの両方'],
+    },
+    {
+      id: 'q3',
+      prompt: 'モーダルを `document.body` 直下にレンダリングする主な理由は？',
+      answer: '親要素の overflow:hidden や z-index の影響を避けるため',
+      hint: '親のスタイルに依存しない独立したレイヤーが必要です。',
+      explanation: '親コンポーネントに overflow:hidden が設定されていると、その子要素として配置したモーダルは切り取られてしまいます。body 直下にレンダリングすることでこの制約を回避できます。',
+      choices: ['親要素の overflow:hidden や z-index の影響を避けるため', 'パフォーマンスが向上するため', 'SEO対策のため', 'TypeScript の型チェックが簡単になるため'],
+    },
+    {
+      id: 'q4',
+      prompt: 'Portal 内のクリックが意図せず親の onClick を発火させてしまうときの対処法は？',
+      answer: 'e.stopPropagation() を呼ぶ',
+      hint: 'イベントの伝播を止める標準的な方法です。',
+      explanation: 'Portal 内の要素での onClick に e.stopPropagation() を追加することで、イベントが React ツリーを伝播して親の onClick ハンドラを発火させるのを防げます。',
+      choices: ['e.stopPropagation() を呼ぶ', 'e.preventDefault() を呼ぶ', 'portal prop に stopBubbling を渡す', 'createPortal の第3引数に false を渡す'],
+    },
+    {
+      id: 'q5',
+      prompt: 'Portal を使ってコンポーネントを動的に作成したコンテナにレンダリングする場合、コンポーネントのアンマウント時に行うべきことは？',
+      answer: '作成した DOM 要素を document.body から削除する',
+      hint: 'useEffect のクリーンアップ関数で後片付けします。',
+      explanation: 'useEffect 内で document.createElement → document.body.appendChild し、クリーンアップ関数で document.body.removeChild を呼びます。これでメモリリークを防げます。',
+      choices: ['作成した DOM 要素を document.body から削除する', '何もしなくてよい（自動クリーンアップされる）', 'createPortal の戻り値に .destroy() を呼ぶ', 'ReactDOM.unmountComponentAtNode を呼ぶ'],
+    },
+  ],
+  testTask: {
+    instruction: 'isOpen が true のとき document.body へモーダルをレンダリングしてください。createPortal を使います。',
+    starterCode: `import { ____ } from 'react-dom'
+
+function Modal({ isOpen, onClose }) {
+  if (!isOpen) return null
+
+  return ____(
+    <div>
+      <p>モーダルの中身</p>
+      <button onClick={onClose}>閉じる</button>
+    </div>,
+    document.body
+  )
+}`,
+    expectedKeywords: ['createPortal'],
+    explanation: 'react-dom から createPortal をインポートし、createPortal(children, document.body) でモーダルを body 直下にレンダリングします。',
+  },
+  challengeTask: {
+    patterns: [
+      {
+        id: 'portals-1',
+        prompt: 'createPortal を使ってモーダルコンポーネントを実装してください。',
+        requirements: [
+          'createPortal で document.body へレンダリングする',
+          'isOpen が false のときは null を返す',
+          'オーバーレイクリックで onClose を呼ぶ（モーダル内クリックは閉じない）',
+          'モーダル内に children を表示し、「閉じる」ボタンを設置する',
+        ],
+        hints: [
+          'オーバーレイの onClick に onClose を設定し、モーダルコンテンツの onClick には e.stopPropagation() を付けます',
+          'createPortal の第2引数は document.body です',
+        ],
+        expectedKeywords: ['createPortal', 'document.body', 'stopPropagation'],
+        starterCode: `import { createPortal } from 'react-dom'
+import { useState } from 'react'
+
+function Modal({ isOpen, onClose, children }) {
+  // TODO: isOpen が false なら null を返す
+
+  // TODO: createPortal で document.body へレンダリング
+  // - オーバーレイ全体: onClose を設定
+  // - モーダルコンテンツ: stopPropagation で閉じないようにする
+  // - 「閉じる」ボタン
+}
+
+function App() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <div style={{ overflow: 'hidden', height: '100px' }}>
+      <button onClick={() => setIsOpen(true)}>モーダルを開く</button>
+      <Modal isOpen={isOpen} onClose={() => setIsOpen(false)}>
+        <h2>モーダルタイトル</h2>
+        <p>overflow: hidden の親でも正しく表示される</p>
+      </Modal>
+    </div>
+  )
+}`,
+      },
+      {
+        id: 'portals-2',
+        prompt: 'useEffect と createPortal を組み合わせた動的コンテナを持つポータルを実装してください。',
+        requirements: [
+          'useEffect でマウント時に div を document.body に追加し、アンマウント時に削除する',
+          'mounted フラグが true になってから createPortal でレンダリングする',
+          'children を動的コンテナ経由でレンダリングする',
+          'クリーンアップで document.body.removeChild を呼ぶ',
+        ],
+        hints: [
+          'containerRef.current に document.createElement("div") を保存します',
+          'useEffect の戻り値（クリーンアップ）で document.body.removeChild(containerRef.current) を呼びます',
+          'mounted が false のときは null を返します',
+        ],
+        expectedKeywords: ['createPortal', 'useEffect', 'removeChild', 'mounted'],
+        starterCode: `import { useRef, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+function DynamicPortal({ children }) {
+  const [mounted, setMounted] = useState(false)
+  const containerRef = useRef(null)
+
+  useEffect(() => {
+    // TODO: div を作成して body に追加、mounted を true に
+    // TODO: クリーンアップで body から削除
+
+  }, [])
+
+  // TODO: mounted が false なら null を返す
+  // TODO: createPortal で containerRef.current にレンダリング
+}
+
+function App() {
+  return (
+    <div>
+      <DynamicPortal>
+        <p>動的コンテナにレンダリングされた要素</p>
+      </DynamicPortal>
+    </div>
+  )
+}`,
+      },
+    ],
+  },
+}

--- a/apps/web/src/content/react-modern/steps/use-optimistic.ts
+++ b/apps/web/src/content/react-modern/steps/use-optimistic.ts
@@ -1,0 +1,296 @@
+import type { LearningStepContent } from '@/content/fundamentals/steps'
+
+export const useOptimisticStep: LearningStepContent = {
+  id: 'use-optimistic',
+  order: 34,
+  title: 'useOptimistic',
+  summary: 'useOptimisticを使ってサーバー応答を待たずにUIを先行更新し、非同期処理中も快適な操作感を実現する方法を学ぶ。',
+  readMarkdown: `# useOptimistic
+
+## Optimistic UI とは
+
+**Optimistic UI**（楽観的 UI）は、サーバーへのリクエストが完了する前に、成功したと仮定して UI を先行更新するパターンです。ユーザーが送信ボタンを押した瞬間にリストへ追加し、サーバー応答後に確定（または失敗時に元に戻す）します。
+
+## useOptimistic — 楽観的更新フック
+
+\`useOptimistic(state, updateFn)\` は、非同期アクション中に使う一時的な「楽観的な状態」を管理するフックです（React 19+）。
+
+\`\`\`jsx
+import { useOptimistic } from 'react'
+
+const [optimisticMessages, addOptimisticMessage] = useOptimistic(
+  messages,
+  (currentMessages, newMessage) => [...currentMessages, newMessage]
+)
+\`\`\`
+
+- \`messages\`: 実際の state（サーバー確定済み）
+- \`updateFn(currentState, payload)\`: 楽観的な状態を生成する関数
+- \`optimisticMessages\`: アクション中は楽観的な値、完了後は実際の値に戻る
+- \`addOptimisticMessage(payload)\`: 楽観的更新をトリガーする関数
+
+## 基本的な使い方
+
+\`\`\`jsx
+import { useState, useOptimistic } from 'react'
+
+function MessageList({ messages, sendMessage }) {
+  const [optimisticMessages, addOptimisticMessage] = useOptimistic(
+    messages,
+    (state, newText) => [...state, { id: Date.now(), text: newText, sending: true }]
+  )
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    const text = e.target.message.value
+    e.target.reset()
+
+    // 即時 UI 更新（楽観的）
+    addOptimisticMessage(text)
+
+    // サーバーへ送信（非同期）
+    await sendMessage(text)
+    // 完了後、optimisticMessages は自動的に実際の messages に同期される
+  }
+
+  return (
+    <div>
+      <ul>
+        {optimisticMessages.map((msg) => (
+          <li key={msg.id} style={{ opacity: msg.sending ? 0.5 : 1 }}>
+            {msg.text}
+            {msg.sending && ' (送信中...)'}
+          </li>
+        ))}
+      </ul>
+      <form onSubmit={handleSubmit}>
+        <input name="message" />
+        <button type="submit">送信</button>
+      </form>
+    </div>
+  )
+}
+\`\`\`
+
+## sending フラグでローディング状態を表現
+
+楽観的なアイテムに \`sending: true\` のようなフラグを付けることで、送信中と確定済みを区別できます。
+
+\`\`\`jsx
+const [optimisticTodos, addOptimisticTodo] = useOptimistic(
+  todos,
+  (state, newTitle) => [
+    ...state,
+    { id: \`temp-\${Date.now()}\`, title: newTitle, sending: true },
+  ]
+)
+\`\`\`
+
+## エラー時の自動ロールバック
+
+非同期アクションが失敗した場合、\`optimisticMessages\` は自動的に元の \`messages\` に戻ります。エラーハンドリングは通常の try/catch で行います。
+
+\`\`\`jsx
+async function handleSubmit(text) {
+  addOptimisticMessage(text) // 楽観的更新
+
+  try {
+    await sendToServer(text)
+    // 成功: 親から渡された messages が更新され、楽観的状態と一致する
+  } catch (err) {
+    // 失敗: optimisticMessages が元の messages に自動的に戻る
+    console.error('送信失敗', err)
+  }
+}
+\`\`\`
+
+## useTransition との組み合わせ
+
+\`useOptimistic\` は \`startTransition\` または Server Actions と組み合わせて使います。
+
+\`\`\`jsx
+import { useOptimistic, useTransition } from 'react'
+
+function App({ items, addItem }) {
+  const [isPending, startTransition] = useTransition()
+  const [optimisticItems, addOptimisticItem] = useOptimistic(
+    items,
+    (state, newItem) => [...state, { ...newItem, pending: true }]
+  )
+
+  function handleAdd(item) {
+    startTransition(async () => {
+      addOptimisticItem(item)
+      await addItem(item)
+    })
+  }
+
+  return (
+    <ul>
+      {optimisticItems.map((item) => (
+        <li key={item.id} className={item.pending ? 'opacity-50' : ''}>
+          {item.name}
+        </li>
+      ))}
+    </ul>
+  )
+}
+\`\`\`
+`,
+  practiceQuestions: [
+    {
+      id: 'q1',
+      prompt: '`useOptimistic(state, updateFn)` の `updateFn` の引数は？',
+      answer: '(currentState, payload)',
+      hint: '現在の状態と、addOptimistic に渡した値を受け取ります。',
+      explanation: 'updateFn は (currentState, payload) を受け取り、楽観的な新しい状態を返す純粋関数です。payload は addOptimistic(payload) で渡した値です。',
+      choices: ['(currentState, payload)', '(payload)', '(currentState)', '(prevState, newState)'],
+    },
+    {
+      id: 'q2',
+      prompt: 'サーバーへのリクエストが失敗した場合、楽観的な状態はどうなる？',
+      answer: '元の state に自動的に戻る',
+      hint: '「楽観的」なので、失敗したら元に戻るのが自然な挙動です。',
+      explanation: 'useOptimistic の楽観的状態は非同期アクションが失敗すると自動的に元の state に戻ります。明示的なロールバック処理は不要です。',
+      choices: ['元の state に自動的に戻る', '楽観的な状態のまま残る', 'undefined になる', 'エラーがスローされる'],
+    },
+    {
+      id: 'q3',
+      prompt: '`const [optimisticItems, addOptimisticItem] = useOptimistic(...)` — `optimisticItems` はいつ実際の state と同じ値になる？',
+      answer: '非同期アクションが完了したとき',
+      hint: 'アクション中は楽観的な値、それ以外は実際の値です。',
+      explanation: '非同期アクション（startTransition や Server Action）が完了すると、optimisticItems は自動的に実際の state と同期されます。',
+      choices: ['非同期アクションが完了したとき', 'addOptimisticItem を呼んだ直後', 'コンポーネントが再レンダリングされたとき', '常に同じ値'],
+    },
+    {
+      id: 'q4',
+      prompt: '送信中のアイテムを半透明にするには `sending: true` フラグをどこに付ける？',
+      answer: 'updateFn で返す楽観的なアイテムオブジェクト',
+      hint: 'updateFn の返却値に含めます。',
+      explanation: 'updateFn で [...state, { ...newItem, sending: true }] のように楽観的なアイテムに sending フラグを付け、UI 側で sending プロパティを参照してスタイルを変えます。',
+      choices: ['updateFn で返す楽観的なアイテムオブジェクト', 'useOptimistic の第3引数', 'addOptimisticItem の第2引数', '実際の state オブジェクト'],
+    },
+    {
+      id: 'q5',
+      prompt: '`useOptimistic` が対応しているのは React の何番以降？',
+      answer: 'React 19',
+      hint: '比較的新しいフックです。',
+      explanation: 'useOptimistic は React 19 で追加された新しいフックです。Server Actions と組み合わせる場面で特に効果を発揮します。',
+      choices: ['React 19', 'React 18', 'React 17', 'React 16'],
+    },
+  ],
+  testTask: {
+    instruction: 'メッセージ送信後に即座にリストへ追加する楽観的更新を実装してください。`useOptimistic` を使い、送信中は `sending: true` を付けます。',
+    starterCode: `import { useOptimistic } from 'react'
+
+function MessageList({ messages, sendMessage }) {
+  const [optimisticMessages, addOptimisticMessage] = ____(
+    messages,
+    (state, newText) => [...state, { id: Date.now(), text: newText, sending: true }]
+  )
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    const text = e.target.message.value
+    e.target.reset()
+    addOptimisticMessage(text)
+    await sendMessage(text)
+  }
+
+  return (
+    <ul>
+      {optimisticMessages.map((msg) => (
+        <li key={msg.id} style={{ opacity: msg.sending ? 0.5 : 1 }}>
+          {msg.text}
+        </li>
+      ))}
+    </ul>
+  )
+}`,
+    expectedKeywords: ['useOptimistic'],
+    explanation: 'useOptimistic(state, updateFn) でフックを呼び出し、楽観的な状態と更新関数を取得します。',
+  },
+  challengeTask: {
+    patterns: [
+      {
+        id: 'use-optimistic-1',
+        prompt: 'useOptimistic を使って「いいね」ボタンを楽観的に更新してください。',
+        requirements: [
+          'useOptimistic で likes カウントを楽観的に+1する',
+          'ボタンクリック時に addOptimisticLike() を呼び、即座に表示を更新する',
+          'toggleLike(postId) という非同期関数でサーバーへ送信する',
+          '送信中は liked フラグを反転した楽観的な値を表示する',
+        ],
+        hints: [
+          'updateFn: (state) => ({ ...state, likes: state.likes + 1, liked: !state.liked })',
+          'addOptimisticLike は引数なし（payload 不要）でも使えます',
+          'startTransition 内で addOptimisticLike と await toggleLike を呼びます',
+        ],
+        expectedKeywords: ['useOptimistic', 'addOptimistic'],
+        starterCode: `import { useOptimistic, useTransition } from 'react'
+
+function LikeButton({ post, toggleLike }) {
+  const [isPending, startTransition] = useTransition()
+  // TODO: useOptimistic で likes と liked を楽観的に管理する
+  // updateFn: likes を+1し、liked を反転する
+
+  function handleClick() {
+    startTransition(async () => {
+      // TODO: 楽観的更新 → サーバー送信
+    })
+  }
+
+  return (
+    <button onClick={handleClick} disabled={isPending}>
+      {/* TODO: 楽観的な likes と liked を表示 */}
+      {post.liked ? '❤️' : '🤍'} {post.likes}
+    </button>
+  )
+}`,
+      },
+      {
+        id: 'use-optimistic-2',
+        prompt: 'useOptimistic を使ったTodoリストの追加を実装してください。',
+        requirements: [
+          'useOptimistic で todos リストを楽観的に更新する',
+          'フォーム送信時に新しい Todo を即座にリストへ追加する（pending: true 付き）',
+          'pending な Todo は opacity-50 で半透明表示する',
+          'createTodo(title) でサーバーへ送信し、完了後に実際のリストが更新される',
+        ],
+        hints: [
+          'updateFn: (state, title) => [...state, { id: `temp-${Date.now()}`, title, pending: true }]',
+          'フォームの onSubmit で addOptimisticTodo(title) を呼ぶ',
+          'className={`${todo.pending ? "opacity-50" : ""}`} でスタイルを制御',
+        ],
+        expectedKeywords: ['useOptimistic', 'pending'],
+        starterCode: `import { useOptimistic } from 'react'
+
+function TodoList({ todos, createTodo }) {
+  // TODO: useOptimistic で todo リストを楽観的に管理する
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    const title = e.target.title.value
+    e.target.reset()
+    // TODO: 楽観的更新 + サーバー送信
+  }
+
+  return (
+    <div>
+      <ul>
+        {/* TODO: optimisticTodos をレンダリング（pending で opacity-50）*/}
+        {todos.map((todo) => (
+          <li key={todo.id}>{todo.title}</li>
+        ))}
+      </ul>
+      <form onSubmit={handleSubmit}>
+        <input name="title" placeholder="新しい Todo" />
+        <button type="submit">追加</button>
+      </form>
+    </div>
+  )
+}`,
+      },
+    ],
+  },
+}


### PR DESCRIPTION
## 概要

v2 M5 タスク 5-2 — React モダンコースの残り3ステップを作成。

## 作成したコンテンツ

| ファイル | ID | order | タイトル |
|---------|-----|-------|---------|
| `content/react-modern/steps/use-optimistic.ts` | `use-optimistic` | 34 | useOptimistic |
| `content/react-modern/steps/portals.ts` | `portals` | 35 | Portals |
| `content/react-modern/steps/forward-ref.ts` | `forward-ref` | 36 | forwardRef と useImperativeHandle |

## 各ステップの構成

- **readMarkdown**: react.dev Reference 準拠
- **practiceQuestions**: 5問（選択式）
- **testTask**: 穴埋め式コード補完
- **challengeTask**: 2パターン（実装課題）

## チェック

- [x] typecheck / lint PASS（pre-commit フック通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)