### PR TITLE
feat: ミニプロジェクト サービス・テスト・UI (9-3)

### DIFF
--- a/apps/web/src/content/mini-projects/projects.ts
+++ b/apps/web/src/content/mini-projects/projects.ts
@@ -1,0 +1,533 @@
+import type { MiniProject } from './types'
+
+export const MINI_PROJECTS: MiniProject[] = [
+  // ─── beginner ──────────────────────────────────────────────────────────────
+
+  {
+    id: 'todo-app',
+    difficulty: 'beginner',
+    title: 'Todo App',
+    description: 'useState を使ってタスクの追加・完了切り替え・フィルタリングができる Todo アプリを作成してください。',
+    keyElements: ['useState', 'filter', 'map', 'onChange'],
+    milestones: [
+      {
+        id: 'milestone-1',
+        title: 'useState でタスクリストを管理',
+        description: 'useState でタスク配列を状態管理し、初期タスクを表示できる',
+        requiredKeywords: ['usestate(', 'settasks('],
+      },
+      {
+        id: 'milestone-2',
+        title: 'フォームでタスクを追加',
+        description: 'input と button でタスクを追加できる',
+        requiredKeywords: ['oninputchange', 'setinput(', 'addtask'],
+      },
+      {
+        id: 'milestone-3',
+        title: '完了/未完了の切り替え',
+        description: 'タスクをクリックして completed を toggle できる',
+        requiredKeywords: ['toggletask', 'completed'],
+      },
+      {
+        id: 'milestone-4',
+        title: 'フィルター機能',
+        description: 'all / active / completed でタスクを絞り込める',
+        requiredKeywords: ['filter(', 'setfilter('],
+      },
+    ],
+    initialCode: `import { useState } from 'react'
+
+interface Task {
+  id: number
+  text: string
+  completed: boolean
+}
+
+type Filter = 'all' | 'active' | 'completed'
+
+export default function TodoApp() {
+  // TODO: tasks の useState を定義する
+  // TODO: input の useState を定義する
+  // TODO: filter の useState を定義する
+
+  function addTask() {
+    // TODO: 新しいタスクを tasks に追加する
+  }
+
+  function toggleTask(id: number) {
+    // TODO: 指定 id の completed を反転する
+  }
+
+  // TODO: filter に応じて tasks をフィルタリングする
+  const filteredTasks: Task[] = []
+
+  return (
+    <div>
+      <h1>Todo App</h1>
+      {/* TODO: input と追加ボタンを実装する */}
+      {/* TODO: フィルターボタン (all / active / completed) を実装する */}
+      {/* TODO: filteredTasks を map でリスト表示する */}
+    </div>
+  )
+}
+`,
+  },
+
+  {
+    id: 'counter-extended',
+    difficulty: 'beginner',
+    title: 'カウンター拡張',
+    description: '複数のカウンターを管理し、個別にインクリメント/デクリメントして合計を表示するアプリを作成してください。',
+    keyElements: ['useState', 'map', '合計計算', 'reduce'],
+    milestones: [
+      {
+        id: 'milestone-1',
+        title: 'useState でカウンター配列を管理',
+        description: '複数カウンターの初期状態を useState で管理できる',
+        requiredKeywords: ['usestate(', 'setcounters('],
+      },
+      {
+        id: 'milestone-2',
+        title: '複数カウンターの個別操作',
+        description: '各カウンターを個別にインクリメント/デクリメントできる',
+        requiredKeywords: ['increment(', 'decrement(', 'map('],
+      },
+      {
+        id: 'milestone-3',
+        title: '合計表示',
+        description: '全カウンターの合計値をリアルタイムに表示できる',
+        requiredKeywords: ['reduce(', 'total'],
+      },
+    ],
+    initialCode: `import { useState } from 'react'
+
+interface Counter {
+  id: number
+  label: string
+  value: number
+}
+
+export default function CounterExtended() {
+  // TODO: counters の useState を定義する（初期値は 3 つ程度）
+
+  function increment(id: number) {
+    // TODO: 指定 id のカウンターを +1 する
+  }
+
+  function decrement(id: number) {
+    // TODO: 指定 id のカウンターを -1 する
+  }
+
+  // TODO: reduce で合計値を計算する
+  const total = 0
+
+  return (
+    <div>
+      <h1>カウンター拡張</h1>
+      {/* TODO: counters を map でカウンター表示 */}
+      {/* TODO: 合計値を表示 */}
+    </div>
+  )
+}
+`,
+  },
+
+  {
+    id: 'rock-paper-scissors',
+    difficulty: 'beginner',
+    title: 'じゃんけん',
+    description: 'Math.random を使ってコンピューターとじゃんけんできるアプリを作成してください。勝敗を判定して結果を表示します。',
+    keyElements: ['useState', 'Math.random', '勝敗判定', 'onClick'],
+    milestones: [
+      {
+        id: 'milestone-1',
+        title: 'Math.random でコンピューターの手を生成',
+        description: 'Math.random() を使ってグー/チョキ/パーをランダムに選択できる',
+        requiredKeywords: ['math.random()', 'choices'],
+      },
+      {
+        id: 'milestone-2',
+        title: '勝敗判定ロジック',
+        description: 'プレイヤーとコンピューターの手を比較して勝敗を判定できる',
+        requiredKeywords: ['judgeresult', 'winner'],
+      },
+      {
+        id: 'milestone-3',
+        title: 'useState で結果を管理',
+        description: 'プレイヤーの手・コンピューターの手・結果を useState で管理して表示できる',
+        requiredKeywords: ['usestate(', 'setresult('],
+      },
+    ],
+    initialCode: `import { useState } from 'react'
+
+type Hand = 'グー' | 'チョキ' | 'パー'
+type Result = '勝ち' | '負け' | '引き分け' | null
+
+const HANDS: Hand[] = ['グー', 'チョキ', 'パー']
+
+export default function RockPaperScissors() {
+  // TODO: playerHand, computerHand, result の useState を定義する
+
+  function getComputerHand(): Hand {
+    // TODO: Math.random() で HANDS からランダムに選ぶ
+    return 'グー'
+  }
+
+  function judgeResult(player: Hand, computer: Hand): Result {
+    // TODO: 勝敗を判定する（引き分け / 勝ち / 負け）
+    return null
+  }
+
+  function play(hand: Hand) {
+    // TODO: コンピューターの手を取得し、judgeResult で結果を判定して state を更新する
+  }
+
+  return (
+    <div>
+      <h1>じゃんけん</h1>
+      {/* TODO: グー/チョキ/パー の選択ボタンを表示する */}
+      {/* TODO: プレイヤー・コンピューターの手と結果を表示する */}
+    </div>
+  )
+}
+`,
+  },
+
+  // ─── intermediate ──────────────────────────────────────────────────────────
+
+  {
+    id: 'timer-app',
+    difficulty: 'intermediate',
+    title: 'タイマー',
+    description: 'setInterval を使ったカウントダウンタイマーを作成してください。開始・停止・リセット機能と時間のフォーマット表示を実装します。',
+    keyElements: ['setInterval', 'clearInterval', 'useEffect', 'useState'],
+    milestones: [
+      {
+        id: 'milestone-1',
+        title: 'setInterval でカウントダウン',
+        description: 'setInterval を使って 1 秒ごとに時間を減らせる',
+        requiredKeywords: ['setinterval(', 'settimeremaining('],
+      },
+      {
+        id: 'milestone-2',
+        title: 'clearInterval でクリーンアップ',
+        description: 'useEffect の return で clearInterval を呼んでメモリリークを防げる',
+        requiredKeywords: ['clearinterval(', 'return () =>'],
+      },
+      {
+        id: 'milestone-3',
+        title: 'isRunning で開始/停止を管理',
+        description: 'isRunning フラグで開始・停止ボタンを切り替えられる',
+        requiredKeywords: ['isrunning', 'setisrunning('],
+      },
+      {
+        id: 'milestone-4',
+        title: '時間のフォーマット表示',
+        description: '秒数を「MM:SS」形式でフォーマットして表示できる',
+        requiredKeywords: ['formattime(', 'padstart('],
+      },
+    ],
+    initialCode: `import { useState, useEffect } from 'react'
+
+const INITIAL_TIME = 60
+
+export default function TimerApp() {
+  // TODO: timeRemaining と isRunning の useState を定義する
+
+  useEffect(() => {
+    // TODO: isRunning が true のとき setInterval で 1 秒ごとに時間を減らす
+    // TODO: return でクリーンアップ（clearInterval）する
+  }, [/* TODO: 依存配列 */])
+
+  function formatTime(seconds: number): string {
+    // TODO: 秒数を "MM:SS" 形式に変換する（String.padStart を使う）
+    return String(seconds)
+  }
+
+  return (
+    <div>
+      <h1>タイマー</h1>
+      {/* TODO: formatTime で時間を表示 */}
+      {/* TODO: 開始/停止ボタン（isRunning で切り替え）を実装 */}
+      {/* TODO: リセットボタンを実装 */}
+    </div>
+  )
+}
+`,
+  },
+
+  {
+    id: 'markdown-previewer',
+    difficulty: 'intermediate',
+    title: 'Markdown プレビュー',
+    description: 'textarea に入力した Markdown テキストをリアルタイムでプレビューする2カラムエディタを作成してください。',
+    keyElements: ['useState', 'dangerouslySetInnerHTML', 'replace', 'onChange'],
+    milestones: [
+      {
+        id: 'milestone-1',
+        title: 'textarea で入力を管理',
+        description: 'textarea の onChange で入力テキストを useState に保存できる',
+        requiredKeywords: ['usestate(', 'setmarkdown(', 'onchange'],
+      },
+      {
+        id: 'milestone-2',
+        title: 'dangerouslySetInnerHTML でプレビュー',
+        description: 'dangerouslySetInnerHTML を使って HTML を描画できる',
+        requiredKeywords: ['dangerouslysetinnerhtml', '__html'],
+      },
+      {
+        id: 'milestone-3',
+        title: 'replace で Markdown を変換',
+        description: 'String.replace で見出し・太字・コードブロックなど基本構文を HTML に変換できる',
+        requiredKeywords: ['replace(/', 'parsemarkdown('],
+      },
+    ],
+    initialCode: `import { useState } from 'react'
+
+const INITIAL_MARKDOWN = \`# Hello Markdown
+
+**太字** や *斜体* が使えます。
+
+\\\`コード\\\` もインライン表示できます。
+\`
+
+function parseMarkdown(text: string): string {
+  // TODO: replace を使って Markdown を HTML に変換する
+  // ヒント: # 見出し → <h1>, **太字** → <strong>, *斜体* → <em>, \`コード\` → <code>
+  return text
+}
+
+export default function MarkdownPreviewer() {
+  // TODO: markdown テキストの useState を定義する（初期値は INITIAL_MARKDOWN）
+
+  return (
+    <div style={{ display: 'flex', gap: '16px', height: '400px' }}>
+      {/* TODO: 左カラム: textarea で入力エリアを実装 */}
+      {/* TODO: 右カラム: dangerouslySetInnerHTML でプレビューを表示 */}
+    </div>
+  )
+}
+`,
+  },
+
+  {
+    id: 'quiz-app',
+    difficulty: 'intermediate',
+    title: 'クイズアプリ',
+    description: '複数問のクイズを順番に出題し、正誤判定・画面遷移・最終スコア表示まで実装してください。',
+    keyElements: ['useState', '正誤判定', '画面遷移', 'スコア集計'],
+    milestones: [
+      {
+        id: 'milestone-1',
+        title: '問題データを表示',
+        description: 'クイズデータの配列から現在の問題を取得して表示できる',
+        requiredKeywords: ['currentindex', 'questions['],
+      },
+      {
+        id: 'milestone-2',
+        title: '正誤判定',
+        description: '選択肢クリックで正解かどうかを判定してフィードバックを表示できる',
+        requiredKeywords: ['iscorrect', 'setscore('],
+      },
+      {
+        id: 'milestone-3',
+        title: '次の問題へ遷移',
+        description: '「次へ」ボタンで currentIndex を進めて次の問題を表示できる',
+        requiredKeywords: ['setcurrentindex(', 'currentindex + 1'],
+      },
+      {
+        id: 'milestone-4',
+        title: 'スコアと結果画面',
+        description: '全問終了後にスコアを表示する結果画面に切り替えられる',
+        requiredKeywords: ['isfinished', 'score'],
+      },
+    ],
+    initialCode: `import { useState } from 'react'
+
+interface Question {
+  id: number
+  text: string
+  choices: string[]
+  correctIndex: number
+}
+
+const QUESTIONS: Question[] = [
+  { id: 1, text: 'React の状態管理フックは？', choices: ['useEffect', 'useState', 'useRef', 'useMemo'], correctIndex: 1 },
+  { id: 2, text: '副作用を扱うフックは？', choices: ['useState', 'useCallback', 'useEffect', 'useContext'], correctIndex: 2 },
+  { id: 3, text: 'コンテキストの値を取得するフックは？', choices: ['useRef', 'useReducer', 'useMemo', 'useContext'], correctIndex: 3 },
+]
+
+export default function QuizApp() {
+  // TODO: currentIndex, score, isFinished, selectedIndex の useState を定義する
+
+  function handleSelect(index: number) {
+    // TODO: 正誤判定してスコアを更新し selectedIndex を設定する
+  }
+
+  function handleNext() {
+    // TODO: currentIndex を進め、最後の問題なら isFinished を true にする
+  }
+
+  // TODO: isFinished が true なら結果画面を表示する
+
+  return (
+    <div>
+      <h1>クイズ ({/* TODO: 現在の問題番号 / 全問題数 */})</h1>
+      {/* TODO: 現在の問題文と選択肢ボタンを表示する */}
+      {/* TODO: 選択後に正誤フィードバックと「次へ」ボタンを表示する */}
+    </div>
+  )
+}
+`,
+  },
+
+  // ─── advanced ──────────────────────────────────────────────────────────────
+
+  {
+    id: 'weather-api',
+    difficulty: 'advanced',
+    title: '天気 API アプリ',
+    description: 'fetch と async/await を使って天気 API からデータを取得し、ローディング・エラーハンドリングを実装してください。',
+    keyElements: ['fetch', 'async/await', 'useEffect', 'ローディング', 'エラーハンドリング'],
+    milestones: [
+      {
+        id: 'milestone-1',
+        title: 'fetch + async/await でデータ取得',
+        description: 'fetch と async/await で API からデータを取得できる',
+        requiredKeywords: ['async ', 'await fetch('],
+      },
+      {
+        id: 'milestone-2',
+        title: 'ローディング状態を管理',
+        description: 'isLoading フラグでローディング UI を表示できる',
+        requiredKeywords: ['isloading', 'setisloading('],
+      },
+      {
+        id: 'milestone-3',
+        title: 'エラーハンドリング',
+        description: 'try/catch でエラーを捕捉してエラーメッセージを表示できる',
+        requiredKeywords: ['try {', 'catch (', 'seterror('],
+      },
+      {
+        id: 'milestone-4',
+        title: 'useEffect でマウント時に取得',
+        description: 'useEffect で都市変更時に自動的にデータ取得できる',
+        requiredKeywords: ['useeffect(', '[city]'],
+      },
+    ],
+    initialCode: `import { useState, useEffect } from 'react'
+
+interface WeatherData {
+  city: string
+  temperature: number
+  description: string
+  humidity: number
+}
+
+// モック API 関数（実際の API の代わり）
+async function fetchWeather(city: string): Promise<WeatherData> {
+  await new Promise((resolve) => setTimeout(resolve, 800))
+  if (city === 'error') throw new Error('都市が見つかりません')
+  return { city, temperature: Math.round(15 + Math.random() * 20), description: '晴れ', humidity: Math.round(40 + Math.random() * 40) }
+}
+
+export default function WeatherApp() {
+  const [city, setCity] = useState('Tokyo')
+  // TODO: weather, isLoading, error の useState を定義する
+
+  useEffect(() => {
+    // TODO: async 関数を定義して fetchWeather(city) でデータを取得する
+    // TODO: isLoading, error も適切に管理する
+  }, [city])
+
+  return (
+    <div>
+      <h1>天気アプリ</h1>
+      {/* TODO: 都市名入力欄を実装する */}
+      {/* TODO: isLoading, error, weather を条件分岐して表示する */}
+    </div>
+  )
+}
+`,
+  },
+
+  {
+    id: 'shopping-cart',
+    difficulty: 'advanced',
+    title: 'ショッピングカート',
+    description: 'useReducer と useContext を使って商品一覧とカート機能を実装してください。カートへの追加・削除・合計計算が対象です。',
+    keyElements: ['useReducer', 'useContext', 'createContext', 'dispatch'],
+    milestones: [
+      {
+        id: 'milestone-1',
+        title: 'useReducer でカート状態を管理',
+        description: 'useReducer でカート内アイテム配列を管理できる',
+        requiredKeywords: ['usereducer(', 'cartreducer'],
+      },
+      {
+        id: 'milestone-2',
+        title: 'Action 定義と dispatch',
+        description: 'ADD_ITEM / REMOVE_ITEM のアクションを定義して dispatch できる',
+        requiredKeywords: ['add_item', 'remove_item', 'dispatch('],
+      },
+      {
+        id: 'milestone-3',
+        title: 'useContext でカートを共有',
+        description: 'createContext + useContext でカートの状態と dispatch を子コンポーネントに共有できる',
+        requiredKeywords: ['createcontext(', 'usecontext(', 'cartcontext'],
+      },
+      {
+        id: 'milestone-4',
+        title: '合計金額を計算',
+        description: 'reduce で合計金額をリアルタイムに計算して表示できる',
+        requiredKeywords: ['reduce(', 'totalprice'],
+      },
+    ],
+    initialCode: `import { useReducer, useContext, createContext } from 'react'
+
+interface Product {
+  id: number
+  name: string
+  price: number
+}
+
+interface CartItem extends Product {
+  quantity: number
+}
+
+// TODO: CartAction 型を定義する（ADD_ITEM / REMOVE_ITEM）
+type CartAction = never
+
+function cartReducer(state: CartItem[], action: CartAction): CartItem[] {
+  // TODO: ADD_ITEM: 既存アイテムなら quantity を増やし、なければ追加する
+  // TODO: REMOVE_ITEM: 指定 id のアイテムを除去する
+  return state
+}
+
+// TODO: CartContext を createContext で定義する
+const CartContext = createContext<never>(null as never)
+
+const PRODUCTS: Product[] = [
+  { id: 1, name: 'React 入門書', price: 2980 },
+  { id: 2, name: 'TypeScript 完全ガイド', price: 3480 },
+  { id: 3, name: 'Node.js ハンドブック', price: 2580 },
+]
+
+export default function ShoppingCart() {
+  // TODO: useReducer でカート状態を初期化する
+
+  // TODO: totalPrice を reduce で計算する
+
+  return (
+    // TODO: CartContext.Provider で state と dispatch を提供する
+    <div>
+      <h1>ショッピングカート</h1>
+      {/* TODO: 商品一覧と「カートに追加」ボタンを表示する */}
+      {/* TODO: カート内アイテム一覧と「削除」ボタンを表示する */}
+      {/* TODO: 合計金額を表示する */}
+    </div>
+  )
+}
+`,
+  },
+]

