### PR TITLE
feat: WeeklyStatus サークル縮小（v3.3 M2）

### DIFF
--- a/apps/web/src/features/daily/components/WeeklyStatus.tsx
+++ b/apps/web/src/features/daily/components/WeeklyStatus.tsx
@@ -26,7 +26,7 @@ export function WeeklyStatus({ entries, todayStr }: WeeklyStatusProps) {
               <span className="text-xs font-medium text-slate-400">{DAY_LABELS[i]}</span>
               <div
                 className={[
-                  'flex h-10 w-10 items-center justify-center rounded-full text-xs font-bold transition-colors sm:h-11 sm:w-11',
+                  'flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold transition-colors sm:h-10 sm:w-10',
                   entry.completed
                     ? 'bg-amber-400 text-white shadow-sm shadow-amber-200'
                     : isToday


### PR DESCRIPTION
## Summary
- WeeklyStatus の7日サークルを `h-10 w-10` → `h-8 w-8`、`sm:h-11 sm:w-11` → `sm:h-10 sm:w-10` に縮小
- 375px/390px モバイルでの枠溢れを防止（7×32+6×6=260px ≤ 319px）
- CI 全通過（696 テスト PASS）

## Test plan
- [x] `npm run typecheck` PASS
- [x] `npm run lint` PASS
- [x] `npm run test` PASS（696件）
- [x] `npm run build` PASS
- [ ] M5 で Playwright 375px/390px スクリーンショット検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)