### PR TITLE
feat: M4 api-practice 8パターン mobilePuzzle追加

### DIFF
--- a/apps/web/src/content/api-practice/steps/api-counter-get.ts
+++ b/apps/web/src/content/api-practice/steps/api-counter-get.ts
@@ -196,6 +196,24 @@ export function CounterDisplay() {
     </div>
   );
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useEffect, useState } from 'react';\n\nexport function CounterDisplay() {\n  const [value, setValue] = useState<number | null>(null);\n  const [loading, setLoading] = useState(true);\n  const [error, setError] = useState<string | null>(null);\n\n  async function loadCounter() {\n    try {\n      setLoading(true);\n      ____0\n    } catch {\n      setError('エラーが発生しました');\n    } finally {\n      setLoading(false);\n    }\n  }\n\n  useEffect(() => {\n    void loadCounter();\n  }, []);\n\n  if (loading) return <p>読み込み中...</p>;\n  if (error) return (\n    <div>\n      <p>{error}</p>\n      ____1\n    </div>\n  );\n  return (\n    <div>\n      <p>カウンター: {value}</p>\n      ____1\n    </div>\n  );\n}`,
+            blanks: [
+              {
+                id: 'fetch-set',
+                label: 'fetch処理',
+                correctTokens: ['const', 'res', '=', 'await', 'fetch', '(', "'/counter'", ')', 'const', 'data', '=', 'await', 'res.json', '(', ')', 'setValue', '(', 'data.value', ')'],
+                distractorTokens: ['axios', 'XMLHttpRequest', 'data.count', 'setData', 'useCallback'],
+              },
+              {
+                id: 'reload-btn',
+                label: '再読み込み',
+                correctTokens: ['<button onClick={loadCounter}>', '再読み込み', '</button>'],
+                distractorTokens: ['<button onClick={fetch}>', '<a href="/">', 'onSubmit', 'refetch', 'useEffect'],
+              },
+            ],
+          },
         },
       ],
     },

--- a/apps/web/src/content/api-practice/steps/api-counter-post.ts
+++ b/apps/web/src/content/api-practice/steps/api-counter-post.ts
@@ -194,6 +194,24 @@ export function Counter() {
     </div>
   );
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useEffect, useState } from 'react';\n\nexport function Counter() {\n  const [value, setValue] = useState(0);\n  const [submitting, setSubmitting] = useState(false);\n\n  useEffect(() => {\n    fetch('http://localhost:3001/counter')\n      .then(res => res.json())\n      .then(data => setValue(data.value));\n  }, []);\n\n  async function sendValue(nextValue: number) {\n    setSubmitting(true);\n    try {\n      ____0\n    } finally {\n      setSubmitting(false);\n    }\n  }\n\n  return (\n    <div>\n      <p>カウンター: {value}</p>\n      ____1\n    </div>\n  );\n}`,
+            blanks: [
+              {
+                id: 'put-fetch',
+                label: 'PUT送信',
+                correctTokens: ['const', 'res', '=', 'await', 'fetch', '(', "'/counter'", ',', '{', 'method', ':', "'PUT'", ',', 'headers', ':', '{', "'Content-Type'", ':', "'application/json'", '}', ',', 'body', ':', 'JSON.stringify', '(', '{', 'value', ':', 'nextValue', '}', ')', '}', ')', 'const', 'data', '=', 'await', 'res.json', '(', ')', 'setValue', '(', 'data.value', ')'],
+                distractorTokens: ["'POST'", "'PATCH'", 'axios', 'setData', 'JSON.parse'],
+              },
+              {
+                id: 'buttons',
+                label: '3ボタン',
+                correctTokens: ['<button onClick={() => void sendValue(value + 1)} disabled={submitting}>', '+1', '</button>', '<button onClick={() => void sendValue(Math.max(0, value - 1))} disabled={submitting}>', '-1', '</button>', '<button onClick={() => void sendValue(0)} disabled={submitting}>', 'リセット', '</button>'],
+                distractorTokens: ['<button onClick={sendValue}>', 'onChange', 'onSubmit', '<a href="#">'],
+              },
+            ],
+          },
         },
       ],
     },

