### PR TITLE
fix: スマホ表示の UI を改善（カリキュラム・練習モードナビ）

### DIFF
--- a/apps/web/src/features/daily/components/PracticeModeNav.tsx
+++ b/apps/web/src/features/daily/components/PracticeModeNav.tsx
@@ -42,8 +42,8 @@ export function PracticeModeNav() {
         </ul>
       </nav>
 
-      {/* モバイル: 水平ピルナビ */}
-      <nav className="mb-2 flex gap-2 overflow-x-auto lg:hidden" aria-label="練習モード">
+      {/* モバイル: 折り返しピルナビ */}
+      <nav className="mb-2 flex flex-wrap gap-2 lg:hidden" aria-label="練習モード">
         {NAV_ITEMS.map(({ path, label, icon: Icon }) => {
           const isActive = pathname === path || pathname.startsWith(path + '/')
           return (
@@ -51,7 +51,7 @@ export function PracticeModeNav() {
               key={path}
               to={path}
               className={[
-                'flex shrink-0 items-center gap-1.5 rounded-full px-3.5 py-2 text-sm font-medium transition-colors',
+                'flex flex-1 items-center justify-center gap-1.5 rounded-full px-3.5 py-2 text-sm font-medium transition-colors',
                 isActive
                   ? 'bg-amber-500 text-white'
                   : 'border border-slate-200 bg-white text-text-muted hover:border-amber-400 hover:text-amber-600',

--- a/apps/web/src/pages/CurriculumPage.tsx
+++ b/apps/web/src/pages/CurriculumPage.tsx
@@ -213,11 +213,11 @@ function CourseAccordion({
         disabled={lockStatus.locked}
         aria-expanded={isOpen}
       >
-        <div className="flex items-center gap-3">
+        <div className="flex min-w-0 flex-wrap items-center gap-2 sm:gap-3">
           <span className={`rounded-md px-2 py-0.5 text-xs font-semibold ${levelColor}`}>
             {levelLabel}
           </span>
-          <span className="font-semibold text-slate-900">{course.title}</span>
+          <span className="min-w-0 font-semibold text-slate-900">{course.title}</span>
           {hasSteps && (
             <span className="text-xs text-slate-400">
               {completedCount}/{implementedSteps.length}
@@ -226,9 +226,12 @@ function CourseAccordion({
           {isCompleted && <span className="text-xs font-semibold text-emerald-600">完了</span>}
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex shrink-0 items-center gap-2">
           {lockStatus.locked && (
-            <span className="text-xs text-slate-400">🔒 {lockStatus.reason}</span>
+            <span className="hidden text-xs text-slate-400 sm:inline">🔒 {lockStatus.reason}</span>
+          )}
+          {lockStatus.locked && (
+            <span className="text-xs text-slate-400 sm:hidden">🔒</span>
           )}
           {!lockStatus.locked && !lockStatus.warning && hasSteps && (
             <ChevronDown className={`h-4 w-4 text-slate-400 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
@@ -258,8 +261,8 @@ function CourseAccordion({
                     <span className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs font-bold ${done ? 'bg-emerald-500 text-white' : 'border border-slate-300 text-slate-400'}`}>
                       {done ? '✓' : step.order}
                     </span>
-                    <span className={done ? 'text-slate-500' : 'text-slate-800'}>{step.title}</span>
-                    <span className="ml-auto text-xs text-slate-400">{step.description}</span>
+                    <span className={`min-w-0 ${done ? 'text-slate-500' : 'text-slate-800'}`}>{step.title}</span>
+                    <span className="ml-auto hidden text-xs text-slate-400 sm:block">{step.description}</span>
                   </Link>
                 </li>
               )


### PR DESCRIPTION
## Summary
- カリキュラムページ: ステップ説明文をモバイル非表示 (`hidden sm:block`)、アコーディオンヘッダーを `flex-wrap` で折り返し対応、ロック理由をモバイル短縮表示
- 練習モードナビ: `overflow-x-auto` + `shrink-0` → `flex-wrap` + `flex-1` に変更し、4タブを均等幅で2行折り返し表示

Closes #183, Closes #184

## Test plan
- [x] typecheck pass
- [x] lint pass
- [x] test 596件 pass
- [x] build pass
- [ ] ブラウザ確認: スマホ幅（375px）でカリキュラムページのステップ一覧が読みやすいこと
- [ ] ブラウザ確認: 練習モードナビの4タブがすべて見えること

🤖 Generated with [Claude Code](https://claude.com/claude-code)