### PR TITLE
v3 M2: Monaco Editor → CodeMirror 6 移行

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -21,7 +21,6 @@
     "@codemirror/state": "^6.6.0",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@codemirror/view": "^6.41.0",
-    "@monaco-editor/react": "^4.7.0",
     "@supabase/supabase-js": "^2.57.4",
     "@uiw/react-codemirror": "^4.25.9",
     "lucide-react": "^0.577.0",

--- a/apps/web/src/features/learning/ChallengeMode.tsx
+++ b/apps/web/src/features/learning/ChallengeMode.tsx
@@ -1,12 +1,9 @@
-import { Suspense, lazy, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Button } from '../../components/Button'
+import { CodeEditor } from '../../components/CodeEditor'
 import { ErrorBanner } from '../../components/ErrorBanner'
-import { ErrorBoundary } from '../../components/ErrorBoundary'
 import type { ChallengePattern, ChallengeTask } from '../../content/fundamentals/steps'
 import { JudgmentResult } from './components/JudgmentResult'
-import { MONACO_EDITOR_HEIGHT } from '../../shared/constants'
-
-const MonacoEditor = lazy(() => import('@monaco-editor/react'))
 
 interface ChallengeModeProps {
   stepId: string
@@ -71,9 +68,9 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
     }
   }
 