--- a/apps/web/src/content/api-practice/steps/api-custom-hook.ts
+++ b/apps/web/src/content/api-practice/steps/api-custom-hook.ts
@@ -225,6 +225,30 @@ export function useTasks() {
 
   return { tasks, loading, error, createTask, toggleTask, deleteTask };
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useCallback, useEffect, useState } from 'react';\n\ninterface Task { id: string; title: string; completed: boolean; }\n\nexport function useTasks() {\n  const [tasks, setTasks] = useState<Task[]>([]);\n  const [loading, setLoading] = useState(true);\n  const [error, setError] = useState<string | null>(null);\n\n  ____0\n\n  useEffect(() => {\n    void fetchTasks();\n  }, [fetchTasks]);\n\n  ____1\n\n  ____2\n\n  return { tasks, loading, error, fetchTasks, createTask, deleteTask };\n}`,
+            blanks: [
+              {
+                id: 'fetch-tasks',
+                label: 'fetchTasks',
+                correctTokens: ['const', 'fetchTasks', '=', 'useCallback', '(', 'async', '(', ')', '=>', '{', 'setLoading', '(', 'true', ')', 'try', '{', 'const', 'res', '=', 'await', 'fetch', '(', "'/tasks'", ')', 'const', 'data', '=', 'await', 'res.json', '(', ')', 'setTasks', '(', 'data', ')', '}', 'catch', '{', 'setError', '(', "'取得失敗'", ')', '}', 'finally', '{', 'setLoading', '(', 'false', ')', '}', '}', ',', '[', ']', ')'],
+                distractorTokens: ['useMemo', 'useEffect', 'axios', 'XMLHttpRequest', 'setData'],
+              },
+              {
+                id: 'create-task',
+                label: 'createTask',
+                correctTokens: ['const', 'createTask', '=', 'useCallback', '(', 'async', '(', 'title', ':', 'string', ')', '=>', '{', 'const', 'res', '=', 'await', 'fetch', '(', "'/tasks'", ',', '{', 'method', ':', "'POST'", ',', 'headers', ':', '{', "'Content-Type'", ':', "'application/json'", '}', ',', 'body', ':', 'JSON.stringify', '(', '{', 'title', ',', 'completed', ':', 'false', '}', ')', '}', ')', 'const', 'newTask', '=', 'await', 'res.json', '(', ')', 'setTasks', '(', 'prev', '=>', '[', '...prev', ',', 'newTask', ']', ')', '}', ',', '[', ']', ')'],
+                distractorTokens: ["'PUT'", 'useMemo', 'axios', 'JSON.parse', 'setData'],
+              },
+              {
+                id: 'delete-task',
+                label: 'deleteTask',
+                correctTokens: ['const', 'deleteTask', '=', 'useCallback', '(', 'async', '(', 'id', ':', 'string', ')', '=>', '{', 'await', 'fetch', '(', '`/tasks/${id}`', ',', '{', 'method', ':', "'DELETE'", '}', ')', 'setTasks', '(', 'prev', '=>', 'prev.filter', '(', 't', '=>', 't.id', '!==', 'id', ')', ')', '}', ',', '[', ']', ')'],
+                distractorTokens: ["'PATCH'", 'prev.map', 'useMemo', 'axios', 'splice'],
+              },
+            ],
+          },
         },
       ],
     },

--- a/apps/web/src/content/api-practice/steps/api-error-loading.ts
+++ b/apps/web/src/content/api-practice/steps/api-error-loading.ts
@@ -234,6 +234,24 @@ export function TaskListWithState() {
 
   return <p>実装してください</p>;
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useCallback, useEffect, useReducer } from 'react';\n\ninterface Task { id: string; title: string; completed: boolean; }\ntype ApiStatus = 'idle' | 'loading' | 'success' | 'error';\ninterface ApiState { status: ApiStatus; data: Task[] | null; error: string | null; }\ntype Action =\n  | { type: 'FETCH_START' }\n  | { type: 'FETCH_SUCCESS'; payload: Task[] }\n  | { type: 'FETCH_ERROR'; payload: string };\n\nfunction apiReducer(state: ApiState, action: Action): ApiState {\n  switch (action.type) {\n    case 'FETCH_START': return { ...state, status: 'loading', error: null };\n    case 'FETCH_SUCCESS': return { status: 'success', data: action.payload, error: null };\n    case 'FETCH_ERROR': return { status: 'error', data: null, error: action.payload };\n    default: return state;\n  }\n}\n\nexport function TaskListWithState() {\n  const [state, dispatch] = useReducer(apiReducer, { status: 'idle', data: null, error: null });\n\n  const load = useCallback(async () => {\n    ____0\n  }, []);\n\n  useEffect(() => { void load(); }, [load]);\n\n  ____1\n\n  return (\n    <ul>\n      {state.data?.map((task) => (\n        <li key={task.id}>{task.title}</li>\n      ))}\n    </ul>\n  );\n}`,
+            blanks: [
+              {
+                id: 'load-body',
+                label: 'load関数',
+                correctTokens: ['dispatch', '(', '{', 'type', ':', "'FETCH_START'", '}', ')', 'try', '{', 'const', 'res', '=', 'await', 'fetch', '(', "'/tasks'", ')', 'const', 'data', '=', 'await', 'res.json', '(', ')', 'dispatch', '(', '{', 'type', ':', "'FETCH_SUCCESS'", ',', 'payload', ':', 'data', '}', ')', '}', 'catch', '(', 'e', ')', '{', 'dispatch', '(', '{', 'type', ':', "'FETCH_ERROR'", ',', 'payload', ':', '(', 'e', 'as', 'Error', ')', '.message', '}', ')', '}'],
+                distractorTokens: ['setState', 'setLoading', 'axios', 'useCallback', "'FETCH_RESET'"],
+              },
+              {
+                id: 'state-ui',
+                label: '状態別UI',
+                correctTokens: ['if', '(', 'state.status', '===', "'loading'", ')', 'return', '(', '<ul>', '{', '[', '1', ',', '2', ',', '3', ']', '.map', '(', 'i', '=>', '(', '<li', 'key', '=', '{', 'i', '}', 'className', '=', '"animate-pulse bg-gray-200 h-6 rounded mb-2"', '/>', ')', ')', '}', '</ul>', ')', 'if', '(', 'state.status', '===', "'error'", ')', 'return', '(', '<div>', '<p>', '{', 'state.error', '}', '</p>', '<button onClick={() => void load()}>', '再試行', '</button>', '</div>', ')'],
+                distractorTokens: ['state.loading', 'isLoading', "'idle'", 'retry', 'setError', 'console.log'],
+              },
+            ],
+          },
         },
       ],
     },