--- a/apps/web/src/content/mini-projects/types.ts
+++ b/apps/web/src/content/mini-projects/types.ts
@@ -1,0 +1,38 @@
+export type MiniProjectDifficulty = 'beginner' | 'intermediate' | 'advanced'
+export type MiniProjectStatus = 'not_started' | 'in_progress' | 'completed'
+
+export interface MiniProjectMilestone {
+  id: string
+  title: string
+  description: string
+  requiredKeywords: string[]
+}
+
+export interface MiniProject {
+  id: string
+  difficulty: MiniProjectDifficulty
+  title: string
+  description: string
+  keyElements: string[]
+  milestones: MiniProjectMilestone[]
+  initialCode: string
+}
+
+export interface MiniProjectProgress {
+  projectId: string
+  status: MiniProjectStatus
+  code: string | null
+  completedAt: string | null
+}
+
+export interface MilestoneJudgeResult {
+  milestoneId: string
+  passed: boolean
+}
+
+export interface SubmitProjectResult {
+  milestoneResults: MilestoneJudgeResult[]
+  allPassed: boolean
+  pointsEarned: number
+  newStatus: MiniProjectStatus
+}

--- a/apps/web/src/features/daily/components/PracticeModeNav.tsx
+++ b/apps/web/src/features/daily/components/PracticeModeNav.tsx
@@ -18,7 +18,7 @@ export function PracticeModeNav() {
       </p>
       <ul className="space-y-1">
         {NAV_ITEMS.map(({ path, label, icon: Icon }) => {
-          const isActive = pathname === path
+          const isActive = pathname === path || pathname.startsWith(path + '/')
           return (
             <li key={path}>
               <Link

--- a/apps/web/src/features/mini-projects/components/ProjectCard.tsx
+++ b/apps/web/src/features/mini-projects/components/ProjectCard.tsx
@@ -1,0 +1,58 @@
+import type { MiniProject, MiniProjectDifficulty, MiniProjectProgress } from '../../../content/mini-projects/types'
+
+const DIFFICULTY_LABEL: Record<MiniProjectDifficulty, string> = {
+  beginner: '初級',
+  intermediate: '中級',
+  advanced: '上級',
+}
+
+const DIFFICULTY_COLOR: Record<MiniProjectDifficulty, string> = {
+  beginner: 'text-emerald-700 bg-emerald-50 border-emerald-200',
+  intermediate: 'text-amber-700 bg-amber-50 border-amber-200',
+  advanced: 'text-rose-700 bg-rose-50 border-rose-200',
+}
+
+interface ProjectCardProps {
+  project: MiniProject
+  progress: MiniProjectProgress | undefined
+  onClick: () => void
+}
+
+export function ProjectCard({ project, progress, onClick }: ProjectCardProps) {
+  const status = progress?.status ?? 'not_started'
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full rounded-xl border border-border bg-bg-surface p-4 text-left transition-shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-amber-400"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span
+          className={`shrink-0 rounded-full border px-2 py-0.5 text-xs font-semibold ${DIFFICULTY_COLOR[project.difficulty]}`}
+        >
+          {DIFFICULTY_LABEL[project.difficulty]}
+        </span>
+        {status === 'completed' ? (
+          <span className="text-sm text-emerald-600">✅ 完了</span>
+        ) : status === 'in_progress' ? (
+          <span className="text-xs text-amber-600">🔄 進行中</span>
+        ) : (
+          <span className="text-xs text-text-muted">🔓 未着手</span>
+        )}
+      </div>
+      <p className="mt-2 font-semibold text-text-dark">{project.title}</p>
+      <p className="mt-1 line-clamp-2 text-xs text-text-muted">{project.description}</p>
+      <div className="mt-3 flex flex-wrap gap-1">
+        {project.keyElements.map((el) => (
+          <span
+            key={el}
+            className="rounded-md bg-bg-muted px-1.5 py-0.5 text-xs text-text-muted"
+          >
+            {el}
+          </span>
+        ))}
+      </div>
+    </button>
+  )
+}

--- a/apps/web/src/pages/MiniProjectDetailPage.tsx
+++ b/apps/web/src/pages/MiniProjectDetailPage.tsx
@@ -1,14 +1,215 @@
-import { useParams } from 'react-router-dom'
+import { Suspense, lazy, useCallback, useEffect, useState } from 'react'
+import { Link, Navigate, useParams } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { getProjectProgressMap, submitProject } from '../services/miniProjectService'
+import { PracticeModeNav } from '../features/daily/components/PracticeModeNav'
+import { Spinner } from '../components/Spinner'
+import { MINI_PROJECTS } from '../content/mini-projects/projects'
+import type { MilestoneJudgeResult, MiniProjectProgress, MiniProjectStatus, SubmitProjectResult } from '../content/mini-projects/types'
+
+const MonacoEditor = lazy(() => import('@monaco-editor/react'))
 
 export function MiniProjectDetailPage() {
   const { projectId } = useParams<{ projectId: string }>()
-  useDocumentTitle('ミニプロジェクト実装')
+  const { user } = useAuth()
+
+  const project = MINI_PROJECTS.find((p) => p.id === projectId)
+
+  useDocumentTitle(project ? project.title : 'ミニプロジェクト実装')
+
+  const [progress, setProgress] = useState<MiniProjectProgress | null>(null)
+  const [code, setCode] = useState('')
+  const [milestoneResults, setMilestoneResults] = useState<MilestoneJudgeResult[] | null>(null)
+  const [submitResult, setSubmitResult] = useState<SubmitProjectResult | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+
+  const loadProgress = useCallback(async () => {
+    if (!user || !project) return
+    try {
+      const map = await getProjectProgressMap(user.id)
+      const prog = map.get(project.id) ?? null
+      setProgress(prog)
+      setCode(prog?.code ?? project.initialCode)
+    } catch {
+      setCode(project.initialCode)
+    }
+  }, [user, project])
+
+  useEffect(() => {
+    void loadProgress()
+  }, [loadProgress])
+
+  if (!project) {
+    return <Navigate to="/practice/mini-projects" replace />
+  }
+
+  const currentStatus: MiniProjectStatus = submitResult?.newStatus ?? progress?.status ?? 'not_started'
+  const isCompleted = currentStatus === 'completed'
+
+  async function handleSubmit() {
+    if (!user || !project) return
+    setIsSubmitting(true)
+    setSubmitError(null)
+    try {
+      const previousStatus: MiniProjectStatus = progress?.status ?? 'not_started'
+      const result = await submitProject(user.id, project, code, previousStatus)
+      setSubmitResult(result)
+      setMilestoneResults(result.milestoneResults)
+      setProgress((prev) => ({
+        projectId: project.id,
+        status: result.newStatus,
+        code,
+        completedAt: result.allPassed ? new Date().toISOString() : (prev?.completedAt ?? null),
+      }))
+    } catch (e) {
+      setSubmitError(e instanceof Error ? e.message : '送信に失敗しました')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  function getMilestoneIcon(milestoneId: string): string {
+    if (!milestoneResults) return '🔒'
+    const r = milestoneResults.find((r) => r.milestoneId === milestoneId)
+    if (!r) return '🔒'
+    return r.passed ? '✅' : '▶'
+  }
 
   return (
-    <div className="flex min-h-[60vh] flex-col items-center justify-center">
-      <h1 className="text-2xl font-bold text-text-dark">ミニプロジェクト実装</h1>
-      <p className="mt-2 text-text-light">準備中です（ID: {projectId}）</p>
+    <div className="mx-auto max-w-screen-xl px-4 py-8">
+      <div className="flex gap-6">
+        <PracticeModeNav />
+
+        <div className="flex min-w-0 flex-1 gap-4">
+          {/* 左パネル */}
+          <div className="w-72 shrink-0 space-y-4">
+            <Link
+              to="/practice/mini-projects"
+              className="flex items-center gap-1 text-sm text-text-muted hover:text-text-dark"
+            >
+              ← 一覧に戻る
+            </Link>
+
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+                {project.difficulty === 'beginner' ? '初級' : project.difficulty === 'intermediate' ? '中級' : '上級'}
+              </p>
+              <h2 className="mt-1 text-lg font-bold text-text-dark">{project.title}</h2>
+              <p className="mt-1 text-sm text-text-muted">{project.description}</p>
+            </div>
+
+            {/* マイルストーン一覧 */}
+            <div className="space-y-2">
+              <p className="text-xs font-semibold uppercase tracking-wider text-text-muted">
+                マイルストーン
+              </p>
+              {project.milestones.map((milestone) => (
+                <div
+                  key={milestone.id}
+                  className="rounded-lg border border-border bg-bg-surface p-3"
+                >
+                  <div className="flex items-center gap-2">
+                    <span className="text-base">{getMilestoneIcon(milestone.id)}</span>
+                    <p className="text-sm font-medium text-text-dark">{milestone.title}</p>
+                  </div>
+                  <p className="mt-1 text-xs text-text-muted">{milestone.description}</p>
+                </div>
+              ))}
+            </div>
+
+            {/* 送信結果 */}
+            {submitResult && (
+              <div
+                className={`rounded-xl border p-4 text-sm ${submitResult.allPassed ? 'border-emerald-200 bg-emerald-50' : 'border-amber-200 bg-amber-50'}`}
+                role="status"
+              >
+                {submitResult.allPassed ? (
+                  <>
+                    <p className="font-semibold text-emerald-800">
+                      ✅ 全マイルストーン達成！
+                      {submitResult.pointsEarned > 0 && ` +${submitResult.pointsEarned} Pt`}
+                    </p>
+                    <p className="mt-1 text-xs text-emerald-700">
+                      {submitResult.pointsEarned > 0
+                        ? 'おめでとうございます！初回完了ボーナスを獲得しました。'
+                        : 'このプロジェクトは既に完了済みです。'}
+                    </p>
+                  </>
+                ) : (
+                  <>
+                    <p className="font-semibold text-amber-800">
+                      {submitResult.milestoneResults.filter((r) => r.passed).length} /{' '}
+                      {submitResult.milestoneResults.length} マイルストーン達成
+                    </p>
+                    <p className="mt-1 text-xs text-amber-700">
+                      未達成のマイルストーンの条件を確認して、コードを修正してください。
+                    </p>
+                  </>
+                )}
+              </div>
+            )}
+
+            {submitError && (
+              <p className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                {submitError}
+              </p>
+            )}
+          </div>
+
+          {/* 右エリア: Monaco Editor */}
+          <div className="flex min-w-0 flex-1 flex-col gap-4">
+            {isCompleted && !submitResult && (
+              <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
+                ✅ このプロジェクトは完了済みです。コードを確認・編集できます。
+              </div>
+            )}
+
+            <div className="overflow-hidden rounded-xl border border-border">
+              <Suspense
+                fallback={
+                  <div className="flex h-80 items-center justify-center bg-slate-900 text-sm text-slate-300">
+                    <Spinner />
+                  </div>
+                }
+              >
+                <MonacoEditor
+                  height="520px"
+                  defaultLanguage="typescript"
+                  theme="vs-dark"
+                  value={code}
+                  options={{ minimap: { enabled: false }, fontSize: 14, scrollBeyondLastLine: false }}
+                  onChange={(v) => {
+                    setCode(v ?? '')
+                    setMilestoneResults(null)
+                    setSubmitResult(null)
+                  }}
+                />
+              </Suspense>
+            </div>
+
+            <div className="flex items-center gap-4">
+              <button
+                type="button"
+                onClick={() => void handleSubmit()}
+                disabled={isSubmitting || isCompleted}
+                className="rounded-lg bg-amber-500 px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isSubmitting ? '判定中...' : isCompleted ? '✅ 完了済み' : '判定する'}
+              </button>
+              {isCompleted && (
+                <Link
+                  to="/practice/mini-projects"
+                  className="text-sm font-medium text-text-muted hover:text-text-dark"
+                >
+                  一覧に戻る →
+                </Link>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/pages/MiniProjectsPage.tsx
+++ b/apps/web/src/pages/MiniProjectsPage.tsx
@@ -1,12 +1,109 @@
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { getProjectProgressMap } from '../services/miniProjectService'
+import { PracticeModeNav } from '../features/daily/components/PracticeModeNav'
+import { ProjectCard } from '../features/mini-projects/components/ProjectCard'
+import { Spinner } from '../components/Spinner'
+import { MINI_PROJECTS } from '../content/mini-projects/projects'
+import type { MiniProjectDifficulty, MiniProjectProgress } from '../content/mini-projects/types'
+
+type FilterValue = 'all' | MiniProjectDifficulty
+
+const FILTER_OPTIONS: { value: FilterValue; label: string }[] = [
+  { value: 'all', label: '全て' },
+  { value: 'beginner', label: '初級' },
+  { value: 'intermediate', label: '中級' },
+  { value: 'advanced', label: '上級' },
+]
 
 export function MiniProjectsPage() {
   useDocumentTitle('ミニプロジェクト')
 
+  const { user } = useAuth()
+  const navigate = useNavigate()
+
+  const [progressMap, setProgressMap] = useState<Map<string, MiniProjectProgress>>(new Map())
+  const [filter, setFilter] = useState<FilterValue>('all')
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadProgress = useCallback(async () => {
+    if (!user) return
+    setIsLoading(true)
+    setError(null)
+    try {
+      const map = await getProjectProgressMap(user.id)
+      setProgressMap(map)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'データの取得に失敗しました')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [user])
+
+  useEffect(() => {
+    void loadProgress()
+  }, [loadProgress])
+
+  const filteredProjects =
+    filter === 'all' ? MINI_PROJECTS : MINI_PROJECTS.filter((p) => p.difficulty === filter)
+
   return (
-    <div className="flex min-h-[60vh] flex-col items-center justify-center">
-      <h1 className="text-2xl font-bold text-text-dark">ミニプロジェクト</h1>
-      <p className="mt-2 text-text-light">準備中です</p>
+    <div className="mx-auto max-w-4xl px-4 py-8">
+      <div className="flex gap-8">
+        <PracticeModeNav />
+
+        <div className="min-w-0 flex-1 space-y-5">
+          <div>
+            <h1 className="text-2xl font-bold text-text-dark">ミニプロジェクト</h1>
+            <p className="mt-1 text-sm text-text-muted">
+              仕様からゼロ実装する体験で、総合的な実装力を鍛えましょう
+            </p>
+          </div>
+
+          {/* フィルター */}
+          <div className="flex gap-2">
+            {FILTER_OPTIONS.map(({ value, label }) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setFilter(value)}
+                className={[
+                  'rounded-full px-4 py-1.5 text-sm font-medium transition-colors',
+                  filter === value
+                    ? 'bg-amber-500 text-white'
+                    : 'border border-border text-text-muted hover:border-amber-400 hover:text-amber-600',
+                ].join(' ')}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          {isLoading ? (
+            <div className="flex justify-center py-16">
+              <Spinner />
+            </div>
+          ) : error ? (
+            <div className="rounded-xl border border-red-200 bg-red-50 p-5 text-sm text-red-700">
+              {error}
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {filteredProjects.map((project) => (
+                <ProjectCard
+                  key={project.id}
+                  project={project}
+                  progress={progressMap.get(project.id)}
+                  onClick={() => void navigate(`/practice/mini-projects/${project.id}`)}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/services/__tests__/miniProjectService.test.ts
+++ b/apps/web/src/services/__tests__/miniProjectService.test.ts
@@ -1,0 +1,201 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { supabase } from '../../lib/supabaseClient'
+import { awardPoints } from '../pointService'
+import {
+  judgeProject,
+  calcStatus,
+  getProjectProgressMap,
+  submitProject,
+} from '../miniProjectService'
+import type { MiniProject } from '../../content/mini-projects/types'
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: { from: vi.fn() },
+}))
+vi.mock('../pointService', () => ({ awardPoints: vi.fn() }))
+
+const mockFrom = vi.mocked(supabase.from)
+const mockAwardPoints = vi.mocked(awardPoints)
+
+// ─── サンプルデータ ──────────────────────────────────────
+
+const sampleProject: MiniProject = {
+  id: 'todo-app',
+  difficulty: 'beginner',
+  title: 'Todo App',
+  description: 'テスト用',
+  keyElements: ['useState'],
+  milestones: [
+    {
+      id: 'milestone-1',
+      title: 'useState 管理',
+      description: 'useState でタスクを管理',
+      requiredKeywords: ['usestate(', 'settasks('],
+    },
+    {
+      id: 'milestone-2',
+      title: 'フォーム追加',
+      description: 'フォームでタスクを追加',
+      requiredKeywords: ['addtask', 'setinput('],
+    },
+  ],
+  initialCode: '// initial',
+}
+
+// ─── judgeProject テスト ─────────────────────────────────
+
+describe('judgeProject', () => {
+  it('全マイルストーンのキーワードを含むコードは全 passed: true', () => {
+    const code = 'useState( setTasks( addTask setInput('
+    const results = judgeProject(code, sampleProject)
+    expect(results).toHaveLength(2)
+    expect(results[0].passed).toBe(true)
+    expect(results[1].passed).toBe(true)
+  })
+
+  it('一部マイルストーンのキーワードのみ含む場合は部分的に passed', () => {
+    const code = 'useState( setTasks('
+    const results = judgeProject(code, sampleProject)
+    expect(results[0].passed).toBe(true)
+    expect(results[1].passed).toBe(false)
+  })
+
+  it('キーワードを含まないコードは全 passed: false', () => {
+    const code = 'const x = 1'
+    const results = judgeProject(code, sampleProject)
+    expect(results.every((r) => !r.passed)).toBe(true)
+  })
+
+  it('大文字小文字を区別しない', () => {
+    const code = 'USESTATE( SETTASKS('
+    const results = judgeProject(code, sampleProject)
+    expect(results[0].passed).toBe(true)
+  })
+})
+
+// ─── calcStatus テスト ───────────────────────────────────
+
+describe('calcStatus', () => {
+  it('全通過なら completed', () => {
+    const results = [
+      { milestoneId: 'milestone-1', passed: true },
+      { milestoneId: 'milestone-2', passed: true },
+    ]
+    expect(calcStatus(results)).toBe('completed')
+  })
+
+  it('一部通過なら in_progress', () => {
+    const results = [
+      { milestoneId: 'milestone-1', passed: true },
+      { milestoneId: 'milestone-2', passed: false },
+    ]
+    expect(calcStatus(results)).toBe('in_progress')
+  })
+
+  it('0通過なら not_started', () => {
+    const results = [
+      { milestoneId: 'milestone-1', passed: false },
+      { milestoneId: 'milestone-2', passed: false },
+    ]
+    expect(calcStatus(results)).toBe('not_started')
+  })
+})
+
+// ─── getProjectProgressMap テスト ────────────────────────
+
+describe('getProjectProgressMap', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+
+  it('進捗なしの場合は空の Map を返す', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ data: [], error: null }),
+      }),
+    } as unknown as ReturnType<typeof supabase.from>)
+
+    const result = await getProjectProgressMap('user-1')
+    expect(result.size).toBe(0)
+  })
+
+  it('completed 進捗が Map に含まれる', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({
+          data: [
+            { project_id: 'todo-app', status: 'completed', code: 'code here', completed_at: '2026-03-30T10:00:00Z' },
+          ],
+          error: null,
+        }),
+      }),
+    } as unknown as ReturnType<typeof supabase.from>)
+
+    const result = await getProjectProgressMap('user-1')
+    expect(result.get('todo-app')?.status).toBe('completed')
+    expect(result.get('todo-app')?.completedAt).toBe('2026-03-30T10:00:00Z')
+  })
+
+  it('in_progress 進捗が Map に含まれる', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({
+          data: [
+            { project_id: 'timer-app', status: 'in_progress', code: 'partial', completed_at: null },
+          ],
+          error: null,
+        }),
+      }),
+    } as unknown as ReturnType<typeof supabase.from>)
+
+    const result = await getProjectProgressMap('user-1')
+    expect(result.get('timer-app')?.status).toBe('in_progress')
+    expect(result.get('timer-app')?.code).toBe('partial')
+  })
+})
+
+// ─── submitProject テスト ────────────────────────────────
+
+describe('submitProject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockFrom.mockReturnValue({
+      upsert: vi.fn().mockResolvedValue({ error: null }),
+    } as unknown as ReturnType<typeof supabase.from>)
+    mockAwardPoints.mockResolvedValue()
+  })
+
+  it('全マイルストーン通過で allPassed: true かつ 100 Pt を返す', async () => {
+    const code = 'useState( setTasks( addTask setInput('
+    const result = await submitProject('user-1', sampleProject, code, 'not_started')
+    expect(result.allPassed).toBe(true)
+    expect(result.pointsEarned).toBe(100)
+    expect(mockAwardPoints).toHaveBeenCalledWith('user-1', 100, 'ミニプロジェクト完了（Todo App）')
+  })
+
+  it('初回 completed 時のみポイントを付与する（previousStatus: not_started）', async () => {
+    const code = 'useState( setTasks( addTask setInput('
+    const result = await submitProject('user-1', sampleProject, code, 'not_started')
+    expect(result.pointsEarned).toBe(100)
+    expect(mockAwardPoints).toHaveBeenCalledTimes(1)
+  })
+
+  it('既に completed の場合はポイントを付与しない（previousStatus: completed）', async () => {
+    const code = 'useState( setTasks( addTask setInput('
+    const result = await submitProject('user-1', sampleProject, code, 'completed')
+    expect(result.pointsEarned).toBe(0)
+    expect(mockAwardPoints).not.toHaveBeenCalled()
+  })
+
+  it('一部通過の場合は 0 Pt で allPassed: false', async () => {
+    const code = 'useState( setTasks('
+    const result = await submitProject('user-1', sampleProject, code, 'not_started')
+    expect(result.allPassed).toBe(false)
+    expect(result.pointsEarned).toBe(0)
+    expect(mockAwardPoints).not.toHaveBeenCalled()
+  })
+
+  it('milestoneResults の長さがマイルストーン数と一致する', async () => {
+    const code = 'useState( setTasks('
+    const result = await submitProject('user-1', sampleProject, code, 'not_started')
+    expect(result.milestoneResults).toHaveLength(sampleProject.milestones.length)
+  })
+})

