### PR TITLE
fix: 残存モバイル課題修正（タップターゲット + hover-only）

### DIFF
--- a/apps/web/src/components/CodeEditor/CodeToolbar.tsx
+++ b/apps/web/src/components/CodeEditor/CodeToolbar.tsx
@@ -65,7 +65,7 @@ export function CodeToolbar({ keywords, onInsert }: CodeToolbarProps) {
               key={kw}
               type="button"
               aria-label={`${kw} を挿入`}
-              className="rounded-lg bg-slate-700 px-3 py-2 font-mono text-sm text-slate-200 active:bg-slate-600"
+              className="min-h-[44px] rounded-lg bg-slate-700 px-3 py-2 font-mono text-sm text-slate-200 active:bg-slate-600"
               onPointerDown={(e) => {
                 e.preventDefault()
                 onInsert(kw)

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -44,7 +44,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
             {this.state.error?.message || 'アプリケーションの一部でエラーが発生しました。'}
           </p>
           <button
-            className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-400/50"
+            className="min-h-[44px] rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-400/50"
             type="button"
             onClick={this.handleRetry}
           >

--- a/apps/web/src/components/LearningSidebar.tsx
+++ b/apps/web/src/components/LearningSidebar.tsx
@@ -71,7 +71,7 @@ function CourseSection({
     <div>
       <button
         type="button"
-        className={`flex w-full items-center justify-between rounded-lg px-2 py-1.5 text-xs font-semibold transition ${
+        className={`flex w-full min-h-[44px] items-center justify-between rounded-lg px-2 py-1.5 text-xs font-semibold transition ${
           containsCurrent ? 'text-primary-dark' : 'text-slate-600 hover:bg-slate-50'
         } ${lockStatus.locked ? 'opacity-50' : ''}`}
         onClick={() => !lockStatus.locked && setIsOpen((prev) => !prev)}
@@ -96,7 +96,7 @@ function CourseSection({
             return (
               <li key={step.id}>
                 <Link
-                  className={`flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition ${
+                  className={`flex min-h-[44px] items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition ${
                     isCurrent
                       ? 'border border-primary-mint/30 bg-secondary-bg text-primary-dark'
                       : 'text-slate-600 hover:bg-slate-50'

--- a/apps/web/src/features/api-practice/components/ErrorView.tsx
+++ b/apps/web/src/features/api-practice/components/ErrorView.tsx
@@ -14,7 +14,7 @@ export function ErrorView({ message, onRetry }: ErrorViewProps) {
       <p className="text-sm font-medium text-rose-700">{message}</p>
       {onRetry ? (
         <button
-          className="mt-2 text-xs font-medium text-rose-600 underline hover:text-rose-800"
+          className="mt-2 min-h-[44px] text-xs font-medium text-rose-600 underline hover:text-rose-800"
           type="button"
           onClick={onRetry}
         >

--- a/apps/web/src/features/base-nook/components/TopicCard.tsx
+++ b/apps/web/src/features/base-nook/components/TopicCard.tsx
@@ -58,7 +58,7 @@ export function TopicCard({ topic, progress, onClick }: TopicCardProps) {
         </div>
         <div className="flex items-center justify-between text-xs text-slate-400">
           <span>{earnedPt > 0 ? `${earnedPt} pt` : '--'}</span>
-          <span className="flex items-center gap-0.5 font-medium text-amber-600 opacity-0 transition-opacity group-hover:opacity-100">
+          <span className="flex items-center gap-0.5 font-medium text-amber-600 opacity-0 transition-opacity group-hover:opacity-100 group-active:opacity-100">
             学ぶ <ChevronRight size={14} aria-hidden="true" />
           </span>
         </div>

--- a/apps/web/src/features/code-doctor/components/ProblemCard.tsx
+++ b/apps/web/src/features/code-doctor/components/ProblemCard.tsx
@@ -53,7 +53,7 @@ export function ProblemCard({ problem, progress, onClick }: ProblemCardProps) {
       <p className="line-clamp-2 text-sm leading-relaxed text-slate-500">{problem.description}</p>
 
       <div className="mt-auto pt-3">
-        <span className="text-xs font-medium text-amber-600 opacity-0 transition-opacity group-hover:opacity-100">
+        <span className="text-xs font-medium text-amber-600 opacity-0 transition-opacity group-hover:opacity-100 group-active:opacity-100">
           問題を解く →
         </span>
       </div>

--- a/apps/web/src/features/code-reading/components/ReadingCard.tsx
+++ b/apps/web/src/features/code-reading/components/ReadingCard.tsx
@@ -57,7 +57,7 @@ export function ReadingCard({ problem, progress, onClick }: ReadingCardProps) {
         <span className="rounded-md border border-slate-100 bg-slate-50 px-2 py-0.5 text-xs text-slate-500">
           設問 {totalCount}問
         </span>
-        <span className="text-xs font-medium text-amber-600 opacity-0 transition-opacity group-hover:opacity-100">
+        <span className="text-xs font-medium text-amber-600 opacity-0 transition-opacity group-hover:opacity-100 group-active:opacity-100">
           挑戦する →
         </span>
       </div>


### PR DESCRIPTION
## Summary
- CodeToolbar / LearningSidebar / ErrorBoundary / ErrorView のボタン・リンクに `min-h-[44px]` 追加
- ProblemCard / ReadingCard / TopicCard の hover-only テキストに `group-active:opacity-100` 追加（モバイルタップ時も表示）

## Test plan
- [x] typecheck PASS
- [x] lint PASS
- [x] test 696件 PASS
- [x] build PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)