--- a/apps/web/src/content/api-practice/steps/api-tasks-create.ts
+++ b/apps/web/src/content/api-practice/steps/api-tasks-create.ts
@@ -212,6 +212,30 @@ export function TaskManager() {
     </div>
   );
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useEffect, useState } from 'react';\n\ninterface Task { id: string; title: string; completed: boolean; }\n\nexport function TaskManager() {\n  const [tasks, setTasks] = useState<Task[]>([]);\n  const [inputValue, setInputValue] = useState('');\n  const [submitting, setSubmitting] = useState(false);\n  const [error, setError] = useState<string | null>(null);\n\n  useEffect(() => {\n    fetch('/tasks').then(r => r.json()).then(d => setTasks(d));\n  }, []);\n\n  async function handleSubmit(e: React.FormEvent) {\n    e.preventDefault();\n    ____0\n    setSubmitting(true);\n    try {\n      ____1\n      ____2\n    } finally {\n      setSubmitting(false);\n    }\n  }\n\n  return (\n    <div>\n      <form onSubmit={(e) => void handleSubmit(e)}>\n        <input value={inputValue} onChange={(e) => setInputValue(e.target.value)} />\n        <button type="submit" disabled={submitting}>追加</button>\n      </form>\n      {error && <p>{error}</p>}\n      <ul>{tasks.map(t => <li key={t.id}>{t.title}</li>)}</ul>\n    </div>\n  );\n}`,
+            blanks: [
+              {
+                id: 'validation',
+                label: 'バリデーション',
+                correctTokens: ['if', '(', '!', 'inputValue.trim', '(', ')', ')', '{', 'setError', '(', "'タスク名を入力してください'", ')', 'return', '}'],
+                distractorTokens: ['inputValue.length', 'inputValue.slice', 'throw', 'console.log', 'alert'],
+              },
+              {
+                id: 'post-fetch',
+                label: 'POST送信',
+                correctTokens: ['const', 'res', '=', 'await', 'fetch', '(', "'/tasks'", ',', '{', 'method', ':', "'POST'", ',', 'headers', ':', '{', "'Content-Type'", ':', "'application/json'", '}', ',', 'body', ':', 'JSON.stringify', '(', '{', 'title', ':', 'inputValue', '}', ')', '}', ')'],
+                distractorTokens: ["'PUT'", "'PATCH'", 'axios', 'JSON.parse', 'XMLHttpRequest'],
+              },
+              {
+                id: 'update-list',
+                label: 'リスト更新',
+                correctTokens: ['const', 'newTask', '=', 'await', 'res.json', '(', ')', 'setTasks', '(', 'prev', '=>', '[', '...prev', ',', 'newTask', ']', ')', 'setInputValue', '(', "''", ')'],
+                distractorTokens: ['setData', 'push', 'concat', 'splice', 'setItems'],
+              },
+            ],
+          },
         },
       ],
     },

--- a/apps/web/src/content/api-practice/steps/api-tasks-delete.ts
+++ b/apps/web/src/content/api-practice/steps/api-tasks-delete.ts
@@ -173,6 +173,24 @@ export function TaskList() {
     </ul>
   );
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useEffect, useState } from 'react';\n\ninterface Task { id: string; title: string; completed: boolean; }\n\nexport function TaskList() {\n  const [tasks, setTasks] = useState<Task[]>([]);\n  const [deletingId, setDeletingId] = useState<string | null>(null);\n\n  useEffect(() => {\n    fetch('/tasks').then(r => r.json()).then(d => setTasks(d));\n  }, []);\n\n  async function handleDelete(task: Task) {\n    ____0\n    setDeletingId(task.id);\n    try {\n      await fetch(\`/tasks/\${task.id}\`, { method: 'DELETE' });\n      ____1\n    } finally {\n      setDeletingId(null);\n    }\n  }\n\n  return (\n    <ul>\n      {tasks.map((task) => (\n        <li key={task.id}>\n          {task.title}\n          <button onClick={() => void handleDelete(task)}\n            disabled={deletingId === task.id}>\n            {deletingId === task.id ? '削除中...' : '削除'}\n          </button>\n        </li>\n      ))}\n    </ul>\n  );\n}`,
+            blanks: [
+              {
+                id: 'confirm-check',
+                label: 'confirm確認',
+                correctTokens: ['if', '(', '!', 'confirm', '(', "'本当に削除しますか？'", ')', ')', 'return'],
+                distractorTokens: ['alert', 'prompt', 'window.open', 'console.log', 'throw'],
+              },
+              {
+                id: 'filter-list',
+                label: 'リスト更新',
+                correctTokens: ['setTasks', '(', 'prev', '=>', 'prev.filter', '(', 't', '=>', 't.id', '!==', 'task.id', ')', ')'],
+                distractorTokens: ['prev.map', 'prev.splice', 'prev.find', 'setDeletingId', 'push'],
+              },
+            ],
+          },
         },
       ],
     },

