### PR TITLE
fix: v3.5 監査リグレッション全29項目修正

### DIFF
--- a/apps/web/src/features/daily/components/DailyChallengeCard.tsx
+++ b/apps/web/src/features/daily/components/DailyChallengeCard.tsx
@@ -27,7 +27,7 @@ export function DailyChallengeCard({ question, dateStr, onSubmit }: DailyChallen
   const formattedDate = dateStr.replace(/-/g, '/')
 
   return (
-    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+    <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6">
       <div className="mb-5 flex items-center justify-between">
         <span className="text-sm font-medium text-slate-500">{formattedDate}</span>
         <span className="rounded-full border border-amber-200 bg-amber-50 px-3 py-0.5 text-xs font-semibold text-amber-700">
@@ -50,7 +50,11 @@ export function DailyChallengeCard({ question, dateStr, onSubmit }: DailyChallen
                 if (e.key === 'Enter') void handleSubmit()
               }}
               placeholder="答えを入力..."
-              className="mb-4 w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm text-text-dark placeholder-slate-400 transition-colors focus:border-amber-400 focus:bg-white focus:outline-none focus:ring-1 focus:ring-amber-400"
+              autoComplete="off"
+              autoCorrect="off"
+              spellCheck={false}
+              autoCapitalize="off"
+              className="mb-4 min-h-[44px] w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm text-text-dark placeholder-slate-400 transition-colors focus:border-amber-400 focus:bg-white focus:outline-none focus:ring-1 focus:ring-amber-400"
             />
           ) : (
             <div className="mb-4 space-y-2" role="radiogroup" aria-label="選択肢">
@@ -58,7 +62,7 @@ export function DailyChallengeCard({ question, dateStr, onSubmit }: DailyChallen
                 <label
                   key={choice}
                   className={[
-                    'flex cursor-pointer items-center gap-3 rounded-xl border px-4 py-3 text-sm transition-all',
+                    'flex min-h-[44px] cursor-pointer items-center gap-3 rounded-xl border px-4 py-3 text-sm transition-all',
                     answer === choice
                       ? 'border-amber-400 bg-amber-50 text-amber-700 shadow-sm'
                       : 'border-slate-200 bg-white text-text-dark hover:border-amber-200 hover:bg-amber-50/30',
@@ -82,13 +86,13 @@ export function DailyChallengeCard({ question, dateStr, onSubmit }: DailyChallen
             <button
               onClick={() => void handleSubmit()}
               disabled={!answer.trim() || isSubmitting}
-              className="rounded-lg bg-amber-500 px-5 py-2 text-sm font-semibold text-white transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-50"
+              className="min-h-[44px] rounded-lg bg-amber-500 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-amber-600 disabled:cursor-not-allowed disabled:opacity-50"
             >
               {isSubmitting ? '判定中...' : '判定する'}
             </button>
             <button
               onClick={() => setShowHint((v) => !v)}
-              className="text-sm text-slate-500 transition-colors hover:text-amber-600"
+              className="min-h-[44px] px-2 text-sm text-slate-500 transition-colors hover:text-amber-600"
             >
               {showHint ? 'ヒントを隠す' : 'ヒントを見る'}
             </button>

--- a/apps/web/src/features/dashboard/components/AppHeader.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeader.tsx
@@ -122,7 +122,7 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
             <span className="font-display text-2xl font-bold tracking-tight text-primary-mint">Coden</span>
           </Link>
 
-          <nav className="hidden items-center gap-5 text-sm font-medium lg:flex" aria-label="メインナビゲーション">
+          <nav className="hidden items-center gap-5 text-sm font-medium md:flex" aria-label="メインナビゲーション">
             <Link
               to="/"
               className={navLinkClass(location.pathname === '/')}
@@ -205,7 +205,7 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
           </div>
           <div className="hidden text-sm font-medium text-slate-600 sm:block">{displayName}</div>
           <button
-            className="hidden rounded-lg border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 lg:block"
+            className="hidden rounded-lg border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 md:block"
             type="button"
             onClick={onSignOut}
           >
@@ -215,7 +215,7 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
           {/* モバイル: ハンバーガーボタン */}
           <button
             ref={menuButtonRef}
-            className="rounded-lg p-2 text-slate-600 transition hover:bg-slate-100 lg:hidden"
+            className="rounded-lg p-2 text-slate-600 transition hover:bg-slate-100 md:hidden"
             type="button"
             onClick={() => setIsDrawerOpen(true)}
             aria-label="メニューを開く"
@@ -232,7 +232,7 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
         ref={drawerRef}
         role="dialog"
         aria-modal="true"
-        className="fixed inset-0 z-50 flex flex-col bg-white lg:hidden"
+        className="fixed inset-0 z-50 flex flex-col bg-white md:hidden"
         aria-label="モバイルナビゲーション"
       >
         {/* ヘッダー */}

--- a/apps/web/src/features/learning/TestMode.tsx
+++ b/apps/web/src/features/learning/TestMode.tsx
@@ -1,11 +1,14 @@
-import { Fragment, Suspense, useMemo, useState } from 'react'
+import { Fragment, Suspense, useCallback, useMemo, useState } from 'react'
 import { Button } from '../../components/Button'
 import { ErrorBoundary } from '../../components/ErrorBoundary'
+import { useIsMobile } from '../../hooks/useIsMobile'
 import type { TestTask } from '../../content/fundamentals/steps'
+import { CodePuzzle } from './CodePuzzle/CodePuzzle'
 import { JudgmentResult } from './components/JudgmentResult'
 import { useJudgmentAction } from './hooks/useJudgmentAction'
 import { useStepReset } from './hooks/useStepReset'
 import { previewByStepId } from './testModePreview'
+import { checkAllKeywords } from './utils/keywordMatcher'
 import { previewComponentByStepId } from './previews'
 
 interface TestModeProps {
@@ -15,6 +18,7 @@ interface TestModeProps {
 }
 
 export function TestMode({ stepId, task, onComplete }: TestModeProps) {
+  const isMobile = useIsMobile()
   const [blankInput, setBlankInput] = useState('')
   const [isJudged, setIsJudged] = useState(false)
   const { handleResult } = useJudgmentAction(stepId, onComplete)
@@ -26,9 +30,7 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
 
   const mergedCode = useMemo(() => task.starterCode.replace('____', blankInput), [blankInput, task.starterCode])
   const isPassed = useMemo(
-    () =>
-      blankInput.length > 0 &&
-      task.expectedKeywords.every((keyword) => mergedCode.toLowerCase().includes(keyword.toLowerCase())),
+    () => blankInput.length > 0 && checkAllKeywords(mergedCode, task.expectedKeywords),
     [blankInput, mergedCode, task.expectedKeywords],
   )
 
@@ -42,6 +44,15 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
     setBlankInput(value)
   }
 
+  const handlePuzzleSubmit = useCallback(
+    (mergedCode: string) => {
+      const isCorrect = checkAllKeywords(mergedCode, task.expectedKeywords)
+      setIsJudged(true)
+      handleResult(isCorrect)
+    },
+    [task.expectedKeywords, handleResult],
+  )
+
   const parts = task.starterCode.split('____')
 
   const preview = previewByStepId[stepId]
@@ -49,51 +60,60 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
   return (
     <section className="mt-4 space-y-4">
       <h2 className="text-lg font-semibold">Test</h2>
-      <p className="text-sm text-slate-700">{task.instruction}</p>
 
-      <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-lg border border-slate-300 bg-slate-900 p-4 font-mono text-sm leading-relaxed text-slate-100">
-        {parts.map((part, index) => (
-          <Fragment key={index}>
-            {part}
-            {index < parts.length - 1 && (
-              <input
-                className={`mx-1 inline-block w-full max-w-xs min-h-[44px] rounded bg-slate-800 px-2 py-0.5 text-emerald-300 outline-none ring-1 placeholder:text-slate-500 focus:ring-2 sm:w-64 ${isJudged
-                  ? isPassed
-                    ? 'ring-emerald-500 focus:ring-emerald-400'
-                    : 'ring-rose-500 focus:ring-rose-400'
-                  : 'ring-slate-500 focus:ring-primary-mint'
-                  }`}
-                placeholder="コードを入力"
-                aria-label="コードの空欄を入力"
-                value={blankInput}
-                onChange={(event) => handleInputChange(event.target.value)}
+      {isMobile ? (
+        <ErrorBoundary fallback={<p className="text-sm text-red-600">パズルの表示中にエラーが発生しました。</p>}>
+          <CodePuzzle task={task} onSubmit={handlePuzzleSubmit} />
+        </ErrorBoundary>
+      ) : (
+        <>
+          <p className="text-sm text-slate-700">{task.instruction}</p>
+
+          <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-lg border border-slate-300 bg-slate-900 p-4 font-mono text-sm leading-relaxed text-slate-100">
+            {parts.map((part, index) => (
+              <Fragment key={index}>
+                {part}
+                {index < parts.length - 1 && (
+                  <input
+                    className={`mx-1 inline-block w-full max-w-xs rounded bg-slate-800 px-2 py-0.5 text-emerald-300 outline-none ring-1 placeholder:text-slate-500 focus:ring-2 sm:w-64 ${isJudged
+                      ? isPassed
+                        ? 'ring-emerald-500 focus:ring-emerald-400'
+                        : 'ring-rose-500 focus:ring-rose-400'
+                      : 'ring-slate-500 focus:ring-primary-mint'
+                      }`}
+                    placeholder="コードを入力"
+                    aria-label="コードの空欄を入力"
+                    value={blankInput}
+                    onChange={(event) => handleInputChange(event.target.value)}
+                  />
+                )}
+              </Fragment>
+            ))}
+          </pre>
+
+          <div className="flex flex-col items-start gap-4 pt-4 sm:flex-row sm:items-center">
+            <Button size="lg" onClick={handleJudge}>
+              判定する
+            </Button>
+
+            {isJudged && (
+              <JudgmentResult
+                isPassed={isPassed}
+                passedMessage="テスト合格！ ライブプレビューが解禁されました。"
+                failedMessage="必要キーワードを満たしていません。"
+                failedHint="コードを見直して、もう一度試してください。"
               />
             )}
-          </Fragment>
-        ))}
-      </pre>
+          </div>
 
-      <div className="flex flex-col items-start gap-4 pt-4 sm:flex-row sm:items-center">
-        <Button size="lg" onClick={handleJudge}>
-          判定する
-        </Button>
-
-        {isJudged && (
-          <JudgmentResult
-            isPassed={isPassed}
-            passedMessage="テスト合格！ ライブプレビューが解禁されました。"
-            failedMessage="必要キーワードを満たしていません。"
-            failedHint="コードを見直して、もう一度試してください。"
-          />
-        )}
-      </div>
-
-      {isJudged && !isPassed && task.explanation ? (
-        <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2">
-          <p className="text-xs font-semibold text-amber-700">解説</p>
-          <p className="mt-0.5 text-sm text-amber-900">{task.explanation}</p>
-        </div>
-      ) : null}
+          {isJudged && !isPassed && task.explanation ? (
+            <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2">
+              <p className="text-xs font-semibold text-amber-700">解説</p>
+              <p className="mt-0.5 text-sm text-amber-900">{task.explanation}</p>
+            </div>
+          ) : null}
+        </>
+      )}
 
       {isJudged && isPassed && preview ? (
         <div className="mt-4 rounded-lg border border-emerald-300 bg-emerald-50 p-4">

--- a/apps/web/src/features/learning/previews/FormPreview.tsx
+++ b/apps/web/src/features/learning/previews/FormPreview.tsx
@@ -18,7 +18,7 @@ export default function FormPreview() {
         <p className="text-sm font-medium text-emerald-700">送信完了！</p>
         <p className="text-xs text-slate-600">名前: {name} / メール: {email}</p>
         <button
-          className="rounded-lg border border-slate-300 px-3 py-1 text-sm text-slate-700 hover:bg-slate-100"
+          className="rounded-lg border border-slate-300 px-3 py-2 min-h-[44px] text-sm text-slate-700 hover:bg-slate-100"
           onClick={() => {
             setName('')
             setEmail('')
@@ -37,7 +37,7 @@ export default function FormPreview() {
         <label className="block text-xs font-medium text-slate-600">
           名前
           <input
-            className="mt-1 w-full rounded border border-slate-300 px-2 py-1 text-sm"
+            className="mt-1 w-full rounded border border-slate-300 px-3 py-2 min-h-[44px] text-sm"
             value={name}
             onChange={(e) => setName(e.target.value)}
           />
@@ -47,7 +47,7 @@ export default function FormPreview() {
         <label className="block text-xs font-medium text-slate-600">
           メール
           <input
-            className="mt-1 w-full rounded border border-slate-300 px-2 py-1 text-sm"
+            className="mt-1 w-full rounded border border-slate-300 px-3 py-2 min-h-[44px] text-sm"
             type="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
@@ -57,7 +57,7 @@ export default function FormPreview() {
       <button
         type="submit"
         disabled={!isValid}
-        className="rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
+        className="rounded-lg bg-emerald-600 px-4 py-2 min-h-[44px] text-sm font-medium text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-50"
       >
         送信
       </button>

--- a/apps/web/src/pages/BaseNookTopicPage.tsx
+++ b/apps/web/src/pages/BaseNookTopicPage.tsx
@@ -97,11 +97,11 @@ export function BaseNookTopicPage() {
     <div className="min-h-screen bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50">
       <AppHeader displayName={greetingName} onSignOut={() => void handleSignOut()} />
 
-      <main className="mx-auto max-w-4xl px-4 py-8">
+      <main className="mx-auto max-w-4xl px-3 py-6 sm:px-4 sm:py-8">
         {/* 戻るリンク */}
         <Link
           to="/base-nook"
-          className="mb-6 inline-flex items-center gap-1.5 text-sm font-medium text-slate-500 hover:text-sky-600"
+          className="mb-6 inline-flex min-h-[44px] items-center gap-1.5 text-sm font-medium text-slate-500 hover:text-sky-600"
         >
           <ArrowLeft size={16} aria-hidden="true" />
           Base Nook に戻る
@@ -128,7 +128,7 @@ export function BaseNookTopicPage() {
         ) : (
           <>
             {/* 解説パート */}
-            <section className="mb-10 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-8">
+            <section className="mb-10 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6 lg:p-8">
               <ArticleView markdown={topic.article} />
             </section>
 

--- a/apps/web/src/pages/CurriculumPage.tsx
+++ b/apps/web/src/pages/CurriculumPage.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { ChevronDown, Code2 } from 'lucide-react'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useGreetingName } from '../hooks/useGreetingName'
 import { useSignOut } from '../hooks/useSignOut'
+import { ErrorBanner } from '../components/ErrorBanner'
 import { CATEGORIES, type CategoryMeta, type CourseMeta } from '../content/courseData'
 import { useLearningContext } from '../contexts/LearningContext'
 import { AppHeader } from '../features/dashboard/components/AppHeader'
@@ -14,7 +15,9 @@ export function CurriculumPage() {
   useDocumentTitle('カリキュラム')
   const { completedStepIds, isLoadingStats } = useLearningContext()
   const { greetingName } = useGreetingName()
-  const handleSignOut = useSignOut()
+  const [error, setError] = useState<string | null>(null)
+  const onSignOutError = useCallback((msg: string) => setError(msg), [])
+  const handleSignOut = useSignOut(onSignOutError)
 
   // ハッシュからスクロール
   useEffect(() => {
@@ -29,6 +32,7 @@ export function CurriculumPage() {
       <AppHeader displayName={greetingName} onSignOut={() => void handleSignOut()} />
 
       <main className="mx-auto w-full max-w-screen-xl px-4 py-8 sm:px-6 lg:px-8">
+        {error ? <ErrorBanner className="mb-4">{error}</ErrorBanner> : null}
         <h1 className="text-2xl font-bold text-slate-900">カリキュラム</h1>
         <p className="mt-1 text-sm text-slate-500">カテゴリ・コース・ステップを一覧して学習を始めましょう</p>
 
@@ -45,7 +49,7 @@ export function CurriculumPage() {
         </div>
 
         {/* 練習モードセクション */}
-        <section id="practice" className="mt-12">
+        <section id="practice" className="mt-6 border-t border-slate-200 pt-6">
           <h2 className="text-xl font-bold text-slate-900">練習モード</h2>
           <p className="mt-1 text-sm text-slate-500">繰り返し学習で知識を定着させましょう</p>
 
@@ -85,7 +89,7 @@ function CategorySection({
 
   return (
     <section id={category.id}>
-      <div className="flex items-center gap-3">
+      <div className="flex items-center gap-3 border-l-4 border-emerald-400 pl-3">
         <div className="rounded-lg bg-primary-mint/10 p-2">
           <IconComponent className="h-5 w-5 text-primary-dark" aria-hidden="true" />
         </div>
@@ -145,7 +149,7 @@ function CourseAccordion({
     <div className={`rounded-xl border bg-white shadow-sm ${lockStatus.locked ? 'border-slate-200 opacity-60' : 'border-slate-200'}`}>
       <button
         type="button"
-        className="flex w-full items-center justify-between px-5 py-4 text-left"
+        className="flex w-full items-center justify-between px-4 py-3 text-left sm:px-5 sm:py-4"
         onClick={() => !lockStatus.locked && setIsOpen((prev) => !prev)}
         disabled={lockStatus.locked}
         aria-expanded={isOpen}
@@ -180,7 +184,7 @@ function CourseAccordion({
       </button>
 
       {isOpen && !lockStatus.locked && hasSteps && (
-        <div className="border-t border-slate-100 px-5 py-3">
+        <div className="border-t border-slate-100 px-4 py-3 sm:px-5">
           {!lockStatus.locked && lockStatus.warning && (
             <p className="mb-3 rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-700">
               {lockStatus.warning}
@@ -193,7 +197,7 @@ function CourseAccordion({
                 <li key={step.id}>
                   <Link
                     to={`/step/${step.id}`}
-                    className="flex items-center gap-3 rounded-lg px-3 py-2 text-sm transition hover:bg-slate-50"
+                    className="flex min-h-[44px] items-center gap-3 rounded-lg px-3 py-2 text-sm transition hover:bg-slate-50"
                   >
                     <span className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs font-bold ${done ? 'bg-emerald-500 text-white' : 'border border-slate-300 text-slate-400'}`}>
                       {done ? '✓' : step.order}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -94,7 +94,7 @@ export function DashboardPage() {
             {/* スキルアップセクション */}
             <div className="space-y-4">
               <h2 className="text-lg font-bold text-slate-900">スキルアップ</h2>
-              <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              <div className="grid grid-cols-2 gap-2 sm:gap-3 lg:grid-cols-3">
                 {PRACTICE_MODE_CARDS.filter((c) => c.to !== '/daily').map((card) => (
                   <Link
                     key={card.to}
@@ -107,7 +107,7 @@ export function DashboardPage() {
                     <h3 className="mt-2 text-sm font-bold text-slate-900 group-hover:text-primary-dark">
                       {card.title}
                     </h3>
-                    <p className="mt-0.5 text-xs text-slate-500">{card.description}</p>
+                    <p className="mt-0.5 hidden text-xs text-slate-500 sm:block">{card.description}</p>
                   </Link>
                 ))}
               </div>
@@ -162,7 +162,7 @@ function CategoryCard({
             </span>
             <span className="text-slate-400" aria-live="polite">{progressPercent}%</span>
           </div>
-          <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-slate-100">
+          <div className="mt-1 h-2 w-full overflow-hidden rounded-full bg-slate-100 sm:h-1.5">
             <div
               className="h-full rounded-full bg-primary-mint transition-all duration-500"
               style={{ width: `${progressPercent}%` }}

--- a/apps/web/src/pages/ProfilePage.tsx
+++ b/apps/web/src/pages/ProfilePage.tsx
@@ -30,6 +30,7 @@ export function ProfilePage() {
   const [isSavingDisplayName, setIsSavingDisplayName] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [notice, setNotice] = useState<string | null>(null)
+  const [showUnearned, setShowUnearned] = useState(false)
 
   // displayName が取得されたら入力フィールドを同期
   useEffect(() => {
@@ -155,7 +156,7 @@ export function ProfilePage() {
           </div>
         </section>
 
-        <section className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <section className="grid grid-cols-2 gap-3 sm:gap-4 lg:grid-cols-4">
           <article className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
             <p className="text-xs font-bold uppercase tracking-wide text-text-light">総ポイント</p>
             <p className="mt-2 text-2xl font-black text-amber-600">{stats?.total_points ?? 0} Pt</p>
@@ -183,43 +184,67 @@ export function ProfilePage() {
             </span>
           </div>
           {isLoadingAchievements ? <p className="mb-3 text-xs text-text-light" role="status" aria-live="polite">バッジ状態を更新中...</p> : null}
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {BADGE_DEFINITIONS.map((badge) => {
-              const unlocked = unlockedBadgeIds.includes(badge.id)
-              return (
-                <article
-                  key={badge.id}
-                  className={`rounded-xl border p-4 ${unlocked ? 'border-amber-200 bg-amber-50' : 'border-slate-200 bg-slate-50 opacity-70'
-                    }`}
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <h3 className={`text-sm font-bold ${unlocked ? 'text-amber-900' : 'text-slate-600'}`}>{badge.name}</h3>
-                    <span className="text-lg">{unlocked ? <Trophy className="h-5 w-5 text-amber-600" aria-hidden="true" /> : <Lock className="h-5 w-5 text-slate-400" aria-hidden="true" />}</span>
-                  </div>
-                  <p className={`mt-1 text-xs ${unlocked ? 'text-amber-700' : 'text-slate-500'}`}>{badge.description}</p>
-                </article>
-              )
-            })}
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {BADGE_DEFINITIONS.filter((b) => unlockedBadgeIds.includes(b.id)).map((badge) => (
+              <article
+                key={badge.id}
+                className="rounded-xl border border-amber-200 bg-amber-50 p-4"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <h3 className="text-sm font-bold text-amber-900">{badge.name}</h3>
+                  <span className="text-lg"><Trophy className="h-5 w-5 text-amber-600" aria-hidden="true" /></span>
+                </div>
+                <p className="mt-1 text-xs text-amber-700">{badge.description}</p>
+              </article>
+            ))}
+            {showUnearned && BADGE_DEFINITIONS.filter((b) => !unlockedBadgeIds.includes(b.id)).map((badge) => (
+              <article
+                key={badge.id}
+                className="rounded-xl border border-slate-200 bg-slate-50 p-4 opacity-40 grayscale"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <h3 className="text-sm font-bold text-slate-600">{badge.name}</h3>
+                  <span className="text-lg"><Lock className="h-5 w-5 text-slate-400" aria-hidden="true" /></span>
+                </div>
+                <p className="mt-1 text-xs text-slate-500">{badge.description}</p>
+              </article>
+            ))}
           </div>
+          {BADGE_DEFINITIONS.filter((b) => !unlockedBadgeIds.includes(b.id)).length > 0 && (
+            <button
+              type="button"
+              onClick={() => setShowUnearned(!showUnearned)}
+              className="mt-3 text-sm text-text-muted hover:text-text-dark"
+            >
+              {showUnearned ? '未獲得を隠す' : `未獲得を表示（${BADGE_DEFINITIONS.filter((b) => !unlockedBadgeIds.includes(b.id)).length}個）`}
+            </button>
+          )}
         </section>
 
         <section className="rounded-2xl border border-slate-100 bg-white p-6 shadow-sm">
-          <h2 className="mb-4 text-lg font-bold text-text-dark">ポイント履歴</h2>
-          {isLoading ? <Spinner size="sm" label="履歴を読み込み中..." /> : null}
-          {!isLoading && pointHistory.length === 0 ? <p className="text-sm text-text-light">ポイント履歴はまだありません。</p> : null}
-          {pointHistory.length > 0 ? (
-            <ul className="divide-y divide-slate-100">
-              {pointHistory.map((entry) => (
-                <li key={entry.id} className="flex flex-wrap items-center justify-between gap-2 py-3">
-                  <div>
-                    <p className="text-sm font-medium text-text-dark">{entry.reason}</p>
-                    <p className="text-xs text-text-light">{formatDateTime(entry.created_at)}</p>
-                  </div>
-                  <p className="text-sm font-bold text-primary-dark">+{entry.amount} Pt</p>
-                </li>
-              ))}
-            </ul>
-          ) : null}
+          <details className="group">
+            <summary className="flex cursor-pointer list-none items-center justify-between py-1 text-lg font-bold text-text-dark">
+              ポイント履歴
+              <span className="text-sm text-text-muted transition-transform group-open:rotate-180">▼</span>
+            </summary>
+            <div className="mt-3">
+              {isLoading ? <Spinner size="sm" label="履歴を読み込み中..." /> : null}
+              {!isLoading && pointHistory.length === 0 ? <p className="text-sm text-text-light">ポイント履歴はまだありません。</p> : null}
+              {pointHistory.length > 0 ? (
+                <ul className="divide-y divide-slate-100">
+                  {pointHistory.map((entry) => (
+                    <li key={entry.id} className="flex flex-wrap items-center justify-between gap-2 py-3">
+                      <div>
+                        <p className="text-sm font-medium text-text-dark">{entry.reason}</p>
+                        <p className="text-xs text-text-light">{formatDateTime(entry.created_at)}</p>
+                      </div>
+                      <p className="text-sm font-bold text-primary-dark">+{entry.amount} Pt</p>
+                    </li>
+                  ))}
+                </ul>
+              ) : null}
+            </div>
+          </details>
         </section>
       </main>
     </div>


### PR DESCRIPTION
## Summary

PR #227（v3 リリース前監査）でファイル全体が書き換えられた際に失われた v3.1〜v3.3 の機能・スタイルを復元。

- **A（機能復元）**: TestMode CodePuzzle モバイル分岐、ProfilePage showUnearned トグル、ポイント履歴アコーディオン
- **B（タップターゲット）**: min-h-[44px] を DailyChallengeCard, FormPreview, BaseNookTopicPage, CurriculumPage に復元
- **C（レスポンシブ）**: p-4 sm:p-6 等のレスポンシブ padding を 6箇所に復元
- **D（モバイルレイアウト）**: grid-cols-2, hidden sm:block, opacity-40 grayscale を復元
- **E（ブレイクポイント）**: AppHeader のナビゲーション md ブレイクポイントを復元（lg → md）
- **F（UI要素）**: カテゴリ左ボーダー + セクション区切り線を復元
- **G（属性・エラー処理）**: autoComplete 属性 + CurriculumPage エラーハンドリングを復元

監査の正当な改善（aria属性, role, useSignOut/useGreetingName フック抽出, フォーカストラップ, shared constants 等）はすべて維持。

## Test plan

- [x] typecheck: PASS
- [x] lint: PASS
- [x] test: 696件 PASS
- [x] build: PASS
- [ ] モバイル表示で TestMode が CodePuzzle に切り替わることを確認
- [ ] ProfilePage で未獲得バッジトグルが動作することを確認
- [ ] 768px 以上でデスクトップナビが表示されることを確認

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)