### PR TITLE
feat: コードドクター サービス・テスト・UI (8-3)

### DIFF
--- a/apps/web/src/features/code-doctor/components/ProblemCard.tsx
+++ b/apps/web/src/features/code-doctor/components/ProblemCard.tsx
@@ -1,0 +1,49 @@
+import type { CodeDoctorProblem, CodeDoctorProgress } from '../../../content/code-doctor/types'
+
+const DIFFICULTY_LABEL: Record<CodeDoctorProblem['difficulty'], string> = {
+  beginner: '初級',
+  intermediate: '中級',
+  advanced: '上級',
+}
+
+const DIFFICULTY_COLOR: Record<CodeDoctorProblem['difficulty'], string> = {
+  beginner: 'text-emerald-700 bg-emerald-50 border-emerald-200',
+  intermediate: 'text-amber-700 bg-amber-50 border-amber-200',
+  advanced: 'text-rose-700 bg-rose-50 border-rose-200',
+}
+
+interface ProblemCardProps {
+  problem: CodeDoctorProblem
+  progress: CodeDoctorProgress | undefined
+  onClick: () => void
+}
+
+export function ProblemCard({ problem, progress, onClick }: ProblemCardProps) {
+  const solved = progress?.solved ?? false
+  const attempts = progress?.attempts ?? 0
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full rounded-xl border border-border bg-bg-surface p-4 text-left transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-amber-400"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span
+          className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-semibold ${DIFFICULTY_COLOR[problem.difficulty]}`}
+        >
+          {DIFFICULTY_LABEL[problem.difficulty]}
+        </span>
+        {solved ? (
+          <span className="text-sm text-emerald-600">✅ 解決済み</span>
+        ) : attempts > 0 ? (
+          <span className="text-xs text-text-muted">{attempts}回挑戦中</span>
+        ) : (
+          <span className="text-xs text-text-muted">🔓 未挑戦</span>
+        )}
+      </div>
+      <p className="mt-2 font-semibold text-text-dark">{problem.title}</p>
+      <p className="mt-1 line-clamp-2 text-xs text-text-muted">{problem.description}</p>
+    </button>
+  )
+}

--- a/apps/web/src/features/daily/components/PracticeModeNav.tsx
+++ b/apps/web/src/features/daily/components/PracticeModeNav.tsx
@@ -3,9 +3,9 @@ import { Zap, Stethoscope, FolderOpen, BookOpen } from 'lucide-react'
 
 const NAV_ITEMS = [
   { path: '/daily', label: 'デイリー', icon: Zap },
-  { path: '/code-doctor', label: 'ドクター', icon: Stethoscope },
-  { path: '/mini-projects', label: 'ミニプロ', icon: FolderOpen },
-  { path: '/code-reading', label: 'リーディング', icon: BookOpen },
+  { path: '/practice/code-doctor', label: 'ドクター', icon: Stethoscope },
+  { path: '/practice/mini-projects', label: 'ミニプロ', icon: FolderOpen },
+  { path: '/practice/code-reading', label: 'リーディング', icon: BookOpen },
 ]
 
 export function PracticeModeNav() {

--- a/apps/web/src/pages/CodeDoctorPage.tsx
+++ b/apps/web/src/pages/CodeDoctorPage.tsx
@@ -1,12 +1,304 @@
+import { Suspense, lazy, useCallback, useEffect, useState } from 'react'
+import { useAuth } from '../contexts/AuthContext'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { getProblemProgressMap, submitDoctorSolution } from '../services/codeDoctorService'
+import { PracticeModeNav } from '../features/daily/components/PracticeModeNav'
+import { ProblemCard } from '../features/code-doctor/components/ProblemCard'
+import { Spinner } from '../components/Spinner'
+import { CODE_DOCTOR_PROBLEMS } from '../content/code-doctor/problems'
+import type { CodeDoctorDifficulty, CodeDoctorProblem, CodeDoctorProgress, SubmitDoctorResult } from '../content/code-doctor/types'
+
+const MonacoEditor = lazy(() => import('@monaco-editor/react'))
+
+type FilterValue = 'all' | CodeDoctorDifficulty
+
+const FILTER_OPTIONS: { value: FilterValue; label: string }[] = [
+  { value: 'all', label: '全て' },
+  { value: 'beginner', label: '初級' },
+  { value: 'intermediate', label: '中級' },
+  { value: 'advanced', label: '上級' },
+]
+
+const DIFFICULTY_STARS: Record<CodeDoctorDifficulty, string> = {
+  beginner: '★☆☆',
+  intermediate: '★★☆',
+  advanced: '★★★',
+}
 
 export function CodeDoctorPage() {
   useDocumentTitle('コードドクター')
 
+  const { user } = useAuth()
+
+  const [progressMap, setProgressMap] = useState<Map<string, CodeDoctorProgress>>(new Map())
+  const [filter, setFilter] = useState<FilterValue>('all')
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // 問題ビュー用
+  const [selectedProblem, setSelectedProblem] = useState<CodeDoctorProblem | null>(null)
+  const [code, setCode] = useState('')
+  const [result, setResult] = useState<SubmitDoctorResult | null>(null)
+  const [showHint, setShowHint] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const loadProgress = useCallback(async () => {
+    if (!user) return
+    setIsLoading(true)
+    setError(null)
+    try {
+      const map = await getProblemProgressMap(user.id)
+      setProgressMap(map)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'データの取得に失敗しました')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [user])
+
+  useEffect(() => {
+    void loadProgress()
+  }, [loadProgress])
+
+  function handleSelectProblem(problem: CodeDoctorProblem) {
+    setSelectedProblem(problem)
+    setCode(problem.buggyCode)
+    setResult(null)
+    setShowHint(false)
+    setSubmitError(null)
+  }
+
+  function handleBack() {
+    setSelectedProblem(null)
+    setResult(null)
+    setShowHint(false)
+  }
+
+  async function handleSubmit() {
+    if (!user || !selectedProblem) return
+    setIsSubmitting(true)
+    setSubmitError(null)
+    try {
+      const res = await submitDoctorSolution(user.id, selectedProblem, code)
+      setResult(res)
+      if (res.passed) {
+        setProgressMap((prev) => {
+          const next = new Map(prev)
+          next.set(selectedProblem.id, {
+            problemId: selectedProblem.id,
+            solved: true,
+            attempts: (prev.get(selectedProblem.id)?.attempts ?? 0) + 1,
+            solvedAt: new Date().toISOString(),
+          })
+          return next
+        })
+      }
+    } catch (e) {
+      setSubmitError(e instanceof Error ? e.message : '送信に失敗しました')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const filteredProblems =
+    filter === 'all'
+      ? CODE_DOCTOR_PROBLEMS
+      : CODE_DOCTOR_PROBLEMS.filter((p) => p.difficulty === filter)
+
+  // ─── 問題ビュー ─────────────────────────────────────────
+  if (selectedProblem) {
+    return (
+      <div className="mx-auto max-w-screen-xl px-4 py-8">
+        <div className="flex gap-6">
+          <PracticeModeNav />
+
+          <div className="flex min-w-0 flex-1 gap-4">
+            {/* 問題パネル */}
+            <div className="w-72 shrink-0 space-y-4">
+              <button
+                type="button"
+                onClick={handleBack}
+                className="flex items-center gap-1 text-sm text-text-muted hover:text-text-dark"
+              >
+                ← 一覧に戻る
+              </button>
+
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+                  難易度: {DIFFICULTY_STARS[selectedProblem.difficulty]}
+                </p>
+                <h2 className="mt-1 text-lg font-bold text-text-dark">{selectedProblem.title}</h2>
+              </div>
+
+              <div className="rounded-xl border border-border bg-bg-surface p-4 text-sm text-text-dark">
+                <p className="font-semibold text-text-muted">期待される動作:</p>
+                <p className="mt-1">{selectedProblem.description}</p>
+              </div>
+
+              <button
+                type="button"
+                onClick={() => setShowHint((v) => !v)}
+                className="text-sm font-medium text-amber-600 hover:text-amber-700"
+              >
+                💡 {showHint ? 'ヒントを隠す' : 'ヒントを表示'}
+              </button>
+
+              {showHint && (
+                <div className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+                  {selectedProblem.hint}
+                </div>
+              )}
+
+              {result && (
+                <div
+                  className={`rounded-xl border p-4 text-sm ${result.passed ? 'border-emerald-200 bg-emerald-50' : 'border-rose-200 bg-rose-50'}`}
+                  role="status"
+                >
+                  {result.passed ? (
+                    <>
+                      <p className="font-semibold text-emerald-800">
+                        ✅ 正解！ +{result.pointsEarned} Pt
+                      </p>
+                      <p className="mt-2 text-emerald-700">{result.explanation}</p>
+                    </>
+                  ) : (
+                    <>
+                      <p className="font-semibold text-rose-800">❌ まだバグが残っています</p>
+                      {result.missingKeywords.length > 0 && (
+                        <div className="mt-2">
+                          <p className="text-xs text-rose-700">不足している修正:</p>
+                          <ul className="mt-1 list-inside list-disc text-xs text-rose-700">
+                            {result.missingKeywords.map((kw) => (
+                              <li key={kw}>{kw}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                      {result.foundNgKeywords.length > 0 && (
+                        <div className="mt-2">
+                          <p className="text-xs text-rose-700">残っているバグ:</p>
+                          <ul className="mt-1 list-inside list-disc text-xs text-rose-700">
+                            {result.foundNgKeywords.map((kw) => (
+                              <li key={kw}>{kw}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                    </>
+                  )}
+                </div>
+              )}
+
+              {submitError && (
+                <p className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                  {submitError}
+                </p>
+              )}
+            </div>
+
+            {/* Monaco エディタ */}
+            <div className="flex min-w-0 flex-1 flex-col gap-4">
+              <div className="overflow-hidden rounded-xl border border-border">
+                <Suspense
+                  fallback={
+                    <div className="flex h-80 items-center justify-center bg-slate-900 text-sm text-slate-300">
+                      エディタを読み込み中...
+                    </div>
+                  }
+                >
+                  <MonacoEditor
+                    height="480px"
+                    defaultLanguage="typescript"
+                    theme="vs-dark"
+                    value={code}
+                    options={{ minimap: { enabled: false }, fontSize: 14, scrollBeyondLastLine: false }}
+                    onChange={(v) => { setCode(v ?? ''); setResult(null) }}
+                  />
+                </Suspense>
+              </div>
+
+              <div className="flex items-center gap-4">
+                <button
+                  type="button"
+                  onClick={() => void handleSubmit()}
+                  disabled={isSubmitting || result?.passed === true}
+                  className="rounded-lg bg-amber-500 px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {isSubmitting ? '判定中...' : '判定する'}
+                </button>
+                {result?.passed && (
+                  <button
+                    type="button"
+                    onClick={handleBack}
+                    className="text-sm font-medium text-text-muted hover:text-text-dark"
+                  >
+                    一覧に戻る →
+                  </button>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // ─── 一覧ビュー ─────────────────────────────────────────
   return (
-    <div className="flex min-h-[60vh] flex-col items-center justify-center">
-      <h1 className="text-2xl font-bold text-text-dark">コードドクター</h1>
-      <p className="mt-2 text-text-light">準備中です</p>
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <div className="flex gap-8">
+        <PracticeModeNav />
+
+        <div className="min-w-0 flex-1 space-y-5">
+          <div>
+            <h1 className="text-2xl font-bold text-text-dark">コードドクター</h1>
+            <p className="mt-1 text-sm text-text-muted">
+              バグ入りコードを修正してデバッグスキルを鍛えましょう
+            </p>
+          </div>
+
+          {/* フィルタ */}
+          <div className="flex gap-2">
+            {FILTER_OPTIONS.map(({ value, label }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setFilter(value)}
+                className={[
+                  'rounded-full px-4 py-1.5 text-sm font-medium transition-colors',
+                  filter === value
+                    ? 'bg-amber-500 text-white'
+                    : 'border border-border text-text-muted hover:border-amber-400 hover:text-amber-600',
+                ].join(' ')}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          {isLoading ? (
+            <div className="flex justify-center py-16">
+              <Spinner />
+            </div>
+          ) : error ? (
+            <div className="rounded-xl border border-red-200 bg-red-50 p-5 text-sm text-red-700">
+              {error}
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {filteredProblems.map((problem) => (
+                <ProblemCard
+                  key={problem.id}
+                  problem={problem}
+                  progress={progressMap.get(problem.id)}
+                  onClick={() => handleSelectProblem(problem)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/services/__tests__/codeDoctorService.test.ts
+++ b/apps/web/src/services/__tests__/codeDoctorService.test.ts
@@ -1,0 +1,152 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { supabase } from '../../lib/supabaseClient'
+import { awardPoints } from '../pointService'
+import {
+  getPointsForDifficulty,
+  judgeCode,
+  getProblemProgressMap,
+  submitDoctorSolution,
+} from '../codeDoctorService'
+import type { CodeDoctorProblem } from '../../content/code-doctor/types'
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: { from: vi.fn() },
+}))
+vi.mock('../pointService', () => ({ awardPoints: vi.fn() }))
+
+const mockFrom = vi.mocked(supabase.from)
+const mockAwardPoints = vi.mocked(awardPoints)
+
+// ─── 純粋関数テスト ──────────────────────────────────────
+
+describe('getPointsForDifficulty', () => {
+  it('beginner は 15 pt を返す', () => {
+    expect(getPointsForDifficulty('beginner')).toBe(15)
+  })
+  it('intermediate は 30 pt を返す', () => {
+    expect(getPointsForDifficulty('intermediate')).toBe(30)
+  })
+  it('advanced は 50 pt を返す', () => {
+    expect(getPointsForDifficulty('advanced')).toBe(50)
+  })
+})
+
+describe('judgeCode', () => {
+  const problem = {
+    requiredKeywords: ['key=', 'map('],
+    ngKeywords: ['<li>item</li>'],
+  }
+
+  it('必須キーワードをすべて含みNGワードがなければ passed: true', () => {
+    const result = judgeCode('items.map((i) => <li key={i}>{i}</li>)', problem)
+    expect(result.passed).toBe(true)
+    expect(result.missingKeywords).toHaveLength(0)
+    expect(result.foundNgKeywords).toHaveLength(0)
+  })
+
+  it('必須キーワードが不足していれば passed: false', () => {
+    const result = judgeCode('items.map((i) => <li>{i}</li>)', problem)
+    expect(result.passed).toBe(false)
+    expect(result.missingKeywords).toContain('key=')
+  })
+
+  it('NGキーワードが含まれていれば passed: false', () => {
+    const result = judgeCode('<li>item</li> key= map(', problem)
+    expect(result.passed).toBe(false)
+    expect(result.foundNgKeywords).toContain('<li>item</li>')
+  })
+
+  it('大文字小文字を区別しない', () => {
+    const p = { requiredKeywords: ['Key='], ngKeywords: [] }
+    const result = judgeCode('KEY=value', p)
+    expect(result.passed).toBe(true)
+  })
+})
+
+// ─── DB 関数テスト ───────────────────────────────────────
+
+const sampleProblem: CodeDoctorProblem = {
+  id: 'cd-beginner-001',
+  category: 'react',
+  difficulty: 'beginner',
+  title: 'テスト問題',
+  description: 'テスト',
+  buggyCode: '<li>{item}</li>',
+  hint: 'ヒント',
+  requiredKeywords: ['key='],
+  ngKeywords: [],
+  explanation: '解説',
+}
+
+describe('getProblemProgressMap', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('進捗なしの場合は空の Map を返す', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+      }),
+    } as unknown as ReturnType<typeof supabase.from>)
+
+    const result = await getProblemProgressMap('user-1')
+    expect(result.size).toBe(0)
+  })
+
+  it('解決済み問題が Map に含まれる', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({
+          data: [
+            { problem_id: 'cd-beginner-001', solved: true, attempts: 2, solved_at: '2026-03-30T10:00:00Z' },
+          ],
+          error: null,
+        }),
+      }),
+    } as unknown as ReturnType<typeof supabase.from>)
+
+    const result = await getProblemProgressMap('user-1')
+    expect(result.get('cd-beginner-001')?.solved).toBe(true)
+    expect(result.get('cd-beginner-001')?.attempts).toBe(2)
+  })
+})
+
+describe('submitDoctorSolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFrom.mockReturnValue({
+      upsert: vi.fn().mockResolvedValue({ error: null }),
+    } as unknown as ReturnType<typeof supabase.from>)
+    mockAwardPoints.mockResolvedValue()
+  })
+
+  it('正解の場合は passed: true と対応ポイントを返す', async () => {
+    const result = await submitDoctorSolution('user-1', sampleProblem, '<li key={item.id}>{item}</li>')
+    expect(result.passed).toBe(true)
+    expect(result.pointsEarned).toBe(15)
+    expect(mockAwardPoints).toHaveBeenCalledWith('user-1', 15, 'コードドクター正解（beginner）')
+  })
+
+  it('不正解の場合は passed: false で 0 pt', async () => {
+    const result = await submitDoctorSolution('user-1', sampleProblem, '<li>{item}</li>')
+    expect(result.passed).toBe(false)
+    expect(result.pointsEarned).toBe(0)
+    expect(mockAwardPoints).not.toHaveBeenCalled()
+  })
+
+  it('不足キーワードが missingKeywords に含まれる', async () => {
+    const result = await submitDoctorSolution('user-1', sampleProblem, '<li>{item}</li>')
+    expect(result.missingKeywords).toContain('key=')
+  })
+
+  it('正解時に explanation が返される', async () => {
+    const result = await submitDoctorSolution('user-1', sampleProblem, 'key= <li>')
+    expect(result.explanation).toBe('解説')
+  })
+
+  it('advanced 問題の正解は 50 pt', async () => {
+    const advancedProblem: CodeDoctorProblem = { ...sampleProblem, id: 'cd-advanced-001', difficulty: 'advanced' }
+    const result = await submitDoctorSolution('user-1', advancedProblem, 'key=')
+    expect(result.pointsEarned).toBe(50)
+    expect(mockAwardPoints).toHaveBeenCalledWith('user-1', 50, 'コードドクター正解（advanced）')
+  })
+})

--- a/apps/web/src/services/codeDoctorService.ts
+++ b/apps/web/src/services/codeDoctorService.ts
@@ -1,0 +1,104 @@
+import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+import {
+  POINTS_CODE_DOCTOR_BEGINNER,
+  POINTS_CODE_DOCTOR_INTERMEDIATE,
+  POINTS_CODE_DOCTOR_ADVANCED,
+} from '../shared/constants'
+import { awardPoints } from './pointService'
+import type { CodeDoctorProblem, CodeDoctorProgress, SubmitDoctorResult } from '../content/code-doctor/types'
+
+// ─── 純粋関数 ────────────────────────────────────────────
+
+/** 難易度に応じた獲得ポイントを返す */
+export function getPointsForDifficulty(difficulty: CodeDoctorProblem['difficulty']): number {
+  switch (difficulty) {
+    case 'beginner':
+      return POINTS_CODE_DOCTOR_BEGINNER
+    case 'intermediate':
+      return POINTS_CODE_DOCTOR_INTERMEDIATE
+    case 'advanced':
+      return POINTS_CODE_DOCTOR_ADVANCED
+  }
+}
+
+/**
+ * コードが問題の合格条件を満たしているか判定する（純粋関数）
+ * - requiredKeywords をすべて含む
+ * - ngKeywords をどれも含まない
+ */
+export function judgeCode(
+  code: string,
+  problem: Pick<CodeDoctorProblem, 'requiredKeywords' | 'ngKeywords'>,
+): { passed: boolean; missingKeywords: string[]; foundNgKeywords: string[] } {
+  const lower = code.toLowerCase()
+  const missingKeywords = problem.requiredKeywords.filter(
+    (kw) => !lower.includes(kw.toLowerCase()),
+  )
+  const foundNgKeywords = problem.ngKeywords.filter((kw) => lower.includes(kw.toLowerCase()))
+  const passed = missingKeywords.length === 0 && foundNgKeywords.length === 0
+  return { passed, missingKeywords, foundNgKeywords }
+}
+
+// ─── DB 関数 ─────────────────────────────────────────────
+
+/** ユーザーの全問題進捗を Map<problemId, CodeDoctorProgress> で返す */
+export async function getProblemProgressMap(
+  userId: string,
+): Promise<Map<string, CodeDoctorProgress>> {
+  const { data, error } = await supabase
+    .from('code_doctor_progress')
+    .select('problem_id, solved, attempts, solved_at')
+    .eq('user_id', userId)
+
+  if (error) {
+    throw fromSupabaseError(error, 'コードドクター進捗の取得に失敗しました')
+  }
+
+  const map = new Map<string, CodeDoctorProgress>()
+  for (const row of data ?? []) {
+    map.set(row.problem_id, {
+      problemId: row.problem_id,
+      solved: row.solved,
+      attempts: row.attempts,
+      solvedAt: row.solved_at,
+    })
+  }
+  return map
+}
+
+/** コードを送信して判定・DB保存・Pt付与を行う */
+export async function submitDoctorSolution(
+  userId: string,
+  problem: CodeDoctorProblem,
+  code: string,
+): Promise<SubmitDoctorResult> {
+  const { passed, missingKeywords, foundNgKeywords } = judgeCode(code, problem)
+  const pointsEarned = passed ? getPointsForDifficulty(problem.difficulty) : 0
+
+  const { error } = await supabase.from('code_doctor_progress').upsert(
+    {
+      user_id: userId,
+      problem_id: problem.id,
+      category: problem.category,
+      difficulty: problem.difficulty,
+      solved: passed,
+      solved_at: passed ? new Date().toISOString() : null,
+    },
+    { onConflict: 'user_id,problem_id', ignoreDuplicates: false },
+  )
+
+  if (error) {
+    throw fromSupabaseError(error, 'コードドクター送信に失敗しました')
+  }
+
+  if (passed) {
+    await awardPoints(
+      userId,
+      pointsEarned,
+      `コードドクター正解（${problem.difficulty}）`,
+    )
+  }
+
+  return { passed, pointsEarned, missingKeywords, foundNgKeywords, explanation: problem.explanation }
+}


### PR DESCRIPTION
## 変更内容
- `codeDoctorService.ts`: judgeCode/getPointsForDifficulty(純粋関数) + getProblemProgressMap/submitDoctorSolution(DB関数)
- `codeDoctorService.test.ts`: 14テスト
- `PracticeModeNav.tsx`: パスバグ修正（/code-doctor → /practice/code-doctor 等）
- `ProblemCard.tsx`: 問題カード（難易度バッジ・進捗表示）
- `CodeDoctorPage.tsx`: 一覧ビュー（フィルタ+カードグリッド）+ 問題ビュー（問題パネル+Monaco Editor）

## CI
typecheck: pass / lint: pass / test: 444件 PASS（430→444, +14）