### PR TITLE
feat: プレビューコンポーネント一括モバイル最適化（v3.2 M2）

### DIFF
--- a/apps/web/src/features/learning/previews/ApiCounterGetPreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiCounterGetPreview.tsx
@@ -21,7 +21,7 @@ export default function ApiCounterGetPreview() {
         <p className="text-2xl font-bold text-slate-800">{count}</p>
       )}
       <button
-        className="rounded-lg bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-700 active:scale-95"
+        className="rounded-lg bg-blue-600 px-3 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-blue-700 active:scale-95"
         onClick={() => {
           setLoading(true)
           setTimeout(() => {

--- a/apps/web/src/features/learning/previews/ApiCounterPostPreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiCounterPostPreview.tsx
@@ -17,7 +17,7 @@ export default function ApiCounterPostPreview() {
       <p className="text-xs font-medium text-slate-500">POST /api/counter</p>
       <p className="text-2xl font-bold text-slate-800">{count}</p>
       <button
-        className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95 disabled:opacity-50"
+        className="rounded-lg bg-emerald-600 px-4 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-emerald-700 active:scale-95 disabled:opacity-50"
         onClick={handleIncrement}
         disabled={sending}
       >

--- a/apps/web/src/features/learning/previews/ApiCustomHookPreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiCustomHookPreview.tsx
@@ -41,13 +41,13 @@ export default function ApiCustomHookPreview() {
         {tasks.map((t) => (
           <li key={t.id} className="flex items-center gap-2 text-sm">
             <button
-              className={`text-xs ${t.done ? 'text-emerald-500' : 'text-slate-300'}`}
+              className={`min-h-[44px] px-2 py-1 text-xs ${t.done ? 'text-emerald-500' : 'text-slate-300'}`}
               onClick={() => toggleTask(t.id)}
             >
               {t.done ? '✓' : '○'}
             </button>
             <span className={t.done ? 'text-slate-400 line-through' : 'text-slate-700'}>{t.title}</span>
-            <button className="text-xs text-rose-400 hover:text-rose-600" onClick={() => deleteTask(t.id)}>
+            <button className="min-h-[44px] px-2 py-1 text-xs text-rose-400 hover:text-rose-600" onClick={() => deleteTask(t.id)}>
               ✗
             </button>
           </li>
@@ -62,7 +62,7 @@ export default function ApiCustomHookPreview() {
           onKeyDown={(e) => e.key === 'Enter' && handleAdd()}
         />
         <button
-          className="rounded-lg bg-emerald-600 px-3 py-1 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95"
+          className="rounded-lg bg-emerald-600 px-3 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-emerald-700 active:scale-95"
           onClick={handleAdd}
         >
           追加

--- a/apps/web/src/features/learning/previews/ApiErrorLoadingPreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiErrorLoadingPreview.tsx
@@ -19,7 +19,7 @@ export default function ApiErrorLoadingPreview() {
     <div className="space-y-3">
       <p className="text-xs font-medium text-slate-500">非同期UIの状態管理</p>
 
-      <div className="min-h-[48px] rounded-md border border-slate-200 px-3 py-2">
+      <div className="min-h-[44px] rounded-md border border-slate-200 px-3 py-2">
         {status === 'idle' && <p className="text-sm text-slate-400">ボタンを押してリクエストを送信</p>}
         {status === 'loading' && <p className="text-sm text-blue-500 animate-pulse">読み込み中…</p>}
         {status === 'success' && <p className="text-sm font-medium text-emerald-700">データの取得に成功しました</p>}
@@ -33,14 +33,14 @@ export default function ApiErrorLoadingPreview() {
 
       <div className="flex gap-2">
         <button
-          className="rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95 disabled:opacity-50"
+          className="rounded-lg bg-emerald-600 px-3 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-emerald-700 active:scale-95 disabled:opacity-50"
           onClick={simulateSuccess}
           disabled={status === 'loading'}
         >
           成功パターン
         </button>
         <button
-          className="rounded-lg bg-rose-600 px-3 py-2 text-sm font-medium text-white hover:bg-rose-700 active:scale-95 disabled:opacity-50"
+          className="rounded-lg bg-rose-600 px-3 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-rose-700 active:scale-95 disabled:opacity-50"
           onClick={simulateError}
           disabled={status === 'loading'}
         >
@@ -48,7 +48,7 @@ export default function ApiErrorLoadingPreview() {
         </button>
         {(status === 'success' || status === 'error') && (
           <button
-            className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-600 hover:bg-slate-100"
+            className="rounded-lg border border-slate-300 px-3 py-2 min-h-[44px] text-sm text-slate-600 hover:bg-slate-100"
             onClick={() => setStatus('idle')}
           >
             リセット

--- a/apps/web/src/features/learning/previews/ApiFetchPreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiFetchPreview.tsx
@@ -44,7 +44,7 @@ export default function ApiFetchPreview() {
         </ul>
       )}
       <button
-        className="rounded-lg bg-blue-600 px-3 py-1 text-sm font-medium text-white hover:bg-blue-700 active:scale-95"
+        className="rounded-lg bg-blue-600 px-3 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-blue-700 active:scale-95"
         onClick={handleRefresh}
       >
         再取得

--- a/apps/web/src/features/learning/previews/ApiTaskCreatePreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiTaskCreatePreview.tsx
@@ -35,7 +35,7 @@ export default function ApiTaskCreatePreview() {
           onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
         />
         <button
-          className="rounded-lg bg-emerald-600 px-3 py-1 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95 disabled:opacity-50"
+          className="rounded-lg bg-emerald-600 px-3 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-emerald-700 active:scale-95 disabled:opacity-50"
           onClick={handleCreate}
           disabled={sending}
         >

--- a/apps/web/src/features/learning/previews/ApiTaskDeletePreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiTaskDeletePreview.tsx
@@ -31,7 +31,7 @@ export default function ApiTaskDeletePreview() {
             <li key={t.id} className="flex items-center gap-2 text-sm">
               <span className="text-slate-700">{t.title}</span>
               <button
-                className="text-xs text-rose-400 hover:text-rose-600 disabled:opacity-50"
+                className="min-h-[44px] px-2 py-1 text-xs text-rose-400 hover:text-rose-600 active:text-rose-700 disabled:opacity-50"
                 onClick={() => handleDelete(t.id)}
                 disabled={deleting === t.id}
               >
@@ -43,7 +43,7 @@ export default function ApiTaskDeletePreview() {
       )}
       {tasks.length < initial.length && (
         <button
-          className="rounded-lg border border-slate-300 px-3 py-1 text-sm text-slate-600 hover:bg-slate-100"
+          className="rounded-lg border border-slate-300 px-3 py-1 min-h-[44px] text-sm text-slate-600 hover:bg-slate-100"
           onClick={() => setTasks(initial)}
         >
           リセット

--- a/apps/web/src/features/learning/previews/ApiTaskUpdatePreview.tsx
+++ b/apps/web/src/features/learning/previews/ApiTaskUpdatePreview.tsx
@@ -27,7 +27,7 @@ export default function ApiTaskUpdatePreview() {
         {tasks.map((t) => (
           <li key={t.id} className="flex items-center gap-2 text-sm">
             <button
-              className={`rounded px-2 py-0.5 text-xs font-medium ${t.done ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-600'} ${updating === t.id ? 'opacity-50' : 'hover:opacity-80'}`}
+              className={`rounded px-2 py-2 min-h-[44px] text-xs font-medium ${t.done ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-600'} ${updating === t.id ? 'opacity-50' : 'hover:opacity-80'}`}
               onClick={() => handleToggle(t.id)}
               disabled={updating === t.id}
             >

--- a/apps/web/src/features/learning/previews/ConditionalPreview.tsx
+++ b/apps/web/src/features/learning/previews/ConditionalPreview.tsx
@@ -13,7 +13,7 @@ export default function ConditionalPreview() {
         )}
       </div>
       <button
-        className={`rounded-lg px-4 py-2 text-sm font-medium text-white active:scale-95 ${isLoggedIn ? 'bg-rose-600 hover:bg-rose-700' : 'bg-emerald-600 hover:bg-emerald-700'}`}
+        className={`rounded-lg px-4 py-2 min-h-[44px] text-sm font-medium text-white active:scale-95 ${isLoggedIn ? 'bg-rose-600 hover:bg-rose-700' : 'bg-emerald-600 hover:bg-emerald-700'}`}
         onClick={() => setIsLoggedIn((v) => !v)}
       >
         {isLoggedIn ? 'ログアウト' : 'ログイン'}

--- a/apps/web/src/features/learning/previews/ContextPreview.tsx
+++ b/apps/web/src/features/learning/previews/ContextPreview.tsx
@@ -35,7 +35,7 @@ export default function ContextPreview() {
           <ThemedBadge />
         </div>
         <button
-          className="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white hover:bg-indigo-700 active:scale-95"
+          className="rounded-lg bg-indigo-600 px-4 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-indigo-700 active:scale-95"
           onClick={() => setTheme((t) => (t === 'light' ? 'dark' : 'light'))}
         >
           テーマ切替

--- a/apps/web/src/features/learning/previews/CounterPreview.tsx
+++ b/apps/web/src/features/learning/previews/CounterPreview.tsx
@@ -8,19 +8,19 @@ export default function CounterPreview() {
       <p className="text-2xl font-bold text-slate-800">{count}</p>
       <div className="flex gap-2">
         <button
-          className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95"
+          className="rounded-lg bg-emerald-600 px-4 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-emerald-700 active:scale-95"
           onClick={() => setCount((c) => c + 1)}
         >
           +1
         </button>
         <button
-          className="rounded-lg bg-slate-600 px-4 py-2 text-sm font-medium text-white hover:bg-slate-700 active:scale-95"
+          className="rounded-lg bg-slate-600 px-4 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-slate-700 active:scale-95"
           onClick={() => setCount((c) => c - 1)}
         >
           -1
         </button>
         <button
-          className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 active:scale-95"
+          className="rounded-lg border border-slate-300 px-4 py-2 min-h-[44px] text-sm font-medium text-slate-700 hover:bg-slate-100 active:scale-95"
           onClick={() => setCount(0)}
         >
           リセット

--- a/apps/web/src/features/learning/previews/CustomHookPreview.tsx
+++ b/apps/web/src/features/learning/previews/CustomHookPreview.tsx
@@ -14,13 +14,13 @@ export default function CustomHookPreview() {
     <div className="space-y-3">
       <div className="flex gap-3">
         <button
-          className={`rounded-lg px-4 py-2 text-sm font-medium active:scale-95 ${isDark ? 'bg-slate-800 text-white' : 'bg-slate-200 text-slate-800'}`}
+          className={`rounded-lg px-4 py-2 min-h-[44px] text-sm font-medium active:scale-95 ${isDark ? 'bg-slate-800 text-white' : 'bg-slate-200 text-slate-800'}`}
           onClick={toggleDark}
         >
           {isDark ? '🌙 Dark' : '☀️ Light'}
         </button>
         <button
-          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 active:scale-95"
+          className="rounded-lg bg-blue-600 px-4 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-blue-700 active:scale-95"
           onClick={toggleOpen}
         >
           {isOpen ? 'パネルを閉じる' : 'パネルを開く'}

--- a/apps/web/src/features/learning/previews/EffectPreview.tsx
+++ b/apps/web/src/features/learning/previews/EffectPreview.tsx
@@ -15,13 +15,13 @@ export default function EffectPreview() {
       <p className="text-2xl font-mono font-bold text-slate-800">{seconds}s</p>
       <div className="flex gap-2">
         <button
-          className={`rounded-lg px-4 py-2 text-sm font-medium text-white active:scale-95 ${running ? 'bg-amber-600 hover:bg-amber-700' : 'bg-emerald-600 hover:bg-emerald-700'}`}
+          className={`rounded-lg px-4 py-2 min-h-[44px] text-sm font-medium text-white active:scale-95 ${running ? 'bg-amber-600 hover:bg-amber-700' : 'bg-emerald-600 hover:bg-emerald-700'}`}
           onClick={() => setRunning((r) => !r)}
         >
           {running ? '停止' : '開始'}
         </button>
         <button
-          className="rounded-lg border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 active:scale-95"
+          className="rounded-lg border border-slate-300 px-4 py-2 min-h-[44px] text-sm font-medium text-slate-700 hover:bg-slate-100 active:scale-95"
           onClick={() => {
             setRunning(false)
             setSeconds(0)

--- a/apps/web/src/features/learning/previews/EventPreview.tsx
+++ b/apps/web/src/features/learning/previews/EventPreview.tsx
@@ -9,15 +9,17 @@ export default function EventPreview() {
       <p className="text-sm text-slate-700">{message}</p>
       <div className="flex gap-2">
         <button
-          className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 active:scale-95"
+          className="rounded-lg bg-blue-600 px-4 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-blue-700 active:scale-95"
           onClick={() => setMessage('クリックされました！')}
         >
           Click
         </button>
         <button
-          className={`rounded-lg px-4 py-2 text-sm font-medium text-white transition-colors ${hovered ? 'bg-purple-600' : 'bg-slate-500'}`}
+          className={`rounded-lg px-4 py-2 min-h-[44px] text-sm font-medium text-white transition-colors ${hovered ? 'bg-purple-600' : 'bg-slate-500'}`}
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}
+          onTouchStart={() => setHovered(true)}
+          onTouchEnd={() => setHovered(false)}
         >
           Hover me
         </button>

--- a/apps/web/src/features/learning/previews/FormPreview.tsx
+++ b/apps/web/src/features/learning/previews/FormPreview.tsx
@@ -18,7 +18,7 @@ export default function FormPreview() {
         <p className="text-sm font-medium text-emerald-700">送信完了！</p>
         <p className="text-xs text-slate-600">名前: {name} / メール: {email}</p>
         <button
-          className="rounded-lg border border-slate-300 px-3 py-1 text-sm text-slate-700 hover:bg-slate-100"
+          className="rounded-lg border border-slate-300 px-3 py-2 min-h-[44px] text-sm text-slate-700 hover:bg-slate-100"
           onClick={() => {
             setName('')
             setEmail('')
@@ -37,7 +37,7 @@ export default function FormPreview() {
         <label className="block text-xs font-medium text-slate-600">
           名前
           <input
-            className="mt-1 w-full rounded border border-slate-300 px-2 py-1 text-sm"
+            className="mt-1 w-full rounded border border-slate-300 px-3 py-2 min-h-[44px] text-sm"
             value={name}
             onChange={(e) => setName(e.target.value)}
           />
@@ -47,7 +47,7 @@ export default function FormPreview() {
         <label className="block text-xs font-medium text-slate-600">
           メール
           <input
-            className="mt-1 w-full rounded border border-slate-300 px-2 py-1 text-sm"
+            className="mt-1 w-full rounded border border-slate-300 px-3 py-2 min-h-[44px] text-sm"
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
@@ -57,7 +57,7 @@ export default function FormPreview() {
       <button
         type="submit"
         disabled={!isValid}
-        className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
+        className="rounded-lg bg-emerald-600 px-4 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
       >
         送信
       </button>

--- a/apps/web/src/features/learning/previews/ListPreview.tsx
+++ b/apps/web/src/features/learning/previews/ListPreview.tsx
@@ -22,7 +22,7 @@ export default function ListPreview() {
             <span className="text-emerald-500">•</span>
             {fruit}
             <button
-              className="text-xs text-rose-400 hover:text-rose-600"
+              className="min-h-[44px] px-2 py-1 text-xs text-rose-400 hover:text-rose-600"
               onClick={() => setFruits((prev) => prev.filter((_, j) => j !== i))}
             >
               削除
@@ -32,14 +32,14 @@ export default function ListPreview() {
       </ul>
       <div className="flex gap-2">
         <input
-          className="rounded border border-slate-300 px-2 py-1 text-sm"
+          className="rounded border border-slate-300 px-3 py-2 min-h-[44px] text-sm"
           placeholder="フルーツ名"
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && handleAdd()}
         />
         <button
-          className="rounded-lg bg-emerald-600 px-3 py-1 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95"
+          className="rounded-lg bg-emerald-600 px-3 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-emerald-700 active:scale-95"
           onClick={handleAdd}
         >
           追加

--- a/apps/web/src/features/learning/previews/PerformancePreview.tsx
+++ b/apps/web/src/features/learning/previews/PerformancePreview.tsx
@@ -19,13 +19,13 @@ export default function PerformancePreview() {
       </div>
       <div className="flex gap-2">
         <button
-          className="rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95"
+          className="rounded-lg bg-emerald-600 px-3 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-emerald-700 active:scale-95"
           onClick={() => setCount((c) => c + 10)}
         >
           計算量を増やす ({count})
         </button>
         <button
-          className="rounded-lg bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700 active:scale-95"
+          className="rounded-lg bg-indigo-600 px-3 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-indigo-700 active:scale-95"
           onClick={() => setColor((c) => (c === 'emerald' ? 'blue' : 'emerald'))}
         >
           色を切替

--- a/apps/web/src/features/learning/previews/ReducerPreview.tsx
+++ b/apps/web/src/features/learning/previews/ReducerPreview.tsx
@@ -22,19 +22,19 @@ export default function ReducerPreview() {
       <p className="text-2xl font-bold text-slate-800">{state.count}</p>
       <div className="flex gap-2">
         <button
-          className="rounded-lg bg-emerald-600 px-3 py-2 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95"
+          className="rounded-lg bg-emerald-600 px-3 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-emerald-700 active:scale-95"
           onClick={() => dispatch({ type: 'increment' })}
         >
           +1
         </button>
         <button
-          className="rounded-lg bg-slate-600 px-3 py-2 text-sm font-medium text-white hover:bg-slate-700 active:scale-95"
+          className="rounded-lg bg-slate-600 px-3 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-slate-700 active:scale-95"
           onClick={() => dispatch({ type: 'decrement' })}
         >
           -1
         </button>
         <button
-          className="rounded-lg border border-slate-300 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 active:scale-95"
+          className="rounded-lg border border-slate-300 px-3 py-2 min-h-[44px] text-sm font-medium text-slate-700 hover:bg-slate-100 active:scale-95"
           onClick={() => dispatch({ type: 'reset' })}
         >
           リセット

--- a/apps/web/src/features/learning/previews/TestingPreview.tsx
+++ b/apps/web/src/features/learning/previews/TestingPreview.tsx
@@ -26,7 +26,7 @@ export default function TestingPreview() {
       </div>
       <div className="flex items-center gap-3">
         <button
-          className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 active:scale-95 disabled:opacity-50"
+          className="rounded-lg bg-emerald-600 px-4 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-emerald-700 active:scale-95 disabled:opacity-50"
           onClick={runTests}
           disabled={running}
         >


### PR DESCRIPTION
## Summary
- learning/previews/ 配下 19 ファイルの全ボタン・入力に `min-h-[44px]` を追加（WCAG タップターゲット 44px 確保）
- `py-1` / `py-0.5` のボタンは `py-2` に拡大
- EventPreview に `onTouchStart` / `onTouchEnd` ハンドラー追加（タッチデバイス対応）
- ApiErrorLoadingPreview の表示エリア `min-h-[48px]` を `min-h-[44px]` に統一
- FormPreview / ListPreview の入力フィールドも同様に 44px 化

## Test plan
- [x] CI 全通過（typecheck / lint / 696 tests / build）
- [ ] Playwright 目視確認（M4 で実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)