### PR TITLE
feat: Challenge モバイルパズル M3（advanced 4パターン）

### DIFF
--- a/apps/web/src/content/advanced/steps/api-fetch.ts
+++ b/apps/web/src/content/advanced/steps/api-fetch.ts
@@ -275,6 +275,30 @@ export function PostList() {
     </div>
   );
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useState, useEffect } from 'react';\n\nfunction useFetch<T>(url: string) {\n  const [data, setData] = useState<T | null>(null);\n  const [isLoading, setIsLoading] = useState(true);\n  const [error, setError] = useState<string | null>(null);\n\n  useEffect(() => {\n    ____0\n    async function fetchData() {\n      try {\n        ____1\n        const json = await res.json();\n        setData(json);\n      } catch (err) {\n        if ((err as Error).name !== 'AbortError') {\n          setError((err as Error).message);\n        }\n      } finally {\n        setIsLoading(false);\n      }\n    }\n    void fetchData();\n    ____2\n  }, [url]);\n\n  return { data, isLoading, error };\n}\n\ninterface Post { id: number; title: string; }\n\nexport function PostList() {\n  const [postId, setPostId] = useState(1);\n  const { data, isLoading, error } = useFetch<Post>(\n    \`https://jsonplaceholder.typicode.com/posts/\${postId}\`\n  );\n\n  return (\n    <div>\n      <button onClick={() => setPostId(id => Math.max(1, id - 1))}>前の記事</button>\n      <span> 記事 #{postId} </span>\n      <button onClick={() => setPostId(id => id + 1)}>次の記事</button>\n      {isLoading && <p>読み込み中...</p>}\n      {error && <p>エラー: {error}</p>}\n      {data && <h2>{data.title}</h2>}\n    </div>\n  );\n}`,
+            blanks: [
+              {
+                id: 'abort-controller',
+                label: 'AbortController作成',
+                correctTokens: ['const', 'controller', '=', 'new', 'AbortController', '(', ')'],
+                distractorTokens: ['XMLHttpRequest', 'useCallback', 'EventEmitter', 'let'],
+              },
+              {
+                id: 'fetch',
+                label: 'fetch実行',
+                correctTokens: ['const', 'res', '=', 'await', 'fetch', '(', 'url', ',', '{', 'signal', ':', 'controller.signal', '}', ')'],
+                distractorTokens: ['XMLHttpRequest', 'axios', 'method', "'GET'", 'useCallback'],
+              },
+              {
+                id: 'cleanup',
+                label: 'クリーンアップ',
+                correctTokens: ['return', '(', ')', '=>', 'controller.abort', '(', ')'],
+                distractorTokens: ['controller.cancel', 'clearInterval', 'removeEventListener', 'useMemo'],
+              },
+            ],
+          },
         },
       ],
     },

--- a/apps/web/src/content/advanced/steps/custom-hooks.ts
+++ b/apps/web/src/content/advanced/steps/custom-hooks.ts
@@ -226,6 +226,24 @@ export function PersistentCounter() {
     </div>
   );
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useState } from 'react';\n\nfunction useLocalStorage<T>(key: string, initialValue: T) {\n  const [storedValue, setStoredValue] = useState(() => {\n    ____0\n  });\n\n  const setValue = (val: T) => {\n    setStoredValue(val);\n    ____1\n  };\n\n  return { value: storedValue, setValue };\n}\n\nexport function PersistentCounter() {\n  const { value: count, setValue: setCount } = useLocalStorage('count', 0);\n\n  return (\n    <div>\n      <p>カウント: {count}</p>\n      <button onClick={() => setCount(count + 1)}>+1</button>\n      <button onClick={() => setCount(0)}>リセット</button>\n    </div>\n  );\n}`,
+            blanks: [
+              {
+                id: 'read',
+                label: 'localStorage読み込み',
+                correctTokens: ['const', 'item', '=', 'localStorage.getItem', '(', 'key', ')', 'return', 'item', '?', 'JSON.parse', '(', 'item', ')', ':', 'initialValue'],
+                distractorTokens: ['sessionStorage.getItem', 'useEffect', 'JSON.stringify', 'undefined'],
+              },
+              {
+                id: 'write',
+                label: 'localStorage保存',
+                correctTokens: ['localStorage.setItem', '(', 'key', ',', 'JSON.stringify', '(', 'val', ')', ')'],
+                distractorTokens: ['sessionStorage.setItem', 'JSON.parse', 'useEffect', 'getItem'],
+              },
+            ],
+          },
         },
       ],
     },

--- a/apps/web/src/content/advanced/steps/performance.ts
+++ b/apps/web/src/content/advanced/steps/performance.ts
@@ -193,6 +193,24 @@ export function OptimizedCounter() {
     </div>
   );
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useState, useCallback, memo } from 'react';\n\n____0\n\nexport function OptimizedCounter() {\n  const [count, setCount] = useState(0);\n  const [theme, setTheme] = useState<'light' | 'dark'>('light');\n\n  const handleIncrement = ____1\n  const handleDecrement = useCallback(() => setCount(c => c - 1), []);\n\n  return (\n    <div>\n      <p>カウント: {count}</p>\n      <ActionButton onClick={handleIncrement} label="増やす" />\n      <ActionButton onClick={handleDecrement} label="減らす" />\n      <button onClick={() => setTheme(t => t === 'light' ? 'dark' : 'light')}>\n        テーマ切り替え（{theme}）\n      </button>\n    </div>\n  );\n}`,
+            blanks: [
+              {
+                id: 'memo-component',
+                label: 'memoコンポーネント',
+                correctTokens: ['const', 'ActionButton', '=', 'memo', '(', '(', '{', 'onClick', ',', 'label', '}', ')', '=>', '{', 'return', '<button onClick={onClick}>', '{label}', '</button>', '}', ')'],
+                distractorTokens: ['useMemo', 'forwardRef', 'React.lazy', 'useRef', 'useCallback'],
+              },
+              {
+                id: 'use-callback',
+                label: 'useCallback定義',
+                correctTokens: ['useCallback', '(', '(', ')', '=>', 'setCount', '(', 'c', '=>', 'c', '+', '1', ')', ',', '[', ']', ')'],
+                distractorTokens: ['useMemo', 'useRef', 'React.lazy', 'forwardRef'],
+              },
+            ],
+          },
         },
       ],
     },

