### PR TITLE
fix: モバイルドロワーの z-index スタッキングコンテキスト修正

### DIFF
--- a/apps/web/src/features/dashboard/components/AppHeader.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeader.tsx
@@ -79,6 +79,7 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
     'block rounded-lg px-3 py-2 pl-6 text-sm text-slate-600 transition hover:bg-slate-50'
 
   return (
+    <>
     <header className="sticky top-0 z-40 border-b border-slate-200/70 bg-white/90 backdrop-blur">
       <div className="mx-auto flex h-16 w-full max-w-7xl items-center justify-between gap-4 px-4 sm:px-6 lg:px-8">
         <div className="flex items-center gap-8">
@@ -179,106 +180,107 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
           </button>
         </div>
       </div>
-
-      {/* モバイルドロワー */}
-      {isDrawerOpen ? (
-        <div className="fixed inset-0 z-50 md:hidden">
-          {/* オーバーレイ */}
-          <div
-            className="absolute inset-0 bg-black/30 transition-opacity"
-            onClick={closeDrawer}
-            aria-hidden="true"
-          />
-
-          {/* ドロワーパネル */}
-          <nav
-            className="absolute right-0 top-0 flex h-full w-72 flex-col bg-white shadow-xl transition-transform duration-300"
-            aria-label="モバイルナビゲーション"
-          >
-            {/* ヘッダー */}
-            <div className="flex h-16 items-center justify-between border-b border-slate-200 px-4">
-              <span className="text-sm font-semibold text-slate-900">メニュー</span>
-              <button
-                className="rounded-lg p-2 text-slate-500 transition hover:bg-slate-100"
-                type="button"
-                onClick={closeDrawer}
-                aria-label="メニューを閉じる"
-              >
-                <X className="h-5 w-5" />
-              </button>
-            </div>
-
-            {/* ユーザー情報 */}
-            <div className="border-b border-slate-100 px-4 py-3">
-              <div className="text-sm font-medium text-slate-900">{displayName}</div>
-              <div className="mt-1.5 flex items-center gap-2">
-                <span className="rounded-full border border-amber-300/30 bg-amber-50 px-2 py-0.5 text-xs font-semibold text-amber-700">
-                  <Gem className="inline-block h-3.5 w-3.5" /> {stats?.total_points ?? 0} Pt
-                </span>
-                <span className="rounded-full border border-primary-mint/30 bg-secondary-bg px-2 py-0.5 text-xs font-semibold text-primary-dark">
-                  <Flame className="inline-block h-3.5 w-3.5" /> {stats?.current_streak ?? 0}日連続
-                </span>
-              </div>
-            </div>
-
-            {/* ナビゲーションリンク */}
-            <div className="flex-1 overflow-y-auto px-3 py-3">
-              <Link
-                to="/"
-                className={drawerLinkClass(location.pathname === '/')}
-                aria-current={location.pathname === '/' ? 'page' : undefined}
-              >
-                ダッシュボード
-              </Link>
-
-              <Link
-                to="/curriculum"
-                className={drawerLinkClass(isCurriculumActive)}
-                aria-current={location.pathname === '/curriculum' ? 'page' : undefined}
-              >
-                カリキュラム
-              </Link>
-
-              {/* カテゴリ */}
-              <div className="ml-2 border-l border-slate-200 pl-1">
-                {CATEGORIES.map((cat) => (
-                  <Link key={cat.id} to={`/curriculum#${cat.id}`} className={drawerSubLinkClass}>
-                    {cat.title}
-                  </Link>
-                ))}
-              </div>
-
-              {/* 練習モード */}
-              <div className="mb-2 ml-2 border-l border-slate-200 pl-1">
-                {PRACTICE_LINKS.map((link) => (
-                  <Link key={link.to} to={link.to} className={drawerSubLinkClass}>
-                    {link.label}
-                  </Link>
-                ))}
-              </div>
-
-              <Link
-                to="/profile"
-                className={drawerLinkClass(location.pathname === '/profile')}
-                aria-current={location.pathname === '/profile' ? 'page' : undefined}
-              >
-                プロフィール
-              </Link>
-            </div>
-
-            {/* ログアウトボタン */}
-            <div className="border-t border-slate-200 px-3 py-3">
-              <button
-                className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
-                type="button"
-                onClick={() => { closeDrawer(); onSignOut() }}
-              >
-                ログアウト
-              </button>
-            </div>
-          </nav>
-        </div>
-      ) : null}
     </header>
+
+    {/* モバイルドロワー — header 外に配置し z-50 がグローバルに効くようにする */}
+    {isDrawerOpen ? (
+      <div className="fixed inset-0 z-50 md:hidden">
+        {/* オーバーレイ */}
+        <div
+          className="absolute inset-0 bg-black/30 transition-opacity"
+          onClick={closeDrawer}
+          aria-hidden="true"
+        />
+
+        {/* ドロワーパネル */}
+        <nav
+          className="absolute right-0 top-0 flex h-full w-72 flex-col bg-white shadow-xl transition-transform duration-300"
+          aria-label="モバイルナビゲーション"
+        >
+          {/* ヘッダー */}
+          <div className="flex h-16 items-center justify-between border-b border-slate-200 px-4">
+            <span className="text-sm font-semibold text-slate-900">メニュー</span>
+            <button
+              className="rounded-lg p-2 text-slate-500 transition hover:bg-slate-100"
+              type="button"
+              onClick={closeDrawer}
+              aria-label="メニューを閉じる"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+
+          {/* ユーザー情報 */}
+          <div className="border-b border-slate-100 px-4 py-3">
+            <div className="text-sm font-medium text-slate-900">{displayName}</div>
+            <div className="mt-1.5 flex items-center gap-2">
+              <span className="rounded-full border border-amber-300/30 bg-amber-50 px-2 py-0.5 text-xs font-semibold text-amber-700">
+                <Gem className="inline-block h-3.5 w-3.5" /> {stats?.total_points ?? 0} Pt
+              </span>
+              <span className="rounded-full border border-primary-mint/30 bg-secondary-bg px-2 py-0.5 text-xs font-semibold text-primary-dark">
+                <Flame className="inline-block h-3.5 w-3.5" /> {stats?.current_streak ?? 0}日連続
+              </span>
+            </div>
+          </div>
+
+          {/* ナビゲーションリンク */}
+          <div className="flex-1 overflow-y-auto px-3 py-3">
+            <Link
+              to="/"
+              className={drawerLinkClass(location.pathname === '/')}
+              aria-current={location.pathname === '/' ? 'page' : undefined}
+            >
+              ダッシュボード
+            </Link>
+
+            <Link
+              to="/curriculum"
+              className={drawerLinkClass(isCurriculumActive)}
+              aria-current={location.pathname === '/curriculum' ? 'page' : undefined}
+            >
+              カリキュラム
+            </Link>
+
+            {/* カテゴリ */}
+            <div className="ml-2 border-l border-slate-200 pl-1">
+              {CATEGORIES.map((cat) => (
+                <Link key={cat.id} to={`/curriculum#${cat.id}`} className={drawerSubLinkClass}>
+                  {cat.title}
+                </Link>
+              ))}
+            </div>
+
+            {/* 練習モード */}
+            <div className="mb-2 ml-2 border-l border-slate-200 pl-1">
+              {PRACTICE_LINKS.map((link) => (
+                <Link key={link.to} to={link.to} className={drawerSubLinkClass}>
+                  {link.label}
+                </Link>
+              ))}
+            </div>
+
+            <Link
+              to="/profile"
+              className={drawerLinkClass(location.pathname === '/profile')}
+              aria-current={location.pathname === '/profile' ? 'page' : undefined}
+            >
+              プロフィール
+            </Link>
+          </div>
+
+          {/* ログアウトボタン */}
+          <div className="border-t border-slate-200 px-3 py-3">
+            <button
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2.5 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+              type="button"
+              onClick={() => { closeDrawer(); onSignOut() }}
+            >
+              ログアウト
+            </button>
+          </div>
+        </nav>
+      </div>
+    ) : null}
+    </>
   )
 }


### PR DESCRIPTION
## Summary

- モバイルドロワーを `<header z-40 backdrop-blur>` の外に移動し、`z-50` がグローバルスタッキングコンテキストで正しく評価されるよう修正

## 原因

`<header>` の `z-40` と `backdrop-blur` がスタッキングコンテキストを生成し、子要素のドロワー `z-50` が header の z-40 の範囲内に閉じ込められていた

## 変更内容

- `AppHeader.tsx`: ドロワーを `<header>` の外に Fragment で兄弟要素として配置

## Test plan

- [x] typecheck PASS
- [x] lint PASS
- [x] 全596テスト PASS
- [x] build PASS
- [ ] スマホ表示でドロワーが全要素の上に正しく表示されることを確認

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)