### PR TITLE
feat: デイリーチャレンジ サービス・テスト・UI (7-3)

### DIFF
--- a/apps/web/src/features/daily/components/CompletedView.tsx
+++ b/apps/web/src/features/daily/components/CompletedView.tsx
@@ -1,0 +1,32 @@
+interface CompletedViewProps {
+  completedAt: string | null
+  pointsEarned: number
+  dateStr: string
+}
+
+export function CompletedView({ completedAt, pointsEarned, dateStr }: CompletedViewProps) {
+  const formattedDate = dateStr.replace(/-/g, '/')
+  const formattedTime = completedAt
+    ? new Date(completedAt).toLocaleTimeString('ja-JP', {
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    : null
+
+  return (
+    <div className="rounded-xl border border-green-200 bg-green-50 p-6 text-center shadow-sm">
+      <div className="mb-3 text-4xl">✅</div>
+      <h2 className="mb-1 text-lg font-bold text-green-700">今日のチャレンジは完了です！</h2>
+      <p className="mb-4 text-sm text-text-muted">
+        {formattedDate}
+        {formattedTime ? ` ${formattedTime}` : ''} に達成
+      </p>
+      {pointsEarned > 0 && (
+        <div className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-4 py-1.5 text-sm font-semibold text-amber-700">
+          +{pointsEarned} Pt 獲得
+        </div>
+      )}
+      <p className="mt-4 text-sm text-text-muted">明日またチャレンジしてください 🔥</p>
+    </div>
+  )
+}

--- a/apps/web/src/features/daily/components/DailyChallengeCard.tsx
+++ b/apps/web/src/features/daily/components/DailyChallengeCard.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react'
+import type { DailyQuestion, SubmitResult } from '../../../content/daily/types'
+
+interface DailyChallengeCardProps {
+  question: DailyQuestion
+  dateStr: string
+  onSubmit: (answer: string) => Promise<SubmitResult>
+}
+
+export function DailyChallengeCard({ question, dateStr, onSubmit }: DailyChallengeCardProps) {
+  const [answer, setAnswer] = useState('')
+  const [result, setResult] = useState<SubmitResult | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [showHint, setShowHint] = useState(false)
+
+  const handleSubmit = async () => {
+    if (!answer.trim() || isSubmitting) return
+    setIsSubmitting(true)
+    try {
+      const res = await onSubmit(answer)
+      setResult(res)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const formattedDate = dateStr.replace(/-/g, '/')
+
+  return (
+    <div className="rounded-xl border border-border bg-bg-surface p-6 shadow-sm">
+      <div className="mb-4 flex items-center justify-between">
+        <span className="text-sm text-text-muted">📅 {formattedDate}</span>
+        <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700">
+          {question.type === 'blank' ? '穴埋め' : '選択式'}
+        </span>
+      </div>
+
+      <p className="mb-5 whitespace-pre-wrap text-base font-medium leading-relaxed text-text-dark">
+        {question.prompt}
+      </p>
+
+      {!result && (
+        <>
+          {question.type === 'blank' ? (
+            <input
+              type="text"
+              value={answer}
+              onChange={(e) => setAnswer(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') void handleSubmit()
+              }}
+              placeholder="答えを入力..."
+              className="mb-4 w-full rounded-lg border border-border bg-bg-base px-4 py-2 text-sm text-text-dark placeholder-text-muted focus:border-amber-400 focus:outline-none focus:ring-1 focus:ring-amber-400"
+            />
+          ) : (
+            <div className="mb-4 space-y-2">
+              {question.choices?.map((choice) => (
+                <label
+                  key={choice}
+                  className={[
+                    'flex cursor-pointer items-center gap-3 rounded-lg border px-4 py-3 text-sm transition-colors',
+                    answer === choice
+                      ? 'border-amber-400 bg-amber-50 text-amber-700'
+                      : 'border-border bg-bg-base text-text-dark hover:border-amber-200 hover:bg-amber-50/50',
+                  ].join(' ')}
+                >
+                  <input
+                    type="radio"
+                    name="choice"
+                    value={choice}
+                    checked={answer === choice}
+                    onChange={() => setAnswer(choice)}
+                    className="accent-amber-500"
+                  />
+                  {choice}
+                </label>
+              ))}
+            </div>
+          )}
+
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => void handleSubmit()}
+              disabled={!answer.trim() || isSubmitting}
+              className="rounded-lg bg-amber-500 px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isSubmitting ? '判定中...' : '判定する'}
+            </button>
+            <button
+              onClick={() => setShowHint((v) => !v)}
+              className="text-sm text-text-muted underline hover:text-text-dark"
+            >
+              {showHint ? 'ヒントを隠す' : 'ヒントを見る'}
+            </button>
+          </div>
+
+          {showHint && (
+            <p className="mt-3 rounded-lg bg-blue-50 px-4 py-2 text-sm text-blue-700">
+              💡 {question.hint}
+            </p>
+          )}
+        </>
+      )}
+
+      {result && (
+        <div
+          className={[
+            'rounded-xl border p-5',
+            result.isCorrect
+              ? 'border-green-200 bg-green-50'
+              : 'border-red-200 bg-red-50',
+          ].join(' ')}
+        >
+          <div className="mb-2 flex items-center gap-2">
+            <span className="text-xl">{result.isCorrect ? '🎉' : '😢'}</span>
+            <span
+              className={[
+                'text-base font-bold',
+                result.isCorrect ? 'text-green-700' : 'text-red-700',
+              ].join(' ')}
+            >
+              {result.isCorrect ? '正解！' : '不正解'}
+            </span>
+            {result.isCorrect && (
+              <span className="ml-auto text-sm font-semibold text-amber-600">
+                +{result.pointsEarned} Pt
+              </span>
+            )}
+          </div>
+          {!result.isCorrect && (
+            <p className="mb-2 text-sm text-text-dark">
+              正解: <span className="font-mono font-semibold text-red-700">{result.correctAnswer}</span>
+            </p>
+          )}
+          <p className="text-sm leading-relaxed text-text-dark">{result.explanation}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/features/daily/components/PracticeModeNav.tsx
+++ b/apps/web/src/features/daily/components/PracticeModeNav.tsx
@@ -1,0 +1,43 @@
+import { Link, useLocation } from 'react-router-dom'
+import { Zap, Stethoscope, FolderOpen, BookOpen } from 'lucide-react'
+
+const NAV_ITEMS = [
+  { path: '/daily', label: 'デイリー', icon: Zap },
+  { path: '/code-doctor', label: 'ドクター', icon: Stethoscope },
+  { path: '/mini-projects', label: 'ミニプロ', icon: FolderOpen },
+  { path: '/code-reading', label: 'リーディング', icon: BookOpen },
+]
+
+export function PracticeModeNav() {
+  const { pathname } = useLocation()
+
+  return (
+    <nav className="w-44 shrink-0">
+      <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-text-light">
+        練習モード
+      </p>
+      <ul className="space-y-1">
+        {NAV_ITEMS.map(({ path, label, icon: Icon }) => {
+          const isActive = pathname === path
+          return (
+            <li key={path}>
+              <Link
+                to={path}
+                className={[
+                  'flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                  isActive
+                    ? 'bg-amber-100 text-amber-700'
+                    : 'text-text-muted hover:bg-bg-surface hover:text-text-dark',
+                ].join(' ')}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                <Icon size={16} />
+                {label}
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}

--- a/apps/web/src/features/daily/components/WeeklyStatus.tsx
+++ b/apps/web/src/features/daily/components/WeeklyStatus.tsx
@@ -1,0 +1,39 @@
+import type { WeeklyStatusEntry } from '../../../content/daily/types'
+
+const DAY_LABELS = ['月', '火', '水', '木', '金', '土', '日']
+
+interface WeeklyStatusProps {
+  entries: WeeklyStatusEntry[]
+  todayStr: string
+}
+
+export function WeeklyStatus({ entries, todayStr }: WeeklyStatusProps) {
+  return (
+    <div className="rounded-xl border border-border bg-bg-surface p-4">
+      <h3 className="mb-3 text-sm font-semibold text-text-dark">今週の達成状況</h3>
+      <div className="flex items-center gap-2">
+        {entries.map((entry, i) => {
+          const isToday = entry.date === todayStr
+          return (
+            <div key={entry.date} className="flex flex-col items-center gap-1">
+              <span className="text-xs text-text-muted">{DAY_LABELS[i]}</span>
+              <div
+                className={[
+                  'flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold',
+                  entry.completed
+                    ? 'bg-amber-400 text-white'
+                    : isToday
+                      ? 'border-2 border-amber-400 bg-bg-base text-amber-500'
+                      : 'bg-gray-100 text-text-muted',
+                ].join(' ')}
+                aria-label={`${entry.date} ${entry.completed ? '達成' : '未達成'}`}
+              >
+                {entry.completed ? '✓' : isToday ? '●' : '○'}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/pages/DailyChallengePage.tsx
+++ b/apps/web/src/pages/DailyChallengePage.tsx
@@ -1,12 +1,119 @@
+import { useEffect, useState, useCallback } from 'react'
+import { useAuth } from '../contexts/AuthContext'
+import { useLearningContext } from '../contexts/LearningContext'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { getTodayChallenge, submitDailyAnswer, getWeeklyStatus, getTodayJst } from '../services/dailyChallengeService'
+import { PracticeModeNav } from '../features/daily/components/PracticeModeNav'
+import { WeeklyStatus } from '../features/daily/components/WeeklyStatus'
+import { DailyChallengeCard } from '../features/daily/components/DailyChallengeCard'
+import { CompletedView } from '../features/daily/components/CompletedView'
+import { Spinner } from '../components/Spinner'
+import type { TodayChallengeResult, SubmitResult, WeeklyStatusEntry } from '../content/daily/types'
 
 export function DailyChallengePage() {
   useDocumentTitle('デイリーチャレンジ')
 
+  const { user } = useAuth()
+  const { completedStepIds, isLoadingStats } = useLearningContext()
+
+  const [challenge, setChallenge] = useState<TodayChallengeResult | null>(null)
+  const [weeklyStatus, setWeeklyStatus] = useState<WeeklyStatusEntry[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const todayStr = getTodayJst()
+
+  const loadChallenge = useCallback(async () => {
+    if (!user || isLoadingStats) return
+    setIsLoading(true)
+    setError(null)
+    try {
+      const [challengeData, weekly] = await Promise.all([
+        getTodayChallenge(user.id, completedStepIds),
+        getWeeklyStatus(user.id),
+      ])
+      setChallenge(challengeData)
+      setWeeklyStatus(weekly)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'データの取得に失敗しました')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [user, completedStepIds, isLoadingStats])
+
+  useEffect(() => {
+    void loadChallenge()
+  }, [loadChallenge])
+
+  const handleSubmit = async (answer: string): Promise<SubmitResult> => {
+    if (!user || !challenge?.question) {
+      throw new Error('問題が読み込まれていません')
+    }
+    const result = await submitDailyAnswer(user.id, challenge.question, answer, challenge.dateStr)
+    // 回答後に状態を更新
+    setChallenge((prev) =>
+      prev
+        ? {
+            ...prev,
+            alreadyCompleted: true,
+            completedAt: new Date().toISOString(),
+            pointsEarned: result.pointsEarned,
+            question: null,
+          }
+        : prev,
+    )
+    setWeeklyStatus((prev) =>
+      prev.map((e) => (e.date === todayStr ? { ...e, completed: result.isCorrect } : e)),
+    )
+    return result
+  }
+
   return (
-    <div className="flex min-h-[60vh] flex-col items-center justify-center">
-      <h1 className="text-2xl font-bold text-text-dark">デイリーチャレンジ</h1>
-      <p className="mt-2 text-text-light">準備中です</p>
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <div className="flex gap-8">
+        <PracticeModeNav />
+
+        <div className="min-w-0 flex-1 space-y-5">
+          <div>
+            <h1 className="text-2xl font-bold text-text-dark">デイリーチャレンジ</h1>
+            <p className="mt-1 text-sm text-text-muted">完了済みステップから毎日1問出題されます</p>
+          </div>
+
+          {isLoading || isLoadingStats ? (
+            <div className="flex justify-center py-16">
+              <Spinner />
+            </div>
+          ) : error ? (
+            <div className="rounded-xl border border-red-200 bg-red-50 p-5 text-sm text-red-700">
+              {error}
+            </div>
+          ) : completedStepIds.size === 0 ? (
+            <div className="rounded-xl border border-border bg-bg-surface p-8 text-center">
+              <p className="text-2xl">📚</p>
+              <p className="mt-2 font-semibold text-text-dark">ステップを完了するとチャレンジ解禁！</p>
+              <p className="mt-1 text-sm text-text-muted">
+                まずはステップの学習を進めてください。完了済みステップの問題が毎日出題されます。
+              </p>
+            </div>
+          ) : challenge?.alreadyCompleted ? (
+            <CompletedView
+              completedAt={challenge.completedAt}
+              pointsEarned={challenge.pointsEarned}
+              dateStr={challenge.dateStr}
+            />
+          ) : challenge?.question ? (
+            <DailyChallengeCard
+              question={challenge.question}
+              dateStr={challenge.dateStr}
+              onSubmit={handleSubmit}
+            />
+          ) : null}
+
+          {weeklyStatus.length > 0 && (
+            <WeeklyStatus entries={weeklyStatus} todayStr={todayStr} />
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/services/__tests__/dailyChallengeService.test.ts
+++ b/apps/web/src/services/__tests__/dailyChallengeService.test.ts
@@ -1,0 +1,288 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { supabase } from '../../lib/supabaseClient'
+import { awardPoints } from '../pointService'
+import {
+  getTodayJst,
+  getCurrentWeekDates,
+  selectDailyQuestion,
+  getTodayChallenge,
+  submitDailyAnswer,
+  getWeeklyStatus,
+} from '../dailyChallengeService'
+
+// Supabase クライアントをモック
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}))
+
+// pointService をモック
+vi.mock('../pointService', () => ({
+  awardPoints: vi.fn(),
+}))
+
+const mockFrom = vi.mocked(supabase.from)
+const mockAwardPoints = vi.mocked(awardPoints)
+
+// ─── 純粋関数テスト ──────────────────────────────────────
+
+describe('getTodayJst', () => {
+  it('UTC 時刻が JST に変換されて日付が返される', () => {
+    // UTC 15:00 = JST 翌日 00:00 → 日付が変わる境界
+    const utcMidnight = new Date('2026-03-30T15:00:00Z')
+    expect(getTodayJst(utcMidnight)).toBe('2026-03-31')
+  })
+
+  it('UTC 14:59 は JST 23:59 で前日のまま', () => {
+    const before = new Date('2026-03-30T14:59:00Z')
+    expect(getTodayJst(before)).toBe('2026-03-30')
+  })
+
+  it('引数なしで呼び出しても文字列が返る', () => {
+    const result = getTodayJst()
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})
+
+describe('getCurrentWeekDates', () => {
+  it('月曜日を週の先頭として7日分を返す', () => {
+    // 2026-03-30 は月曜日（JST）
+    const monday = new Date('2026-03-30T00:00:00Z')
+    const dates = getCurrentWeekDates(monday)
+    expect(dates).toHaveLength(7)
+    expect(dates[0]).toBe('2026-03-30')
+    expect(dates[6]).toBe('2026-04-05')
+  })
+
+  it('水曜日を基点にした場合も月曜始まりの7日を返す', () => {
+    // 2026-04-01 は水曜
+    const wednesday = new Date('2026-04-01T00:00:00Z')
+    const dates = getCurrentWeekDates(wednesday)
+    expect(dates[0]).toBe('2026-03-30') // 月曜
+    expect(dates[6]).toBe('2026-04-05') // 日曜
+  })
+
+  it('日曜日を基点にした場合も正しい月曜始まりの7日を返す', () => {
+    // 2026-04-05 は日曜
+    const sunday = new Date('2026-04-05T00:00:00Z')
+    const dates = getCurrentWeekDates(sunday)
+    expect(dates[0]).toBe('2026-03-30') // 月曜
+    expect(dates[6]).toBe('2026-04-05') // 日曜
+  })
+})
+
+describe('selectDailyQuestion', () => {
+  it('完了済みステップが空なら undefined を返す', () => {
+    const result = selectDailyQuestion(new Set(), '2026-03-30')
+    expect(result).toBeUndefined()
+  })
+
+  it('完了済みステップに対応する問題が返される', () => {
+    const completedStepIds = new Set(['usestate-basic'])
+    const result = selectDailyQuestion(completedStepIds, '2026-03-30')
+    expect(result).toBeDefined()
+    expect(result?.stepId).toBe('usestate-basic')
+  })
+
+  it('同じ日付・同じ完了ステップなら同じ問題が返される（決定論的）', () => {
+    const completedStepIds = new Set(['usestate-basic', 'events', 'conditional'])
+    const r1 = selectDailyQuestion(completedStepIds, '2026-03-30')
+    const r2 = selectDailyQuestion(completedStepIds, '2026-03-30')
+    expect(r1?.id).toBe(r2?.id)
+  })
+
+  it('日付が異なれば問題が変わりうる', () => {
+    const completedStepIds = new Set([
+      'usestate-basic', 'events', 'conditional', 'lists',
+      'useeffect', 'forms', 'usecontext', 'usereducer',
+    ])
+    const results = new Set(
+      ['2026-03-30', '2026-03-31', '2026-04-01', '2026-04-02'].map(
+        (d) => selectDailyQuestion(completedStepIds, d)?.id,
+      ),
+    )
+    // 4日間で少なくとも2種類以上の問題が選ばれる
+    expect(results.size).toBeGreaterThan(1)
+  })
+
+  it('完了済みステップに含まれないステップの問題は選ばれない', () => {
+    const completedStepIds = new Set(['usestate-basic'])
+    // 100 日分チェック
+    const ids = Array.from({ length: 100 }, (_, i) => {
+      const d = new Date(Date.UTC(2026, 0, 1) + i * 86400000).toISOString().slice(0, 10)
+      return selectDailyQuestion(completedStepIds, d)?.stepId
+    })
+    const uniqueStepIds = new Set(ids)
+    expect(uniqueStepIds.has('events')).toBe(false)
+    expect(uniqueStepIds.has('usestate-basic')).toBe(true)
+  })
+})
+
+// ─── DB 関数テスト ───────────────────────────────────────
+
+describe('getTodayChallenge', () => {
+  const userId = 'user-1'
+  const completedStepIds = new Set(['usestate-basic'])
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('未完了の場合は question を返す', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          }),
+        }),
+      }),
+    } as unknown as ReturnType<typeof supabase.from>)
+
+    const result = await getTodayChallenge(userId, completedStepIds)
+    expect(result.alreadyCompleted).toBe(false)
+    expect(result.question).toBeDefined()
+    expect(result.question?.stepId).toBe('usestate-basic')
+  })
+
+  it('完了済みの場合は alreadyCompleted: true を返す', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                challenge_id: 'usestate-basic-daily-0',
+                completed: true,
+                points_earned: 20,
+                completed_at: '2026-03-30T10:00:00Z',
+              },
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    } as unknown as ReturnType<typeof supabase.from>)
+
+    const result = await getTodayChallenge(userId, completedStepIds)
+    expect(result.alreadyCompleted).toBe(true)
+    expect(result.question).toBeNull()
+    expect(result.pointsEarned).toBe(20)
+  })
+
+  it('完了済みステップがない場合は question: null を返す', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          }),
+        }),
+      }),
+    } as unknown as ReturnType<typeof supabase.from>)
+
+    const result = await getTodayChallenge(userId, new Set())
+    expect(result.question).toBeNull()
+    expect(result.alreadyCompleted).toBe(false)
+  })
+})
+
+describe('submitDailyAnswer', () => {
+  const userId = 'user-1'
+  const dateStr = '2026-03-30'
+  const question = {
+    id: 'usestate-basic-daily-0',
+    stepId: 'usestate-basic',
+    type: 'blank' as const,
+    prompt: 'テスト問題',
+    answer: 'setCount',
+    hint: 'ヒント',
+    explanation: '解説',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFrom.mockReturnValue({
+      upsert: vi.fn().mockResolvedValue({ error: null }),
+    } as unknown as ReturnType<typeof supabase.from>)
+    mockAwardPoints.mockResolvedValue()
+  })
+
+  it('正解の場合は isCorrect: true と 20pt を返す', async () => {
+    const result = await submitDailyAnswer(userId, question, 'setCount', dateStr)
+    expect(result.isCorrect).toBe(true)
+    expect(result.pointsEarned).toBe(20)
+    expect(mockAwardPoints).toHaveBeenCalledWith(userId, 20, 'デイリーチャレンジ正解')
+  })
+
+  it('不正解の場合は isCorrect: false と 0pt を返す', async () => {
+    const result = await submitDailyAnswer(userId, question, 'wrongAnswer', dateStr)
+    expect(result.isCorrect).toBe(false)
+    expect(result.pointsEarned).toBe(0)
+    expect(mockAwardPoints).not.toHaveBeenCalled()
+  })
+
+  it('前後の空白を無視して正解判定する', async () => {
+    const result = await submitDailyAnswer(userId, question, '  setCount  ', dateStr)
+    expect(result.isCorrect).toBe(true)
+  })
+
+  it('大文字・小文字を区別せずに判定する', async () => {
+    const result = await submitDailyAnswer(userId, question, 'SETCOUNT', dateStr)
+    expect(result.isCorrect).toBe(true)
+  })
+
+  it('正解時に explanation が返される', async () => {
+    const result = await submitDailyAnswer(userId, question, 'setCount', dateStr)
+    expect(result.explanation).toBe('解説')
+    expect(result.correctAnswer).toBe('setCount')
+  })
+})
+
+describe('getWeeklyStatus', () => {
+  const userId = 'user-1'
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('7日分のエントリが返される', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          gte: vi.fn().mockReturnValue({
+            lte: vi.fn().mockResolvedValue({ data: [], error: null }),
+          }),
+        }),
+      }),
+    } as unknown as ReturnType<typeof supabase.from>)
+
+    const result = await getWeeklyStatus(userId)
+    expect(result).toHaveLength(7)
+  })
+
+  it('完了済みの日付が completed: true になる', async () => {
+    // 2026-03-30 を月曜として固定
+    const monday = new Date('2026-03-30T00:00:00Z')
+
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          gte: vi.fn().mockReturnValue({
+            lte: vi.fn().mockResolvedValue({
+              data: [{ challenge_date: '2026-03-30', completed: true }],
+              error: null,
+            }),
+          }),
+        }),
+      }),
+    } as unknown as ReturnType<typeof supabase.from>)
+
+    const result = await getWeeklyStatus(userId, monday)
+    const monday_entry = result.find((e) => e.date === '2026-03-30')
+    expect(monday_entry?.completed).toBe(true)
+    const tuesday_entry = result.find((e) => e.date === '2026-03-31')
+    expect(tuesday_entry?.completed).toBe(false)
+  })
+})

