### PR TITLE
fix: ステップページの summary テキスト横溢れを修正

### DIFF
--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -204,7 +204,7 @@ export function StepPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50">
+    <div className="min-h-screen overflow-x-hidden bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50">
       <AppHeader displayName={headerDisplayName} onSignOut={() => void handleSignOut()} />
 
       <main className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-6 sm:px-6">
@@ -239,7 +239,7 @@ export function StepPage() {
             </span>
           </div>
           <h1 className="text-3xl font-bold">{step.title}</h1>
-          <p className="text-slate-600">{step.summary}</p>
+          <p className="break-words text-slate-600">{step.summary}</p>
         </section>
 
         <section className="flex flex-col gap-4 lg:flex-row lg:items-start">


### PR DESCRIPTION
## Summary
- summary の `<p>` に `break-words` を追加（スラッシュ区切りの長い文字列を折り返し可能に）
- ページ外枠 `<div>` に `overflow-x-hidden` を追加（横溢れの安全弁）

step26「ユーティリティ型」の summary "Partial/Required/Readonly/Pick/Omit/Record/ReturnType/Parameters" がスラッシュで区切られた長い文字列のため、ブラウザが単語境界と認識せず画面幅を超えていた。

Refs #186

## Test plan
- [x] typecheck / lint / test 596件 / build 全パス
- [ ] ブラウザ確認: スマホ幅で step26 の summary が折り返されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)