### PR TITLE
fix: コードレビュー Phase B（HIGH 5件）

### DIFF
--- a/apps/web/src/contexts/AchievementContext.tsx
+++ b/apps/web/src/contexts/AchievementContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from 'react'
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from 'react'
 import { Trophy } from 'lucide-react'
 import { BADGE_DEFINITIONS, checkAndUnlockAchievements, getUnlockedAchievements, type BadgeId } from '../services/achievementService'
 import { useAuth } from './AuthContext'
@@ -27,6 +27,14 @@ export function AchievementProvider({ children }: { children: ReactNode }) {
   const [newlyUnlockedBadge, setNewlyUnlockedBadge] = useState<BadgeId | null>(null)
   const [toastQueue, setToastQueue] = useState<BadgeId[]>([])
   const [isChecking, setIsChecking] = useState(false)
+  const isMountedRef = useRef(true)
+
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
 
   const refreshAchievements = useCallback(async () => {
     if (!userId) {
@@ -41,13 +49,16 @@ export function AchievementProvider({ children }: { children: ReactNode }) {
     try {
       const newlyUnlocked = await checkAndUnlockAchievements(userId)
       const latestUnlocked = await getUnlockedAchievements(userId)
+      if (!isMountedRef.current) return
       setUnlockedBadgeIds(latestUnlocked)
 
       if (newlyUnlocked.length > 0) {
         setToastQueue((prev) => [...prev, ...newlyUnlocked])
       }
     } finally {
-      setIsChecking(false)
+      if (isMountedRef.current) {
+        setIsChecking(false)
+      }
     }
   }, [userId])
 

--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -8,7 +8,7 @@ interface AuthContextValue {
   session: Session | null
   isLoading: boolean
   signIn: (email: string, password: string) => Promise<string | null>
-  signUp: (email: string, password: string) => Promise<string | null>
+  signUp: (email: string, password: string) => Promise<string | 'CONFIRM_EMAIL' | null>
   signOut: () => Promise<string | null>
 }
 
@@ -26,26 +26,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     let isMounted = true
+    let subscription: { unsubscribe: () => void } | undefined
 
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange(async (event, nextSession) => {
-      if (!isMounted) {
-        return
-      }
-
+    async function init() {
+      // getSession を先に完了させてから onAuthStateChange を登録し、
+      // トークンリフレッシュによるレースコンディションを防ぐ
       try {
-        if (event === 'SIGNED_OUT' || !nextSession?.user) {
-          setSession(null)
-          setUser(null)
-        } else {
-          setSession(nextSession)
-          setUser(nextSession.user)
-        }
+        const { data } = await supabase.auth.getSession()
+        if (!isMounted) return
+
+        setSession(data.session)
+        setUser(data.session?.user ?? null)
       } catch {
-        if (!isMounted) {
-          return
-        }
+        if (!isMounted) return
 
         setSession(null)
         setUser(null)
@@ -54,35 +47,28 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           setIsLoading(false)
         }
       }
-    })
 
-    supabase.auth
-      .getSession()
-      .then(({ data }) => {
-        if (!isMounted) {
-          return
-        }
+      if (!isMounted) return
 
-        setSession(data.session)
-        setUser(data.session?.user ?? null)
-      })
-      .catch(() => {
-        if (!isMounted) {
-          return
-        }
+      const { data: sub } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+        if (!isMounted) return
 
-        setSession(null)
-        setUser(null)
-      })
-      .finally(() => {
-        if (isMounted) {
-          setIsLoading(false)
+        if (!nextSession?.user) {
+          setSession(null)
+          setUser(null)
+        } else {
+          setSession(nextSession)
+          setUser(nextSession.user)
         }
       })
+      subscription = sub.subscription
+    }
+
+    void init()
 
     return () => {
       isMounted = false
-      subscription.unsubscribe()
+      subscription?.unsubscribe()
     }
   }, [])
 
@@ -109,20 +95,20 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           return error.message
         }
 
+        // 既に登録済みのメールアドレス（identities が空）
+        if (data.user && data.user.identities?.length === 0) {
+          return 'このメールアドレスは既に登録されています。'
+        }
+
+        // セッションが返ってきた場合（メール確認無効時）
         if (data.session?.user) {
           setSession(data.session)
           setUser(data.session.user)
           return null
         }
 
