### PR TITLE
fix: コードレビュー Phase A（CRITICAL 4件）

### DIFF
--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,59 @@
+import { Component } from 'react'
+import type { ErrorInfo, ReactNode } from 'react'
+
+interface ErrorBoundaryProps {
+  children: ReactNode
+  fallback?: ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('ErrorBoundary caught:', error, errorInfo)
+  }
+
+  private handleRetry = () => {
+    this.setState({ hasError: false, error: null })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback
+      }
+
+      return (
+        <div className="flex min-h-[200px] flex-col items-center justify-center gap-4 rounded-xl border border-red-200 bg-red-50 p-8 text-center">
+          <p className="text-lg font-semibold text-red-800">
+            予期しないエラーが発生しました
+          </p>
+          <p className="max-w-md text-sm text-red-600">
+            {this.state.error?.message || 'アプリケーションの一部でエラーが発生しました。'}
+          </p>
+          <button
+            className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-400/50"
+            type="button"
+            onClick={this.handleRetry}
+          >
+            再試行
+          </button>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/apps/web/src/features/learning/ChallengeMode.tsx
+++ b/apps/web/src/features/learning/ChallengeMode.tsx
@@ -1,6 +1,7 @@
 import { Suspense, lazy, useEffect, useMemo, useState } from 'react'
 import { Button } from '../../components/Button'
 import { ErrorBanner } from '../../components/ErrorBanner'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 import type { ChallengePattern, ChallengeTask } from '../../content/fundamentals/steps'
 
 const MonacoEditor = lazy(() => import('@monaco-editor/react'))
@@ -83,16 +84,18 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
       </ul>
 
       <div className="overflow-hidden rounded-lg border border-slate-300">
-        <Suspense fallback={<div className="bg-slate-900 p-4 text-sm text-slate-100">エディタを読み込み中...</div>}>
-          <MonacoEditor
-            defaultLanguage="typescript"
-            height="320px"
-            theme="vs-dark"
-            value={code}
-            options={{ minimap: { enabled: false }, fontSize: 14 }}
-            onChange={handleCodeChange}
-          />
-        </Suspense>
+        <ErrorBoundary fallback={<div className="bg-slate-900 p-4 text-sm text-red-300">エディタの読み込みに失敗しました。ページを再読み込みしてください。</div>}>
+          <Suspense fallback={<div className="bg-slate-900 p-4 text-sm text-slate-100">エディタを読み込み中...</div>}>
+            <MonacoEditor
+              defaultLanguage="typescript"
+              height="320px"
+              theme="vs-dark"
+              value={code}
+              options={{ minimap: { enabled: false }, fontSize: 14 }}
+              onChange={handleCodeChange}
+            />
+          </Suspense>
+        </ErrorBoundary>
       </div>
 
       <div className="flex flex-col items-start gap-4 pt-4 sm:flex-row sm:items-center">

--- a/apps/web/src/features/learning/TestMode.tsx
+++ b/apps/web/src/features/learning/TestMode.tsx
@@ -1,5 +1,6 @@
 import { Fragment, Suspense, useEffect, useMemo, useState } from 'react'
 import { Button } from '../../components/Button'
+import { ErrorBoundary } from '../../components/ErrorBoundary'
 import type { TestTask } from '../../content/fundamentals/steps'
 import { addToReviewList, removeFromReviewList } from '../../services/reviewListService'
 import { previewByStepId } from './testModePreview'
@@ -113,16 +114,18 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
           <p className="mt-1 text-sm text-emerald-700">{preview.description}</p>
           {previewComponentByStepId[stepId] ? (
             <div className="mt-3 rounded-md border border-emerald-200 bg-white p-4">
-              <Suspense
-                fallback={
-                  <p className="text-xs text-slate-400">プレビューを読み込み中…</p>
-                }
-              >
-                {(() => {
-                  const PreviewComponent = previewComponentByStepId[stepId]
-                  return <PreviewComponent />
-                })()}
-              </Suspense>
+              <ErrorBoundary fallback={<p className="text-sm text-red-600">プレビューの表示中にエラーが発生しました。</p>}>
+                <Suspense
+                  fallback={
+                    <p className="text-xs text-slate-400">プレビューを読み込み中…</p>
+                  }
+                >
+                  {(() => {
+                    const PreviewComponent = previewComponentByStepId[stepId]
+                    return <PreviewComponent />
+                  })()}
+                </Suspense>
+              </ErrorBoundary>
             </div>
           ) : null}
         </div>

--- a/apps/web/src/features/learning/hooks/useLearningStep.ts
+++ b/apps/web/src/features/learning/hooks/useLearningStep.ts
@@ -181,7 +181,7 @@ export function useLearningStep(stepId: string): UseLearningStepReturn {
         }
 
         const reason = `「${step.title}」の${mode}モード完了`
-        await awardPoints(user.id, POINTS_PER_MODE_COMPLETE, reason)
+        await awardPoints(POINTS_PER_MODE_COMPLETE, reason)
         await refreshStats()
         try {
           await refreshAchievements()

--- a/apps/web/src/lib/supabaseClient.ts
+++ b/apps/web/src/lib/supabaseClient.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js'
+import type { Database } from '../shared/types/database.types'
 
 const url = import.meta.env.VITE_SUPABASE_URL
 const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
@@ -7,7 +8,7 @@ export const supabaseConfigError = !url || !anonKey
   ? '環境変数 VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY が設定されていません'
   : null
 
-export const supabase = createClient(url ?? 'https://placeholder.supabase.co', anonKey ?? 'placeholder', {
+export const supabase = createClient<Database>(url ?? 'https://placeholder.supabase.co', anonKey ?? 'placeholder', {
   auth: {
     persistSession: true,
     autoRefreshToken: true,

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -6,6 +6,7 @@ import { AuthProvider } from './contexts/AuthContext'
 import { LearningProvider } from './contexts/LearningContext'
 import { AchievementProvider } from './contexts/AchievementContext'
 import { ConfigErrorView } from './components/ConfigErrorView'
+import { ErrorBoundary } from './components/ErrorBoundary'
 import { PageSpinner } from './components/Spinner'
 import { supabaseConfigError } from './lib/supabaseClient'
 import './styles/globals.css'
@@ -177,13 +178,15 @@ async function startApp() {
   } else {
     root.render(
       <React.StrictMode>
-        <AuthProvider>
-          <LearningProvider>
-            <AchievementProvider>
-              <RouterProvider router={router} />
-            </AchievementProvider>
-          </LearningProvider>
-        </AuthProvider>
+        <ErrorBoundary>
+          <AuthProvider>
+            <LearningProvider>
+              <AchievementProvider>
+                <RouterProvider router={router} />
+              </AchievementProvider>
+            </LearningProvider>
+          </AuthProvider>
+        </ErrorBoundary>
       </React.StrictMode>,
     )
   }

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, Navigate, useNavigate, useParams } from 'react-router-dom'
 import { BookOpen, Check, ChevronRight, Code2, PenLine, Trophy } from 'lucide-react'
 import { ErrorBanner } from '../components/ErrorBanner'
+import { ErrorBoundary } from '../components/ErrorBoundary'
 import { LearningSidebar } from '../components/LearningSidebar'
 import { TOTAL_STEP_COUNT, findCategoryByStepId, findCourseByStepId } from '../content/courseData'
 import { PageSpinner } from '../components/Spinner'
@@ -244,6 +245,7 @@ export function StepPage() {
         <section className="flex flex-col gap-4 lg:flex-row lg:items-start">
           <LearningSidebar category={stepCategory} currentStepId={stepId} />
 
+          <ErrorBoundary>
           <div className="flex-1 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
             <nav className="mt-4 border-b border-slate-200 pb-4" aria-label="学習モードステッパー">
               <ol className="flex items-center gap-0">
@@ -387,6 +389,7 @@ export function StepPage() {
               </div>
             ) : null}
           </div>
+          </ErrorBoundary>
         </section>
         {toastMessage ? (
           <div

--- a/apps/web/src/services/__tests__/achievementService.test.ts
+++ b/apps/web/src/services/__tests__/achievementService.test.ts
@@ -280,7 +280,7 @@ describe('checkAndUnlockAchievements', () => {
   it('コードドクター10問完了で doctor-10 バッジが付与される', async () => {
     const doctorData = Array.from({ length: 10 }, (_, i) => ({
       problem_id: `cd-beginner-${String(i + 1).padStart(3, '0')}`,
-      completed: true,
+      solved: true,
     }))
     mockFromWithTable({ code_doctor_progress: doctorData })
 
@@ -292,7 +292,7 @@ describe('checkAndUnlockAchievements', () => {
   it('コードドクター9問完了では doctor-10 バッジは付与されない', async () => {
     const doctorData = Array.from({ length: 9 }, (_, i) => ({
       problem_id: `cd-beginner-${String(i + 1).padStart(3, '0')}`,
-      completed: true,
+      solved: true,
     }))
     mockFromWithTable({ code_doctor_progress: doctorData })
 
@@ -304,7 +304,7 @@ describe('checkAndUnlockAchievements', () => {
   it('コードドクター上級を全問正解で doctor-all-advanced バッジが付与される', async () => {
     const advancedData = Array.from({ length: 10 }, (_, i) => ({
       problem_id: `cd-advanced-${String(i + 1).padStart(3, '0')}`,
-      completed: true,
+      solved: true,
     }))
     mockFromWithTable({ code_doctor_progress: advancedData })
 

--- a/apps/web/src/services/__tests__/codeDoctorService.test.ts
+++ b/apps/web/src/services/__tests__/codeDoctorService.test.ts
@@ -123,7 +123,7 @@ describe('submitDoctorSolution', () => {
     const result = await submitDoctorSolution('user-1', sampleProblem, '<li key={item.id}>{item}</li>')
     expect(result.passed).toBe(true)
     expect(result.pointsEarned).toBe(15)
-    expect(mockAwardPoints).toHaveBeenCalledWith('user-1', 15, 'コードドクター正解（beginner）')
+    expect(mockAwardPoints).toHaveBeenCalledWith(15, 'コードドクター正解（beginner）')
   })
 
   it('不正解の場合は passed: false で 0 pt', async () => {
@@ -147,6 +147,6 @@ describe('submitDoctorSolution', () => {
     const advancedProblem: CodeDoctorProblem = { ...sampleProblem, id: 'cd-advanced-001', difficulty: 'advanced' }
     const result = await submitDoctorSolution('user-1', advancedProblem, 'key=')
     expect(result.pointsEarned).toBe(50)
-    expect(mockAwardPoints).toHaveBeenCalledWith('user-1', 50, 'コードドクター正解（advanced）')
+    expect(mockAwardPoints).toHaveBeenCalledWith(50, 'コードドクター正解（advanced）')
   })
 })

--- a/apps/web/src/services/__tests__/codeReadingService.test.ts
+++ b/apps/web/src/services/__tests__/codeReadingService.test.ts
@@ -158,7 +158,7 @@ describe('submitReading', () => {
     const result = await submitReading('user-1', sampleProblem, answers, false)
     expect(result.allCorrect).toBe(true)
     expect(result.pointsEarned).toBe(10)
-    expect(mockAwardPoints).toHaveBeenCalledWith('user-1', 10, 'コードリーディング完了（カスタムフック）')
+    expect(mockAwardPoints).toHaveBeenCalledWith(10, 'コードリーディング完了（カスタムフック）')
   })
 
   it('全問正解でも previousCompleted: true の場合はポイントを付与しない', async () => {

--- a/apps/web/src/services/__tests__/dailyChallengeService.test.ts
+++ b/apps/web/src/services/__tests__/dailyChallengeService.test.ts
@@ -230,7 +230,7 @@ describe('submitDailyAnswer', () => {
     const result = await submitDailyAnswer(userId, question, 'setCount', dateStr)
     expect(result.isCorrect).toBe(true)
     expect(result.pointsEarned).toBe(20)
-    expect(mockAwardPoints).toHaveBeenCalledWith(userId, 20, 'デイリーチャレンジ正解')
+    expect(mockAwardPoints).toHaveBeenCalledWith(20, 'デイリーチャレンジ正解')
   })
 
   it('不正解の場合は isCorrect: false と 0pt を返す', async () => {
@@ -261,8 +261,8 @@ describe('submitDailyAnswer', () => {
 
     await submitDailyAnswer(userId, question, 'setCount', dateStr)
 
-    expect(mockAwardPoints).toHaveBeenCalledWith(userId, 20, 'デイリーチャレンジ正解')
-    expect(mockAwardPoints).toHaveBeenCalledWith(userId, 50, 'デイリー7日連続ボーナス')
+    expect(mockAwardPoints).toHaveBeenCalledWith(20, 'デイリーチャレンジ正解')
+    expect(mockAwardPoints).toHaveBeenCalledWith(50, 'デイリー7日連続ボーナス')
   })
 
   it('14日連続でも 50pt ボーナスが付与される', async () => {
@@ -270,7 +270,7 @@ describe('submitDailyAnswer', () => {
 
     await submitDailyAnswer(userId, question, 'setCount', dateStr)
 
-    expect(mockAwardPoints).toHaveBeenCalledWith(userId, 50, 'デイリー14日連続ボーナス')
+    expect(mockAwardPoints).toHaveBeenCalledWith(50, 'デイリー14日連続ボーナス')
   })
 
   it('6日連続ではボーナスが付与されない', async () => {
@@ -278,7 +278,7 @@ describe('submitDailyAnswer', () => {
 
     await submitDailyAnswer(userId, question, 'setCount', dateStr)
 
-    expect(mockAwardPoints).not.toHaveBeenCalledWith(userId, 50, expect.any(String))
+    expect(mockAwardPoints).not.toHaveBeenCalledWith(50, expect.any(String))
   })
 
   it('不正解ではストリーク確認せずボーナスも付与されない', async () => {

--- a/apps/web/src/services/__tests__/miniProjectService.test.ts
+++ b/apps/web/src/services/__tests__/miniProjectService.test.ts
@@ -168,7 +168,7 @@ describe('submitProject', () => {
     const result = await submitProject('user-1', sampleProject, code, 'not_started')
     expect(result.allPassed).toBe(true)
     expect(result.pointsEarned).toBe(100)
-    expect(mockAwardPoints).toHaveBeenCalledWith('user-1', 100, 'ミニプロジェクト完了（Todo App）')
+    expect(mockAwardPoints).toHaveBeenCalledWith(100, 'ミニプロジェクト完了（Todo App）')
   })
 
   it('初回 completed 時のみポイントを付与する（previousStatus: not_started）', async () => {

--- a/apps/web/src/services/achievementService.ts
+++ b/apps/web/src/services/achievementService.ts
@@ -109,12 +109,12 @@ export async function getCodeDoctorStats(
 ): Promise<{ totalCompleted: number; advancedCompleted: number }> {
   const { data, error } = await supabase
     .from('code_doctor_progress')
-    .select('problem_id, completed')
+    .select('problem_id, solved')
     .eq('user_id', userId)
 
   if (error) throw fromSupabaseError(error, 'コードドクター進捗の取得に失敗しました')
 
-  const completedRows = (data ?? []).filter((r) => r.completed)
+  const completedRows = (data ?? []).filter((r) => r.solved)
   const advancedIds = new Set(
     CODE_DOCTOR_PROBLEMS.filter((p) => p.difficulty === 'advanced').map((p) => p.id),
   )

--- a/apps/web/src/services/codeDoctorService.ts
+++ b/apps/web/src/services/codeDoctorService.ts
@@ -94,7 +94,6 @@ export async function submitDoctorSolution(
 
   if (passed) {
     await awardPoints(
-      userId,
       pointsEarned,
       `コードドクター正解（${problem.difficulty}）`,
     )

--- a/apps/web/src/services/codeReadingService.ts
+++ b/apps/web/src/services/codeReadingService.ts
@@ -107,7 +107,7 @@ export async function submitReading(
   const pointsEarned = isNewlyCompleted ? getPointsForDifficulty(problem.difficulty) : 0
 
   if (isNewlyCompleted) {
-    await awardPoints(userId, pointsEarned, `コードリーディング完了（${problem.title}）`)
+    await awardPoints(pointsEarned, `コードリーディング完了（${problem.title}）`)
   }
 
   return { questionResults, allCorrect, correctCount, pointsEarned }

--- a/apps/web/src/services/dailyChallengeService.ts
+++ b/apps/web/src/services/dailyChallengeService.ts
@@ -147,12 +147,12 @@ export async function submitDailyAnswer(
   }
 
   if (isCorrect) {
-    await awardPoints(userId, POINTS_DAILY_CORRECT, 'デイリーチャレンジ正解')
+    await awardPoints(POINTS_DAILY_CORRECT, 'デイリーチャレンジ正解')
 
     // 7日連続ボーナスチェック（7の倍数日ごとに付与）
     const streak = await getDailyConsecutiveStreak(userId, dateStr)
     if (streak > 0 && streak % 7 === 0) {
-      await awardPoints(userId, POINTS_DAILY_STREAK_BONUS, `デイリー${streak}日連続ボーナス`)
+      await awardPoints(POINTS_DAILY_STREAK_BONUS, `デイリー${streak}日連続ボーナス`)
     }
   }
 

--- a/apps/web/src/services/miniProjectService.ts
+++ b/apps/web/src/services/miniProjectService.ts
@@ -97,7 +97,7 @@ export async function submitProject(
   const pointsEarned = isNewlyCompleted ? POINTS_MINI_PROJECT_COMPLETE : 0
 
   if (isNewlyCompleted) {
-    await awardPoints(userId, POINTS_MINI_PROJECT_COMPLETE, `ミニプロジェクト完了（${project.title}）`)
+    await awardPoints(POINTS_MINI_PROJECT_COMPLETE, `ミニプロジェクト完了（${project.title}）`)
   }
 
   return { milestoneResults, allPassed, pointsEarned, newStatus }

--- a/apps/web/src/services/pointService.ts
+++ b/apps/web/src/services/pointService.ts
@@ -1,9 +1,8 @@
 import { supabase } from '../lib/supabaseClient'
 import { fromSupabaseError } from '../shared/errors'
 
-export async function awardPoints(userId: string, amount: number, reason: string): Promise<void> {
+export async function awardPoints(amount: number, reason: string): Promise<void> {
     const { error } = await supabase.rpc('award_points_tx', {
-        p_user_id: userId,
         p_amount: amount,
         p_reason: reason,
     })

--- a/apps/web/src/services/progressService.ts
+++ b/apps/web/src/services/progressService.ts
@@ -1,6 +1,6 @@
 import { supabase } from '../lib/supabaseClient'
 import { fromSupabaseError } from '../shared/errors'
-import type { Tables } from '../shared/types/database.types'
+import type { Tables, TablesInsert } from '../shared/types/database.types'
 
 export type ProgressMode = 'read' | 'practice' | 'test' | 'challenge'
 
@@ -24,7 +24,7 @@ export async function getAllStepProgress(userId: string): Promise<StepProgressRo
     throw fromSupabaseError(error, '学習進捗の取得に失敗しました')
   }
 
-  return data as StepProgressRow[]
+  return data
 }
 
 export async function getStepProgress(userId: string, stepId: string): Promise<StepProgressRow | null> {
@@ -43,7 +43,7 @@ export async function getStepProgress(userId: string, stepId: string): Promise<S
 }
 
 export async function upsertProgress(userId: string, stepId: string, patch: ProgressPatch) {
-  const payload: Partial<StepProgressRow> = {
+  const payload: TablesInsert<'step_progress'> = {
     user_id: userId,
     step_id: stepId,
     updated_at: new Date().toISOString(),

--- a/apps/web/src/shared/types/database.types.ts
+++ b/apps/web/src/shared/types/database.types.ts
@@ -253,7 +253,13 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      award_points_tx: {
+        Args: {
+          p_amount: number
+          p_reason: string
+        }
+        Returns: undefined
+      }
     }
     Enums: {
       [_ in never]: never

--- a/apps/web/supabase/sql/004_award_points_rpc.sql
+++ b/apps/web/supabase/sql/004_award_points_rpc.sql
@@ -1,9 +1,12 @@
 -- M1-1: award_points_tx RPC
 -- learning_stats UPSERT + point_history INSERT を1トランザクションで実行する。
 -- Supabase SQL Editor で実行する。
+--
+-- セキュリティ修正（v2roadmap03 2-2）:
+-- - p_user_id を削除し auth.uid() でログインユーザーを特定（権限昇格防止）
+-- - p_amount > 0 チェックで負の値を拒否
 
 create or replace function public.award_points_tx(
-  p_user_id uuid,
   p_amount   integer,
   p_reason   text
 )
@@ -12,19 +15,31 @@ language plpgsql
 security definer
 set search_path = public
 as $$
+declare
+  v_user_id uuid := auth.uid();
 begin
+  -- 認証チェック
+  if v_user_id is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  -- 金額バリデーション
+  if p_amount <= 0 then
+    raise exception 'Amount must be positive';
+  end if;
+
   -- total_points をアトミックに加算（行が存在しなければ INSERT）
   insert into public.learning_stats (user_id, total_points, updated_at)
-  values (p_user_id, p_amount, now())
+  values (v_user_id, p_amount, now())
   on conflict (user_id) do update
     set total_points = public.learning_stats.total_points + excluded.total_points,
         updated_at   = now();
 
   -- ポイント履歴を記録
   insert into public.point_history (user_id, amount, reason)
-  values (p_user_id, p_amount, p_reason);
+  values (v_user_id, p_amount, p_reason);
 end;
 $$;
 
 -- authenticated ロールに実行権限を付与
-grant execute on function public.award_points_tx(uuid, integer, text) to authenticated;
+grant execute on function public.award_points_tx(integer, text) to authenticated;


### PR DESCRIPTION
## Summary
- **2-1**: Supabase クライアントに `Database` 型追加、unsafe cast 削除
- **2-2**: `award_points_tx` RPC で `auth.uid()` 使用・金額バリデーション追加（権限昇格脆弱性の修正）
- **2-3**: `database.types.ts` に `award_points_tx` の型定義追加
- **2-4**: `ErrorBoundary` をルート・StepPage・ChallengeMode・TestMode に配置

## Test plan
- [x] typecheck 通過
- [x] lint 通過
- [x] 全493テスト PASS
- [x] build 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)