### PR TITLE
feat: PracticeModeNav セグメンテッドコントロール化（v3.3 M1）

### DIFF
--- a/apps/web/src/features/daily/components/PracticeModeNav.tsx
+++ b/apps/web/src/features/daily/components/PracticeModeNav.tsx
@@ -42,8 +42,8 @@ export function PracticeModeNav() {
         </ul>
       </nav>
 
-      {/* モバイル: 折り返しピルナビ */}
-      <nav className="mb-2 flex flex-wrap gap-2 lg:hidden" aria-label="練習モード">
+      {/* モバイル: セグメンテッドコントロール */}
+      <nav className="mb-2 flex rounded-lg border border-slate-200 bg-white p-0.5 lg:hidden" aria-label="練習モード">
         {NAV_ITEMS.map(({ path, label, icon: Icon }) => {
           const isActive = pathname === path || pathname.startsWith(path + '/')
           return (
@@ -51,14 +51,14 @@ export function PracticeModeNav() {
               key={path}
               to={path}
               className={[
-                'flex flex-1 items-center justify-center gap-1.5 rounded-full px-3.5 py-2.5 min-h-[44px] text-sm font-medium transition-colors',
+                'flex flex-1 items-center justify-center gap-1 rounded-md px-1 py-2 text-xs font-medium transition-colors',
                 isActive
-                  ? 'bg-amber-500 text-white'
-                  : 'border border-slate-200 bg-white text-text-muted hover:border-amber-400 hover:text-amber-600',
+                  ? 'bg-amber-500 text-white shadow-sm'
+                  : 'text-text-muted hover:text-amber-600',
               ].join(' ')}
               aria-current={isActive ? 'page' : undefined}
             >
-              <Icon size={14} />
+              <Icon size={13} aria-hidden="true" />
               {label}
             </Link>
           )


### PR DESCRIPTION
## Summary
- モバイルの PracticeModeNav をピルボタン群からセグメンテッドコントロールに変更
- 外枠コンテナ (`rounded-lg border p-0.5`) + 内部セグメント (`flex-1 rounded-md text-xs`) で折り返し解消
- アイコンに `aria-hidden="true"` 追加、デスクトップサイドバーは変更なし

## Test plan
- [x] typecheck / lint / test (696件) / build 全通過
- [ ] Playwright で 375px/390px のスクリーンショット検証（M5 で実施）

🤖 Generated with [Claude Code](https://claude.ai/code)