### PR TITLE
feat: ページ余白レスポンシブ化（v3.2 M3）

### DIFF
--- a/apps/web/src/features/base-nook/components/QuizView.tsx
+++ b/apps/web/src/features/base-nook/components/QuizView.tsx
@@ -57,7 +57,7 @@ export function QuizView({ questions, solvedIds, onAnswer, onRefresh, allCleared
   return (
     <div className="space-y-6">
       {/* セクション見出し */}
-      <div className="rounded-xl bg-sky-50 px-5 py-4">
+      <div className="rounded-xl bg-sky-50 px-3 py-3 sm:px-5 sm:py-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <ClipboardCheck size={20} className="text-sky-600" aria-hidden="true" />

--- a/apps/web/src/pages/BaseNookPage.tsx
+++ b/apps/web/src/pages/BaseNookPage.tsx
@@ -69,10 +69,10 @@ export function BaseNookPage() {
     <div className="min-h-screen bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50">
       <AppHeader displayName={greetingName} onSignOut={() => void handleSignOut()} />
 
-      <main className="mx-auto max-w-5xl px-4 py-8">
+      <main className="mx-auto max-w-5xl px-3 py-6 sm:px-4 sm:py-8">
         {/* ヘッダー */}
         <div className="mb-8 flex items-center gap-3">
-          <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-sky-100 text-sky-600">
+          <div className="flex h-10 w-10 items-center justify-center rounded-2xl bg-sky-100 text-sky-600 sm:h-12 sm:w-12">
             <BookOpen size={24} aria-hidden="true" />
           </div>
           <div>
@@ -96,7 +96,7 @@ export function BaseNookPage() {
             <div className="h-8 w-8 animate-spin rounded-full border-4 border-sky-200 border-t-sky-500" />
           </div>
         ) : (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <div className="grid grid-cols-1 gap-3 sm:gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {BASE_NOOK_TOPICS.map((topic) => (
               <TopicCard
                 key={topic.id}

--- a/apps/web/src/pages/BaseNookTopicPage.tsx
+++ b/apps/web/src/pages/BaseNookTopicPage.tsx
@@ -114,7 +114,7 @@ export function BaseNookTopicPage() {
         {/* 戻るリンク */}
         <Link
           to="/base-nook"
-          className="mb-6 inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 hover:text-sky-600"
+          className="mb-6 inline-flex min-h-[44px] items-center gap-1.5 text-sm font-medium text-slate-500 hover:text-sky-600"
         >
           <ArrowLeft size={16} aria-hidden="true" />
           Base Nook に戻る
@@ -141,7 +141,7 @@ export function BaseNookTopicPage() {
         ) : (
           <>
             {/* 解説パート */}
-            <section className="mb-10 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+            <section className="mb-10 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6 lg:p-8">
               <ArticleView markdown={topic.article} />
             </section>
 


### PR DESCRIPTION
## Summary
- BaseNookPage: メインコンテナ余白をレスポンシブ化（`px-3 py-6 sm:px-4 sm:py-8`）、ヘッダーアイコンを `h-10 w-10 sm:h-12 sm:w-12` に、グリッド gap を `gap-3 sm:gap-4` に段階化
- BaseNookTopicPage: 戻るリンクに `min-h-[44px]` タップターゲット追加、解説セクション余白を `p-4 sm:p-6 lg:p-8` に段階化
- QuizView: 見出しセクション余白を `px-3 py-3 sm:px-5 sm:py-4` にレスポンシブ化

## Test plan
- [x] `npm run typecheck` PASS
- [x] `npm run lint` PASS
- [x] `npm run test` PASS (696 tests)
- [x] `npm run build` PASS
- [ ] Playwright 検証は M4 で実施

🤖 Generated with [Claude Code](https://claude.com/claude-code)