--- a/apps/web/src/content/advanced/steps/testing.ts
+++ b/apps/web/src/content/advanced/steps/testing.ts
@@ -215,6 +215,30 @@ describe('LoginForm', () => {
     // TODO: メールを入力して送信し、onLogin が正しく呼ばれることを検証する
   });
 });`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { render, screen } from '@testing-library/react';\nimport userEvent from '@testing-library/user-event';\nimport { vi } from 'vitest';\nimport { LoginForm } from './LoginForm';\n\ndescribe('LoginForm', () => {\n  it('初期状態でエラーメッセージは表示されない', () => {\n    render(<LoginForm onLogin={vi.fn()} />);\n    ____0\n  });\n\n  it('空欄のまま送信するとエラーメッセージが表示される', async () => {\n    const user = userEvent.setup();\n    render(<LoginForm onLogin={vi.fn()} />);\n    await user.click(screen.getByRole('button', { name: 'ログイン' }));\n    ____1\n  });\n\n  it('メールを入力して送信するとonLoginが呼ばれる', async () => {\n    const user = userEvent.setup();\n    const mockOnLogin = vi.fn();\n    render(<LoginForm onLogin={mockOnLogin} />);\n    await user.type(screen.getByLabelText('メールアドレス'), 'test@example.com');\n    await user.click(screen.getByRole('button', { name: 'ログイン' }));\n    ____2\n  });\n});`,
+            blanks: [
+              {
+                id: 'initial-check',
+                label: '初期検証',
+                correctTokens: ['expect', '(', 'screen.queryByText', '(', "'メールアドレスを入力してください'", ')', ')', '.toBeNull', '(', ')'],
+                distractorTokens: ['screen.getByTestId', 'screen.findByText', '.toBeFalsy', 'container'],
+              },
+              {
+                id: 'error-check',
+                label: 'エラー検証',
+                correctTokens: ['expect', '(', 'screen.getByText', '(', "'メールアドレスを入力してください'", ')', ')', '.toBeInTheDocument', '(', ')'],
+                distractorTokens: ['screen.getByTestId', 'screen.findByText', '.toBeCalled', 'container'],
+              },
+              {
+                id: 'mock-check',
+                label: 'mock検証',
+                correctTokens: ['expect', '(', 'mockOnLogin', ')', '.toHaveBeenCalledWith', '(', "'test@example.com'", ')'],
+                distractorTokens: ['screen.getByTestId', '.toBeCalled', 'container', 'screen.findByText'],
+              },
+            ],
+          },
         },
       ],
     },

--- a/docs/roadmaps/v4roadmap01.md
+++ b/docs/roadmaps/v4roadmap01.md
@@ -110,11 +110,11 @@ v3 の Challenge モードはモバイルでフルエディタ + キーボード
 
 4ステップ・4パターン
 
-- [ ] custom-hooks × 1パターンに `mobilePuzzle` 追加
-- [ ] api-fetch × 1パターンに `mobilePuzzle` 追加
-- [ ] performance × 1パターンに `mobilePuzzle` 追加
-- [ ] testing × 1パターンに `mobilePuzzle` 追加
-- [ ] CI 通過確認
+- [x] custom-hooks × 1パターンに `mobilePuzzle` 追加
+- [x] api-fetch × 1パターンに `mobilePuzzle` 追加
+- [x] performance × 1パターンに `mobilePuzzle` 追加
+- [x] testing × 1パターンに `mobilePuzzle` 追加
+- [x] CI 通過確認
 
 ### M4: API連携実践（api-practice）8パターン
 


### PR DESCRIPTION
## Summary
- advanced コース全4ステップ（custom-hooks, api-fetch, performance, testing）に `mobilePuzzle` (type: 'multi') を追加
- 各パターンの設計:
  - **custom-hooks**: localStorage読み込み + 保存（2ブランク / 25トークン）
  - **api-fetch**: AbortController作成 + fetch signal + cleanup（3ブランク / 28トークン）
  - **performance**: memoコンポーネント + useCallback定義（2ブランク / 37トークン）
  - **testing**: queryByText初期検証 + エラー検証 + mock検証（3ブランク / 28トークン）

## Test plan
- [x] `npm run typecheck` — PASS
- [x] `npm run lint` — PASS
- [x] `npm run test` — 698 tests PASS
- [x] `npm run build` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)