### PR TITLE
feat: v3.1 M4 カリキュラムページ モバイル最適化

### DIFF
--- a/apps/web/src/pages/CurriculumPage.tsx
+++ b/apps/web/src/pages/CurriculumPage.tsx
@@ -107,7 +107,7 @@ export function CurriculumPage() {
         </div>
 
         {/* 練習モードセクション */}
-        <section id="practice" className="mt-12">
+        <section id="practice" className="mt-6 border-t border-slate-200 pt-6">
           <h2 className="text-xl font-bold text-slate-900">練習モード</h2>
           <p className="mt-1 text-sm text-slate-500">繰り返し学習で知識を定着させましょう</p>
 
@@ -147,7 +147,7 @@ function CategorySection({
 
   return (
     <section id={category.id}>
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-3 border-l-4 border-emerald-400 pl-3">
         <div className="rounded-lg bg-primary-mint/10 p-2">
           <IconComponent className="h-5 w-5 text-primary-dark" />
         </div>
@@ -208,7 +208,7 @@ function CourseAccordion({
     <div className={`rounded-xl border bg-white shadow-sm ${lockStatus.locked ? 'border-slate-200 opacity-60' : 'border-slate-200'}`}>
       <button
         type="button"
-        className="flex w-full items-center justify-between px-5 py-4 text-left"
+        className="flex w-full items-center justify-between px-4 py-3 text-left sm:px-5 sm:py-4"
         onClick={() => !lockStatus.locked && setIsOpen((prev) => !prev)}
         disabled={lockStatus.locked}
         aria-expanded={isOpen}
@@ -243,7 +243,7 @@ function CourseAccordion({
       </button>
 
       {isOpen && !lockStatus.locked && hasSteps && (
-        <div className="border-t border-slate-100 px-5 py-3">
+        <div className="border-t border-slate-100 px-4 py-3 sm:px-5">
           {!lockStatus.locked && lockStatus.warning && (
             <p className="mb-3 rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-700">
               {lockStatus.warning}
@@ -256,7 +256,7 @@ function CourseAccordion({
                 <li key={step.id}>
                   <Link
                     to={`/step/${step.id}`}
-                    className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition hover:bg-slate-50"
+                    className="flex min-h-[44px] items-center gap-3 rounded-lg px-3 py-2 text-sm transition hover:bg-slate-50"
                   >
                     <span className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs font-bold ${done ? 'bg-emerald-500 text-white' : 'border border-slate-300 text-slate-400'}`}>
                       {done ? '✓' : step.order}


### PR DESCRIPTION
## Summary
- アコーディオンボタン・展開内容の余白をモバイルで縮小（px-4 py-3 / sm:px-5 sm:py-4）
- ステップリンクに min-h-[44px] を追加してタップターゲット確保
- カテゴリヘッダーに左ボーダー（border-l-4 border-emerald-400）で階層を視覚強化
- 練習モードセクションに上ボーダー（border-t border-slate-200）で境界を明確化

## Test plan
- [x] 696テスト全PASS
- [x] typecheck / lint / build 全通過
- [ ] Playwright でモバイル表示確認（375px / 390px）

🤖 Generated with [Claude Code](https://claude.com/claude-code)