-  function handleCodeChange(nextValue: string | undefined) {
+  function handleCodeChange(nextValue: string) {
     setChecked(false)
-    setCode(nextValue ?? '')
+    setCode(nextValue)
   }
 
   return (
@@ -88,18 +85,12 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
       </ul>
 
       <div className="overflow-hidden rounded-lg border border-slate-300">
-        <ErrorBoundary fallback={<div className="bg-slate-900 p-4 text-sm text-red-300">エディタの読み込みに失敗しました。ページを再読み込みしてください。</div>}>
-          <Suspense fallback={<div className="bg-slate-900 p-4 text-sm text-slate-100">エディタを読み込み中...</div>}>
-            <MonacoEditor
-              defaultLanguage="typescript"
-              height={MONACO_EDITOR_HEIGHT}
-              theme="vs-dark"
-              value={code}
-              options={{ minimap: { enabled: false }, fontSize: 14 }}
-              onChange={handleCodeChange}
-            />
-          </Suspense>
-        </ErrorBoundary>
+        <CodeEditor
+          value={code}
+          onChange={handleCodeChange}
+          language="typescript"
+          height="320px"
+        />
       </div>
 
       <div className="flex flex-col items-start gap-4 pt-4 sm:flex-row sm:items-center">

--- a/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
@@ -4,8 +4,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ChallengeMode } from '../ChallengeMode'
 import type { ChallengeTask } from '../../../content/fundamentals/steps'
 
-vi.mock('@monaco-editor/react', () => ({
-  default: ({ value, onChange }: { value?: string; onChange?: (nextValue: string) => void }) => (
+vi.mock('@/components/CodeEditor', () => ({
+  CodeEditor: ({ value, onChange }: { value?: string; onChange?: (nextValue: string) => void }) => (
     <textarea
       aria-label="challenge-editor"
       value={value}

--- a/apps/web/src/pages/CodeDoctorPage.tsx
+++ b/apps/web/src/pages/CodeDoctorPage.tsx
@@ -1,5 +1,6 @@
-import { Suspense, lazy, useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useAuth } from '../contexts/AuthContext'
+import { CodeEditor } from '../components/CodeEditor'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { getProblemProgressMap, submitDoctorSolution } from '../services/codeDoctorService'
 import { PracticeModeNav } from '../features/daily/components/PracticeModeNav'
@@ -8,8 +9,6 @@ import { PracticePageLayout } from '../components/PracticePageLayout'
 import { Spinner } from '../components/Spinner'
 import { CODE_DOCTOR_PROBLEMS } from '../content/code-doctor/problems'
 import type { CodeDoctorDifficulty, CodeDoctorProblem, CodeDoctorProgress, SubmitDoctorResult } from '../content/code-doctor/types'
-
-const MonacoEditor = lazy(() => import('@monaco-editor/react'))
 
 type FilterValue = 'all' | CodeDoctorDifficulty
 
@@ -201,22 +200,12 @@ export function CodeDoctorPage() {
             {/* Monaco エディタ */}
             <div className="flex min-w-0 flex-1 flex-col gap-4">
               <div className="overflow-hidden rounded-xl border border-border">
-                <Suspense
-                  fallback={
-                    <div className="flex h-80 items-center justify-center bg-slate-900 text-sm text-slate-300">
-                      エディタを読み込み中...
-                    </div>
-                  }
-                >
-                  <MonacoEditor
-                    height="480px"
-                    defaultLanguage="typescript"
-                    theme="vs-dark"
-                    value={code}
-                    options={{ minimap: { enabled: false }, fontSize: 14, scrollBeyondLastLine: false }}
-                    onChange={(v) => { setCode(v ?? ''); setResult(null) }}
-                  />
-                </Suspense>
+                <CodeEditor
+                  value={code}
+                  onChange={(v) => { setCode(v); setResult(null) }}
+                  language="typescript"
+                  height="480px"
+                />
               </div>
 
               <div className="flex items-center gap-4">

--- a/apps/web/src/pages/MiniProjectDetailPage.tsx
+++ b/apps/web/src/pages/MiniProjectDetailPage.tsx
@@ -1,15 +1,13 @@
-import { Suspense, lazy, useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Link, Navigate, useParams } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
+import { CodeEditor } from '../components/CodeEditor'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { getProjectProgressMap, submitProject } from '../services/miniProjectService'
 import { PracticeModeNav } from '../features/daily/components/PracticeModeNav'
 import { PracticePageLayout } from '../components/PracticePageLayout'
-import { Spinner } from '../components/Spinner'
 import { MINI_PROJECTS } from '../content/mini-projects/projects'
 import type { MilestoneJudgeResult, MiniProjectProgress, MiniProjectStatus, SubmitProjectResult } from '../content/mini-projects/types'
-
-const MonacoEditor = lazy(() => import('@monaco-editor/react'))
 
 export function MiniProjectDetailPage() {
   const { projectId } = useParams<{ projectId: string }>()
@@ -168,26 +166,16 @@ export function MiniProjectDetailPage() {
             )}
 
             <div className="overflow-hidden rounded-xl border border-border">
-              <Suspense
-                fallback={
-                  <div className="flex h-80 items-center justify-center bg-slate-900 text-sm text-slate-300">
-                    <Spinner />
-                  </div>
-                }
-              >
-                <MonacoEditor
-                  height="520px"
-                  defaultLanguage="typescript"
-                  theme="vs-dark"
-                  value={code}
-                  options={{ minimap: { enabled: false }, fontSize: 14, scrollBeyondLastLine: false }}
-                  onChange={(v) => {
-                    setCode(v ?? '')
-                    setMilestoneResults(null)
-                    setSubmitResult(null)
-                  }}
-                />
-              </Suspense>
+              <CodeEditor
+                value={code}
+                onChange={(v) => {
+                  setCode(v)
+                  setMilestoneResults(null)
+                  setSubmitResult(null)
+                }}
+                language="typescript"
+                height="520px"
+              />
             </div>
 
             <div className="flex items-center gap-4">

--- a/apps/web/src/pages/__tests__/CodeDoctorPage.test.tsx
+++ b/apps/web/src/pages/__tests__/CodeDoctorPage.test.tsx
@@ -29,8 +29,8 @@ vi.mock('@/features/daily/components/PracticeModeNav', () => ({
   PracticeModeNav: () => <nav>PracticeModeNav</nav>,
 }))
 
-vi.mock('@monaco-editor/react', () => ({
-  default: () => <div>MonacoEditor</div>,
+vi.mock('@/components/CodeEditor', () => ({
+  CodeEditor: () => <div>CodeEditor</div>,
 }))
 
 describe('CodeDoctorPage', () => {

--- a/apps/web/src/shared/constants.ts
+++ b/apps/web/src/shared/constants.ts
@@ -47,8 +47,6 @@ export const MAX_CODE_LENGTH = 50_000
 /** デイリーチャレンジ回答の最大文字数 */
 export const MAX_ANSWER_LENGTH = 500
 
-/** Monaco Editor のデフォルト高さ */
-export const MONACO_EDITOR_HEIGHT = '320px'
 
 /** ポイント目標のマイルストーン */
 export const POINT_MILESTONES = [500, 1000, 1500, 2000] as const

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -26,7 +26,6 @@ export default defineConfig({
         manualChunks: {
           'vendor-react': ['react', 'react-dom', 'react-router-dom'],
           'vendor-supabase': ['@supabase/supabase-js'],
-          'vendor-monaco': ['@monaco-editor/react'],
           'vendor-codemirror': ['@uiw/react-codemirror', '@codemirror/view', '@codemirror/state'],
           'vendor-markdown': ['react-markdown', 'remark-gfm'],
           'vendor-prism': ['prismjs'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "@codemirror/state": "^6.6.0",
         "@codemirror/theme-one-dark": "^6.1.3",
         "@codemirror/view": "^6.41.0",
-        "@monaco-editor/react": "^4.7.0",
         "@supabase/supabase-js": "^2.57.4",
         "@uiw/react-codemirror": "^4.25.9",
         "lucide-react": "^0.577.0",
@@ -100,25 +99,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "apps/web/node_modules/@monaco-editor/loader": {
-      "version": "1.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "state-local": "^1.0.6"
-      }
-    },
-    "apps/web/node_modules/@monaco-editor/react": {
-      "version": "4.7.0",
-      "license": "MIT",
-      "dependencies": {
-        "@monaco-editor/loader": "^1.5.0"
-      },
-      "peerDependencies": {
-        "monaco-editor": ">= 0.25.0 < 1",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "apps/web/node_modules/@rolldown/pluginutils": {
@@ -294,11 +274,6 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
-    },
-    "apps/web/node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "license": "MIT",
-      "optional": true
     },
     "apps/web/node_modules/@types/unist": {
       "version": "3.0.3",
@@ -591,13 +566,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "apps/web/node_modules/dompurify": {
-      "version": "3.2.7",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
-      }
-    },
     "apps/web/node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
@@ -754,16 +722,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "apps/web/node_modules/marked": {
-      "version": "14.0.0",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "apps/web/node_modules/mdast-util-find-and-replace": {
@@ -1513,15 +1471,6 @@
       ],
       "license": "MIT"
     },
-    "apps/web/node_modules/monaco-editor": {
-      "version": "0.55.1",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "dompurify": "3.2.7",
-        "marked": "14.0.0"
-      }
-    },
     "apps/web/node_modules/parse-entities": {
       "version": "4.0.2",
       "license": "MIT",
@@ -1694,10 +1643,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "apps/web/node_modules/state-local": {
-      "version": "1.0.7",
-      "license": "MIT"
     },
     "apps/web/node_modules/std-env": {
       "version": "4.0.0",


### PR DESCRIPTION
## Summary
- ChallengeMode / CodeDoctorPage / MiniProjectDetailPage の Monaco Editor を CodeEditor（CodeMirror 6）に移行
- Monaco 用の ErrorBoundary / Suspense ラッパーを除去（CodeMirror は lazy import 不要）
- `@monaco-editor/react` パッケージを撤去し、`vendor-monaco` チャンクを完全消滅
- `MONACO_EDITOR_HEIGHT` 定数を削除
- テストモックを `@/components/CodeEditor` に更新

## バンドルサイズ変更
| チャンク | Before | After |
|---------|--------|-------|
| vendor-monaco | ~750 kB | **削除** |
| vendor-codemirror | 398 kB | 398 kB（変更なし） |

## Test plan
- [x] typecheck PASS
- [x] lint PASS
- [x] 全643テスト PASS（ChallengeMode 2件 + CodeDoctorPage 4件のモック更新含む）
- [x] build PASS（vendor-monaco 消滅確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)