### PR TITLE
feat: ナビ・フィルターのタップターゲット 44px 化（v3.2 M1）

### DIFF
--- a/apps/web/src/components/LearningSidebar.tsx
+++ b/apps/web/src/components/LearningSidebar.tsx
@@ -21,7 +21,7 @@ export function LearningSidebar({ category, currentStepId }: LearningSidebarProp
       <div className="flex items-center justify-between gap-3">
         <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">{category.title}</p>
         <button
-          className="inline-flex items-center gap-1 rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 lg:hidden"
+          className="inline-flex items-center gap-1 rounded-full border border-slate-200 px-3 py-2 min-h-[44px] text-xs font-semibold text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 lg:hidden"
           type="button"
           aria-expanded={!isCollapsed}
           aria-controls="learning-sidebar-list"

--- a/apps/web/src/features/daily/components/PracticeModeNav.tsx
+++ b/apps/web/src/features/daily/components/PracticeModeNav.tsx
@@ -51,7 +51,7 @@ export function PracticeModeNav() {
               key={path}
               to={path}
               className={[
-                'flex flex-1 items-center justify-center gap-1.5 rounded-full px-3.5 py-2 text-sm font-medium transition-colors',
+                'flex flex-1 items-center justify-center gap-1.5 rounded-full px-3.5 py-2.5 min-h-[44px] text-sm font-medium transition-colors',
                 isActive
                   ? 'bg-amber-500 text-white'
                   : 'border border-slate-200 bg-white text-text-muted hover:border-amber-400 hover:text-amber-600',

--- a/apps/web/src/pages/MiniProjectsPage.tsx
+++ b/apps/web/src/pages/MiniProjectsPage.tsx
@@ -73,7 +73,7 @@ export function MiniProjectsPage() {
                   type="button"
                   onClick={() => setFilter(value)}
                   className={[
-                    'rounded-full px-4 py-1.5 text-sm font-medium transition-colors',
+                    'rounded-full px-4 py-2.5 min-h-[44px] text-sm font-medium transition-colors',
                     filter === value
                       ? 'bg-amber-500 text-white'
                       : 'border border-border text-text-muted hover:border-amber-400 hover:text-amber-600',


### PR DESCRIPTION
## Summary

- PracticeModeNav モバイルピルに `min-h-[44px]` + `py-2.5` 追加
- LearningSidebar 折り畳みボタンに `min-h-[44px]` + `py-2` 追加
- MiniProjectsPage フィルターボタンに `min-h-[44px]` + `py-2.5` 追加

## Test plan

- [x] typecheck / lint / test (696 PASS) / build 全通過
- [ ] Playwright 検証は M4 で実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)