### PR TITLE
feat: デイリーチャレンジ DB SQL・型定義・定数 (7-1)

### DIFF
--- a/apps/web/src/shared/constants.ts
+++ b/apps/web/src/shared/constants.ts
@@ -1,6 +1,9 @@
 /** 学習モード（Read/Practice/Test/Challenge）完了時に付与されるポイント */
 export const POINTS_PER_MODE_COMPLETE = 10
 
+/** デイリーチャレンジ正解時に付与されるポイント */
+export const POINTS_DAILY_CORRECT = 20
+
 /** ポイントバッジの閾値 */
 export const BADGE_POINT_THRESHOLD_MID = 500
 export const BADGE_POINT_THRESHOLD_HIGH = 1000

--- a/apps/web/src/shared/types/database.types.ts
+++ b/apps/web/src/shared/types/database.types.ts
@@ -137,6 +137,36 @@ export type Database = {
         }
         Relationships: []
       }
+      daily_challenge_history: {
+        Row: {
+          id: string
+          user_id: string
+          challenge_id: string
+          completed: boolean
+          points_earned: number
+          completed_at: string | null
+          challenge_date: string
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          challenge_id: string
+          completed?: boolean
+          points_earned?: number
+          completed_at?: string | null
+          challenge_date: string
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          challenge_id?: string
+          completed?: boolean
+          points_earned?: number
+          completed_at?: string | null
+          challenge_date?: string
+        }
+        Relationships: []
+      }
       step_progress: {
         Row: {
           challenge_done: boolean

--- a/apps/web/supabase/sql/006_daily_challenge.sql
+++ b/apps/web/supabase/sql/006_daily_challenge.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS public.daily_challenge_history (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  challenge_id TEXT NOT NULL,
+  completed BOOLEAN NOT NULL DEFAULT false,
+  points_earned INTEGER NOT NULL DEFAULT 0,
+  completed_at TIMESTAMPTZ,
+  challenge_date DATE NOT NULL,
+  UNIQUE(user_id, challenge_date)
+);
+ALTER TABLE public.daily_challenge_history ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "own_data" ON public.daily_challenge_history
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## 変更内容
- 006_daily_challenge.sql: daily_challenge_history テーブル + RLS ポリシー
- database.types.ts: daily_challenge_history 型を追加
- constants.ts: POINTS_DAILY_CORRECT = 20 を追加

typecheck/lint pass