-        const signInResult = await supabase.auth.signInWithPassword({ email, password })
-        if (signInResult.error) {
-          return signInResult.error.message
-        }
-
-        setSession(signInResult.data.session)
-        setUser(signInResult.data.user)
-        return null
+        // メール確認待ち
+        return 'CONFIRM_EMAIL'
       },
       signOut: async () => {
         if (supabaseConfigError) {

--- a/apps/web/src/contexts/LearningContext.tsx
+++ b/apps/web/src/contexts/LearningContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useAuth } from './AuthContext'
 import { getLearningStats, type LearningStats } from '../services/statsService'
 import { getAllStepProgress, isStepCompleted } from '../services/progressService'
@@ -26,6 +26,14 @@ export function LearningProvider({ children }: { children: ReactNode }) {
     const [stats, setStats] = useState<LearningStats | null>(null)
     const [completedStepIds, setCompletedStepIds] = useState<ReadonlySet<string>>(EMPTY_SET)
     const [isLoadingStats, setIsLoadingStats] = useState(true)
+    const isMountedRef = useRef(true)
+
+    useEffect(() => {
+        isMountedRef.current = true
+        return () => {
+            isMountedRef.current = false
+        }
+    }, [])
 
     const completedStepsCount = completedStepIds.size
 
@@ -42,6 +50,7 @@ export function LearningProvider({ children }: { children: ReactNode }) {
                 getLearningStats(user.id),
                 getAllStepProgress(user.id),
             ])
+            if (!isMountedRef.current) return
             setStats(currentStats)
             const ids = new Set(
                 progresses.filter(isStepCompleted).map((p) => p.step_id),
@@ -50,7 +59,9 @@ export function LearningProvider({ children }: { children: ReactNode }) {
         } catch (err) {
             console.error('Failed to load learning stats:', err)
         } finally {
-            setIsLoadingStats(false)
+            if (isMountedRef.current) {
+                setIsLoadingStats(false)
+            }
         }
     }, [user])
 

--- a/apps/web/src/features/learning/hooks/useLearningStep.ts
+++ b/apps/web/src/features/learning/hooks/useLearningStep.ts
@@ -53,6 +53,8 @@ export function useLearningStep(stepId: string): UseLearningStepReturn {
   const { refreshAchievements } = useAchievementContext()
 
   const [modeStatus, setModeStatus] = useState<ModeStatus>(INITIAL_MODE_STATUS)
+  const modeStatusRef = useRef(modeStatus)
+  useEffect(() => { modeStatusRef.current = modeStatus }, [modeStatus])
   const [syncMessage, setSyncMessage] = useState<string | null>(null)
   const [toastMessage, setToastMessage] = useState<string | null>(null)
   const completedOnceRef = useRef(false)
@@ -154,9 +156,10 @@ export function useLearningStep(stepId: string): UseLearningStepReturn {
 
   const handleModeComplete = useCallback(
     async (mode: LearningMode) => {
-      if (!step || !user?.id || modeStatus[mode]) return
+      const currentStatus = modeStatusRef.current
+      if (!step || !user?.id || currentStatus[mode]) return
 
-      const wasStepCompleted = modeStatus.read && modeStatus.practice && modeStatus.test && modeStatus.challenge
+      const wasStepCompleted = currentStatus.read && currentStatus.practice && currentStatus.test && currentStatus.challenge
 
       setModeStatus((prev) => ({ ...prev, [mode]: true }))
       setSyncMessage(null)
@@ -194,7 +197,7 @@ export function useLearningStep(stepId: string): UseLearningStepReturn {
         setSyncMessage(message)
       }
     },
-    [modeStatus, refreshStats, refreshAchievements, step, user?.id],
+    [refreshStats, refreshAchievements, step, user?.id],
   )
 
   return {

--- a/apps/web/src/pages/SignUpPage.tsx
+++ b/apps/web/src/pages/SignUpPage.tsx
@@ -29,6 +29,7 @@ export function SignUpPage() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [showConfirmEmail, setShowConfirmEmail] = useState(false)
 
   const isDisabled = useMemo(() => isSubmitting || Boolean(supabaseConfigError), [isSubmitting])
 
@@ -52,6 +53,11 @@ export function SignUpPage() {
     setIsSubmitting(true)
 
     const message = await signUp(normalizedEmail, password)
+    if (message === 'CONFIRM_EMAIL') {
+      setShowConfirmEmail(true)
+      setIsSubmitting(false)
+      return
+    }
     if (message) {
       setError(message)
       setIsSubmitting(false)
@@ -59,6 +65,23 @@ export function SignUpPage() {
     }
 
     navigate('/', { replace: true })
+  }
+
+  if (showConfirmEmail) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50 px-6 py-16">
+        <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm text-center">
+          <h2 className="text-xl font-bold text-slate-800">メールアドレスを確認してください</h2>
+          <p className="text-sm text-slate-600">
+            <span className="font-medium text-slate-800">{email}</span> に確認メールを送信しました。
+          </p>
+          <p className="text-sm text-slate-600">メール内のリンクをクリックして、アカウントの作成を完了してください。</p>
+          <Link className="inline-block text-sm font-medium text-primary-dark underline" to="/login">
+            ログインページへ
+          </Link>
+        </div>
+      </main>
+    )
   }
 
   return (


### PR DESCRIPTION
## Summary
- **3-1**: `useLearningStep` の `handleModeComplete` で `modeStatusRef` を使い stale closure を修正
- **3-2**: `AchievementContext` / `LearningContext` に `isMountedRef` ガード追加（アンマウント後の setState 防止）
- **3-3**: `AuthContext` の `getSession()` → `onAuthStateChange` を逐次実行化（レースコンディション防止）
- **3-4**: `signUp` フローでメール確認待ち UI 表示 + 重複メールアドレス検出
- **3-5**: `LearningOverviewCard.tsx` は v2 で既に削除済み、対応不要

## Test plan
- [x] typecheck PASS
- [x] lint PASS
- [x] test 493/493 PASS
- [x] build PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)