### PR TITLE
fix: ステップページのスマホ表示で横溢れを修正

### DIFF
--- a/apps/web/src/features/learning/ReadMode.tsx
+++ b/apps/web/src/features/learning/ReadMode.tsx
@@ -72,7 +72,7 @@ export function ReadMode({ markdown, onComplete, isCompleted }: ReadModeProps) {
         {completeButton}
       </div>
 
-      <article className="prose prose-slate max-w-none rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5">
+      <article className="prose prose-slate max-w-none overflow-x-hidden rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-5">
         <ReactMarkdown
           remarkPlugins={[remarkGfm]}
           components={{

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -246,7 +246,7 @@ export function StepPage() {
           <LearningSidebar category={stepCategory} currentStepId={stepId} />
 
           <ErrorBoundary>
-          <div className="flex-1 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="min-w-0 flex-1 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
             <nav className="mt-4 border-b border-slate-200 pb-4" aria-label="学習モードステッパー">
               <ol className="flex items-center gap-0">
                 {modeButtons.map((mode, index) => {


### PR DESCRIPTION
## Summary
- StepPage: `flex-1` コンテンツ div に `min-w-0` を追加し、flexbox の min-width: auto デフォルトによる横溢れを解消
- ReadMode: `article` に `overflow-x-hidden` を追加して、マークダウンコンテンツのはみ出しを抑制

Closes #186

## Test plan
- [x] typecheck pass
- [x] lint pass
- [x] test 596件 pass
- [x] build pass
- [ ] ブラウザ確認: スマホ幅（375px）で step26 を表示して横溢れしないこと
- [ ] ブラウザ確認: ハンバーガーメニューが正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)