--- a/apps/web/src/services/miniProjectService.ts
+++ b/apps/web/src/services/miniProjectService.ts
@@ -1,0 +1,104 @@
+import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+import { POINTS_MINI_PROJECT_COMPLETE } from '../shared/constants'
+import { awardPoints } from './pointService'
+import type {
+  MiniProject,
+  MiniProjectProgress,
+  MiniProjectStatus,
+  MilestoneJudgeResult,
+  SubmitProjectResult,
+} from '../content/mini-projects/types'
+
+// ─── 純粋関数 ────────────────────────────────────────────
+
+/**
+ * コードの各マイルストーンを判定する（純粋関数）
+ * 各マイルストーンの requiredKeywords がすべて含まれれば passed
+ * 大文字小文字は無視する
+ */
+export function judgeProject(
+  code: string,
+  project: Pick<MiniProject, 'milestones'>,
+): MilestoneJudgeResult[] {
+  const lower = code.toLowerCase()
+  return project.milestones.map((milestone) => ({
+    milestoneId: milestone.id,
+    passed: milestone.requiredKeywords.every((kw) => lower.includes(kw.toLowerCase())),
+  }))
+}
+
+/**
+ * マイルストーン判定結果からプロジェクトステータスを計算する（純粋関数）
+ * 全通過 → completed / 1つ以上通過 → in_progress / 0通過 → not_started
+ */
+export function calcStatus(results: MilestoneJudgeResult[]): MiniProjectStatus {
+  const passedCount = results.filter((r) => r.passed).length
+  if (passedCount === results.length) return 'completed'
+  if (passedCount > 0) return 'in_progress'
+  return 'not_started'
+}
+
+// ─── DB 関数 ─────────────────────────────────────────────
+
+/** ユーザーの全プロジェクト進捗を Map<projectId, MiniProjectProgress> で返す */
+export async function getProjectProgressMap(
+  userId: string,
+): Promise<Map<string, MiniProjectProgress>> {
+  const { data, error } = await supabase
+    .from('mini_project_progress')
+    .select('project_id, status, code, completed_at')
+    .eq('user_id', userId)
+
+  if (error) {
+    throw fromSupabaseError(error, 'ミニプロジェクト進捗の取得に失敗しました')
+  }
+
+  const map = new Map<string, MiniProjectProgress>()
+  for (const row of data ?? []) {
+    map.set(row.project_id, {
+      projectId: row.project_id,
+      status: row.status as MiniProjectStatus,
+      code: row.code,
+      completedAt: row.completed_at,
+    })
+  }
+  return map
+}
+
+/** コードを送信して判定・DB保存・Pt付与を行う */
+export async function submitProject(
+  userId: string,
+  project: MiniProject,
+  code: string,
+  previousStatus: MiniProjectStatus,
+): Promise<SubmitProjectResult> {
+  const milestoneResults = judgeProject(code, project)
+  const allPassed = milestoneResults.every((r) => r.passed)
+  const newStatus = calcStatus(milestoneResults)
+  const completedAt = allPassed ? new Date().toISOString() : null
+
+  const { error } = await supabase.from('mini_project_progress').upsert(
+    {
+      user_id: userId,
+      project_id: project.id,
+      status: newStatus,
+      code,
+      completed_at: completedAt,
+    },
+    { onConflict: 'user_id,project_id', ignoreDuplicates: false },
+  )
+
+  if (error) {
+    throw fromSupabaseError(error, 'ミニプロジェクト送信に失敗しました')
+  }
+
+  const isNewlyCompleted = allPassed && previousStatus !== 'completed'
+  const pointsEarned = isNewlyCompleted ? POINTS_MINI_PROJECT_COMPLETE : 0
+
+  if (isNewlyCompleted) {
+    await awardPoints(userId, POINTS_MINI_PROJECT_COMPLETE, `ミニプロジェクト完了（${project.title}）`)
+  }
+
+  return { milestoneResults, allPassed, pointsEarned, newStatus }
+}

