### PR TITLE
feat: ミニプロジェクト DB SQL・型定義・定数 (9-1)

### DIFF
--- a/apps/web/src/shared/constants.ts
+++ b/apps/web/src/shared/constants.ts
@@ -9,6 +9,9 @@ export const POINTS_CODE_DOCTOR_BEGINNER = 15
 export const POINTS_CODE_DOCTOR_INTERMEDIATE = 30
 export const POINTS_CODE_DOCTOR_ADVANCED = 50
 
+/** ミニプロジェクト完了時に付与されるポイント */
+export const POINTS_MINI_PROJECT_COMPLETE = 100
+
 /** ポイントバッジの閾値 */
 export const BADGE_POINT_THRESHOLD_MID = 500
 export const BADGE_POINT_THRESHOLD_HIGH = 1000

--- a/apps/web/src/shared/types/database.types.ts
+++ b/apps/web/src/shared/types/database.types.ts
@@ -200,6 +200,12 @@ export type Database = {
         }
         Relationships: []
       }
+      mini_project_progress: {
+        Row: { id: string; user_id: string; project_id: string; status: string; code: string | null; completed_at: string | null }
+        Insert: { id?: string; user_id: string; project_id: string; status?: string; code?: string | null; completed_at?: string | null }
+        Update: { id?: string; user_id?: string; project_id?: string; status?: string; code?: string | null; completed_at?: string | null }
+        Relationships: []
+      }
       step_progress: {
         Row: {
           challenge_done: boolean

--- a/apps/web/supabase/sql/008_mini_projects.sql
+++ b/apps/web/supabase/sql/008_mini_projects.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS public.mini_project_progress (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  project_id   TEXT NOT NULL,
+  status       TEXT DEFAULT 'not_started' CHECK (status IN ('not_started', 'in_progress', 'completed')),
+  code         TEXT,
+  completed_at TIMESTAMPTZ,
+  UNIQUE(user_id, project_id)
+);
+ALTER TABLE public.mini_project_progress ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "own_data" ON public.mini_project_progress
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- `008_mini_projects.sql`: `mini_project_progress` テーブル作成 + RLS ポリシー設定
- `database.types.ts`: `mini_project_progress` 型を追加
- `constants.ts`: `POINTS_MINI_PROJECT_COMPLETE = 100` を追加

## Test plan
- [ ] typecheck ✅ / lint ✅