--- a/apps/web/src/content/api-practice/steps/api-tasks-list.ts
+++ b/apps/web/src/content/api-practice/steps/api-tasks-list.ts
@@ -193,6 +193,24 @@ export function TaskList() {
     </ul>
   );
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useEffect, useState } from 'react';\n\ninterface Task {\n  id: string;\n  title: string;\n  completed: boolean;\n}\n\nexport function TaskList() {\n  const [tasks, setTasks] = useState<Task[]>([]);\n  const [loading, setLoading] = useState(true);\n  const [error, setError] = useState<string | null>(null);\n\n  ____0\n\n  if (loading) return <p>読み込み中...</p>;\n  if (error) return <p>{error}</p>;\n  if (tasks.length === 0) return <p>タスクはありません</p>;\n\n  return (\n    <ul>\n      {tasks.map((task) => (\n        <li key={task.id} style={____1}>\n          {task.title}\n        </li>\n      ))}\n    </ul>\n  );\n}`,
+            blanks: [
+              {
+                id: 'fetch-effect',
+                label: 'fetch+useEffect',
+                correctTokens: ['useEffect', '(', '(', ')', '=>', '{', 'fetch', '(', "'/tasks'", ')', '.then', '(', 'res', '=>', 'res.json', '(', ')', ')', '.then', '(', 'data', '=>', 'setTasks', '(', 'data', ')', ')', '.catch', '(', '(', ')', '=>', 'setError', '(', "'取得失敗'", ')', ')', '.finally', '(', '(', ')', '=>', 'setLoading', '(', 'false', ')', ')', '}', ',', '[', ']', ')'],
+                distractorTokens: ['axios', 'useCallback', 'setData', 'XMLHttpRequest', 'async'],
+              },
+              {
+                id: 'completed-style',
+                label: 'completed表示',
+                correctTokens: ['{', 'textDecoration', ':', 'task.completed', '?', "'line-through'", ':', "'none'", '}'],
+                distractorTokens: ["'underline'", 'task.done', 'color', "'red'", 'task.id'],
+              },
+            ],
+          },
         },
       ],
     },

--- a/apps/web/src/content/api-practice/steps/api-tasks-update.ts
+++ b/apps/web/src/content/api-practice/steps/api-tasks-update.ts
@@ -185,6 +185,30 @@ export function TaskList() {
     </ul>
   );
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useEffect, useState } from 'react';\n\ninterface Task { id: string; title: string; completed: boolean; }\n\nexport function TaskList() {\n  const [tasks, setTasks] = useState<Task[]>([]);\n  const [updatingIds, setUpdatingIds] = useState<Set<string>>(new Set());\n\n  useEffect(() => {\n    fetch('/tasks').then(r => r.json()).then(d => setTasks(d));\n  }, []);\n\n  async function handleToggle(task: Task) {\n    setUpdatingIds(prev => new Set(prev).add(task.id));\n    ____0\n    try {\n      ____1\n    } catch {\n      ____2\n    } finally {\n      setUpdatingIds(prev => { const s = new Set(prev); s.delete(task.id); return s; });\n    }\n  }\n\n  return (\n    <ul>\n      {tasks.map((task) => (\n        <li key={task.id}>\n          <input type="checkbox" checked={task.completed}\n            disabled={updatingIds.has(task.id)}\n            onChange={() => void handleToggle(task)} />\n          {task.title}\n        </li>\n      ))}\n    </ul>\n  );\n}`,
+            blanks: [
+              {
+                id: 'optimistic',
+                label: '楽観的更新',
+                correctTokens: ['setTasks', '(', 'prev', '=>', 'prev.map', '(', 't', '=>', 't.id', '===', 'task.id', '?', '{', '...t', ',', 'completed', ':', '!', 't.completed', '}', ':', 't', ')', ')'],
+                distractorTokens: ['filter', 'find', 'push', 'splice', 'setData'],
+              },
+              {
+                id: 'patch-req',
+                label: 'PATCH送信',
+                correctTokens: ['await', 'fetch', '(', '`/tasks/${task.id}`', ',', '{', 'method', ':', "'PATCH'", ',', 'headers', ':', '{', "'Content-Type'", ':', "'application/json'", '}', ',', 'body', ':', 'JSON.stringify', '(', '{', 'completed', ':', '!', 'task.completed', '}', ')', '}', ')'],
+                distractorTokens: ["'PUT'", "'DELETE'", 'axios', 'JSON.parse', 'XMLHttpRequest'],
+              },
+              {
+                id: 'rollback',
+                label: 'ロールバック',
+                correctTokens: ['setTasks', '(', 'prev', '=>', 'prev.map', '(', 't', '=>', 't.id', '===', 'task.id', '?', '{', '...t', ',', 'completed', ':', 'task.completed', '}', ':', 't', ')', ')'],
+                distractorTokens: ['filter', 'find', 'push', 'setError', 'console.log'],
+              },
+            ],
+          },
         },
       ],
     },