--- a/apps/web/src/shared/constants.ts
+++ b/apps/web/src/shared/constants.ts
@@ -9,6 +9,9 @@ export const POINTS_CODE_DOCTOR_BEGINNER = 15
 export const POINTS_CODE_DOCTOR_INTERMEDIATE = 30
 export const POINTS_CODE_DOCTOR_ADVANCED = 50
 
+/** ミニプロジェクト完了時に付与されるポイント */
+export const POINTS_MINI_PROJECT_COMPLETE = 100
+
 /** ポイントバッジの閾値 */
 export const BADGE_POINT_THRESHOLD_MID = 500
 export const BADGE_POINT_THRESHOLD_HIGH = 1000

--- a/apps/web/src/shared/types/database.types.ts
+++ b/apps/web/src/shared/types/database.types.ts
@@ -200,6 +200,12 @@ export type Database = {
         }
         Relationships: []
       }
+      mini_project_progress: {
+        Row: { id: string; user_id: string; project_id: string; status: string; code: string | null; completed_at: string | null }
+        Insert: { id?: string; user_id: string; project_id: string; status?: string; code?: string | null; completed_at?: string | null }
+        Update: { id?: string; user_id?: string; project_id?: string; status?: string; code?: string | null; completed_at?: string | null }
+        Relationships: []
+      }
       step_progress: {
         Row: {
           challenge_done: boolean

--- a/apps/web/supabase/sql/008_mini_projects.sql
+++ b/apps/web/supabase/sql/008_mini_projects.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS public.mini_project_progress (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  project_id   TEXT NOT NULL,
+  status       TEXT DEFAULT 'not_started' CHECK (status IN ('not_started', 'in_progress', 'completed')),
+  code         TEXT,
+  completed_at TIMESTAMPTZ,
+  UNIQUE(user_id, project_id)
+);
+ALTER TABLE public.mini_project_progress ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "own_data" ON public.mini_project_progress
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- `miniProjectService.ts`: judgeProject（各マイルストーン判定）/ calcStatus / getProjectProgressMap / submitProject（初回 completed 時のみ +100 Pt）
- `miniProjectService.test.ts`: 15テスト追加（444 → 459件）
- `ProjectCard.tsx`: 難易度バッジ + ステータス表示 + keyElements タグ
- `PracticeModeNav.tsx`: `startsWith` 対応で詳細ページでもアクティブ表示
- `MiniProjectsPage.tsx`: フィルター + ProjectCard グリッド + 進捗マップ取得
- `MiniProjectDetailPage.tsx`: useParams / 2カラム / マイルストーン状態表示 / Monaco Editor / 送信判定

## Test plan
- [ ] typecheck ✅ / lint ✅ / test 459件 ✅ / build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)