### PR TITLE
feat: コードドクター DB テーブル・型定義・定数 (8-1)

### DIFF
--- a/apps/web/src/shared/constants.ts
+++ b/apps/web/src/shared/constants.ts
@@ -4,6 +4,11 @@ export const POINTS_PER_MODE_COMPLETE = 10
 /** デイリーチャレンジ正解時に付与されるポイント */
 export const POINTS_DAILY_CORRECT = 20
 
+/** コードドクター正解時に付与されるポイント */
+export const POINTS_CODE_DOCTOR_BEGINNER = 15
+export const POINTS_CODE_DOCTOR_INTERMEDIATE = 30
+export const POINTS_CODE_DOCTOR_ADVANCED = 50
+
 /** ポイントバッジの閾値 */
 export const BADGE_POINT_THRESHOLD_MID = 500
 export const BADGE_POINT_THRESHOLD_HIGH = 1000

--- a/apps/web/src/shared/types/database.types.ts
+++ b/apps/web/src/shared/types/database.types.ts
@@ -167,6 +167,39 @@ export type Database = {
         }
         Relationships: []
       }
+      code_doctor_progress: {
+        Row: {
+          id: string
+          user_id: string
+          problem_id: string
+          category: string
+          difficulty: string
+          solved: boolean
+          attempts: number
+          solved_at: string | null
+        }
+        Insert: {
+          id?: string
+          user_id: string
+          problem_id: string
+          category?: string
+          difficulty: string
+          solved?: boolean
+          attempts?: number
+          solved_at?: string | null
+        }
+        Update: {
+          id?: string
+          user_id?: string
+          problem_id?: string
+          category?: string
+          difficulty?: string
+          solved?: boolean
+          attempts?: number
+          solved_at?: string | null
+        }
+        Relationships: []
+      }
       step_progress: {
         Row: {
           challenge_done: boolean

--- a/apps/web/supabase/sql/007_code_doctor.sql
+++ b/apps/web/supabase/sql/007_code_doctor.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS public.code_doctor_progress (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  problem_id TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'react',
+  difficulty TEXT NOT NULL CHECK (difficulty IN ('beginner', 'intermediate', 'advanced')),
+  solved BOOLEAN NOT NULL DEFAULT false,
+  attempts INTEGER NOT NULL DEFAULT 0,
+  solved_at TIMESTAMPTZ,
+  UNIQUE(user_id, problem_id)
+);
+ALTER TABLE public.code_doctor_progress ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "own_data" ON public.code_doctor_progress
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## 変更内容
- `007_code_doctor.sql`: code_doctor_progress テーブル + RLS ポリシー
- `database.types.ts`: code_doctor_progress テーブル型追加
- `constants.ts`: POINTS_CODE_DOCTOR_BEGINNER/INTERMEDIATE/ADVANCED 追加

## CI
typecheck: pass / lint: pass