--- a/docs/roadmaps/v4roadmap01.md
+++ b/docs/roadmaps/v4roadmap01.md
@@ -120,15 +120,15 @@ v3 の Challenge モードはモバイルでフルエディタ + キーボード
 
 8ステップ・8パターン
 
-- [ ] api-counter-get × 1パターンに `mobilePuzzle` 追加
-- [ ] api-counter-post × 1パターンに `mobilePuzzle` 追加
-- [ ] api-tasks-list × 1パターンに `mobilePuzzle` 追加
-- [ ] api-tasks-create × 1パターンに `mobilePuzzle` 追加
-- [ ] api-tasks-update × 1パターンに `mobilePuzzle` 追加
-- [ ] api-tasks-delete × 1パターンに `mobilePuzzle` 追加
-- [ ] api-custom-hook × 1パターンに `mobilePuzzle` 追加
-- [ ] api-error-loading × 1パターンに `mobilePuzzle` 追加
-- [ ] CI 通過確認
+- [x] api-counter-get × 1パターンに `mobilePuzzle` 追加
+- [x] api-counter-post × 1パターンに `mobilePuzzle` 追加
+- [x] api-tasks-list × 1パターンに `mobilePuzzle` 追加
+- [x] api-tasks-create × 1パターンに `mobilePuzzle` 追加
+- [x] api-tasks-update × 1パターンに `mobilePuzzle` 追加
+- [x] api-tasks-delete × 1パターンに `mobilePuzzle` 追加
+- [x] api-custom-hook × 1パターンに `mobilePuzzle` 追加
+- [x] api-error-loading × 1パターンに `mobilePuzzle` 追加
+- [x] CI 通過確認
 
 ### M5: TypeScript基礎（typescript）12パターン
 


### PR DESCRIPTION
## Summary
- API連携実践コース全8ステップの Challenge パターンに `mobilePuzzle` (type: 'multi') を追加
- 対象: api-counter-get, api-counter-post, api-tasks-list, api-tasks-create, api-tasks-update, api-tasks-delete, api-custom-hook, api-error-loading
- v4roadmap01 M4 チェックボックス更新

## Test plan
- [x] typecheck 通過
- [x] lint 通過
- [x] test 698件 PASS
- [x] build 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)