--- a/apps/web/src/services/dailyChallengeService.ts
+++ b/apps/web/src/services/dailyChallengeService.ts
@@ -1,0 +1,164 @@
+import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+import { POINTS_DAILY_CORRECT } from '../shared/constants'
+import { awardPoints } from './pointService'
+import { DAILY_QUESTIONS } from '../content/daily/questions'
+import type {
+  DailyQuestion,
+  TodayChallengeResult,
+  SubmitResult,
+  WeeklyStatusEntry,
+} from '../content/daily/types'
+
+// ─── 純粋関数 ────────────────────────────────────────────
+
+/** 現在の JST 日付を 'YYYY-MM-DD' 形式で返す */
+export function getTodayJst(now?: Date): string {
+  const d = now ?? new Date()
+  // UTC+9 に補正
+  const jst = new Date(d.getTime() + 9 * 60 * 60 * 1000)
+  return jst.toISOString().slice(0, 10)
+}
+
+/** dateStr ('YYYY-MM-DD') が含まれる週（月〜日）の7日分の日付を返す */
+export function getCurrentWeekDates(now?: Date): string[] {
+  const todayStr = getTodayJst(now)
+  const today = new Date(todayStr + 'T00:00:00Z')
+  // 0=日, 1=月, ..., 6=土 → 月曜を週の起点にする
+  const dayOfWeek = today.getUTCDay() // 0=Sun
+  const mondayOffset = dayOfWeek === 0 ? -6 : 1 - dayOfWeek
+  const monday = new Date(today.getTime() + mondayOffset * 24 * 60 * 60 * 1000)
+
+  return Array.from({ length: 7 }, (_, i) => {
+    const d = new Date(monday.getTime() + i * 24 * 60 * 60 * 1000)
+    return d.toISOString().slice(0, 10)
+  })
+}
+
+/** 完了済みステップのプールから日付に基づいて問題を選択する（決定論的） */
+export function selectDailyQuestion(
+  completedStepIds: ReadonlySet<string>,
+  dateStr: string,
+): DailyQuestion | undefined {
+  if (completedStepIds.size === 0) return undefined
+
+  // 完了済みステップの問題プールを生成
+  const pool = DAILY_QUESTIONS.filter((q) => completedStepIds.has(q.stepId))
+  if (pool.length === 0) return undefined
+
+  // epochDays を決定論的シードとして使用
+  const epochDays = Math.floor(new Date(dateStr + 'T00:00:00Z').getTime() / (1000 * 60 * 60 * 24))
+  return pool[epochDays % pool.length]
+}
+
+// ─── DB 関数 ─────────────────────────────────────────────
+
+/** 今日のチャレンジ情報を取得する */
+export async function getTodayChallenge(
+  userId: string,
+  completedStepIds: ReadonlySet<string>,
+  now?: Date,
+): Promise<TodayChallengeResult> {
+  const dateStr = getTodayJst(now)
+
+  // 今日の完了履歴を確認
+  const { data: history, error } = await supabase
+    .from('daily_challenge_history')
+    .select('challenge_id, completed, points_earned, completed_at')
+    .eq('user_id', userId)
+    .eq('challenge_date', dateStr)
+    .maybeSingle()
+
+  if (error) {
+    throw fromSupabaseError(error, 'デイリーチャレンジ履歴の取得に失敗しました')
+  }
+
+  if (history?.completed) {
+    return {
+      question: null,
+      alreadyCompleted: true,
+      completedAt: history.completed_at,
+      pointsEarned: history.points_earned,
+      dateStr,
+    }
+  }
+
+  const question = selectDailyQuestion(completedStepIds, dateStr)
+
+  return {
+    question: question ?? null,
+    alreadyCompleted: false,
+    completedAt: null,
+    pointsEarned: 0,
+    dateStr,
+  }
+}
+
+/** デイリーチャレンジの回答を送信する */
+export async function submitDailyAnswer(
+  userId: string,
+  question: DailyQuestion,
+  userAnswer: string,
+  dateStr: string,
+): Promise<SubmitResult> {
+  const isCorrect = userAnswer.trim().toLowerCase() === question.answer.trim().toLowerCase()
+  const pointsEarned = isCorrect ? POINTS_DAILY_CORRECT : 0
+
+  const { error } = await supabase
+    .from('daily_challenge_history')
+    .upsert(
+      {
+        user_id: userId,
+        challenge_id: question.id,
+        completed: true,
+        points_earned: pointsEarned,
+        completed_at: new Date().toISOString(),
+        challenge_date: dateStr,
+      },
+      { onConflict: 'user_id,challenge_date' },
+    )
+
+  if (error) {
+    throw fromSupabaseError(error, 'デイリーチャレンジの送信に失敗しました')
+  }
+
+  if (isCorrect) {
+    await awardPoints(userId, POINTS_DAILY_CORRECT, 'デイリーチャレンジ正解')
+  }
+
+  return {
+    isCorrect,
+    pointsEarned,
+    correctAnswer: question.answer,
+    explanation: question.explanation,
+  }
+}
+
+/** 今週（月〜日）の達成状況を取得する */
+export async function getWeeklyStatus(
+  userId: string,
+  now?: Date,
+): Promise<WeeklyStatusEntry[]> {
+  const weekDates = getCurrentWeekDates(now)
+  const [from, to] = [weekDates[0], weekDates[6]]
+
+  const { data, error } = await supabase
+    .from('daily_challenge_history')
+    .select('challenge_date, completed')
+    .eq('user_id', userId)
+    .gte('challenge_date', from)
+    .lte('challenge_date', to)
+
+  if (error) {
+    throw fromSupabaseError(error, '週間達成状況の取得に失敗しました')
+  }
+
+  const completedDates = new Set(
+    (data ?? []).filter((r) => r.completed).map((r) => r.challenge_date),
+  )
+
+  return weekDates.map((date) => ({
+    date,
+    completed: completedDates.has(date),
+  }))
+}


### PR DESCRIPTION
## 変更内容
- dailyChallengeService.ts: 純粋関数(getTodayJst/getCurrentWeekDates/selectDailyQuestion) + DB関数(getTodayChallenge/submitDailyAnswer/getWeeklyStatus)
- dailyChallengeService.test.ts: 21テスト追加
- PracticeModeNav.tsx / WeeklyStatus.tsx / DailyChallengeCard.tsx / CompletedView.tsx
- DailyChallengePage.tsx: プレースホルダーを本実装に置き換え

typecheck/lint/test(430件) pass