### PR TITLE
feat: TypeScript基礎コース mobilePuzzle 全12パターン追加（M5）

### DIFF
--- a/apps/web/src/content/typescript/steps/ts-functions.ts
+++ b/apps/web/src/content/typescript/steps/ts-functions.ts
@@ -178,6 +178,24 @@ console.log(evens); // [2, 4, 6]
 const words = ["cat", "elephant", "dog", "butterfly", "ant"];
 const longWords = filterByCondition(words, (w) => w.length >= 5);
 console.log(longWords); // ["elephant", "butterfly"]`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `____0 {\n  ____1\n}\n\nconst numbers = [1, 2, 3, 4, 5, 6];\nconst evens = filterByCondition(numbers, (n) => n % 2 === 0);\nconsole.log(evens);\n\nconst words = ["cat", "elephant", "dog", "butterfly", "ant"];\nconst longWords = filterByCondition(words, (w) => w.length >= 5);\nconsole.log(longWords);`,
+            blanks: [
+              {
+                id: 'signature',
+                label: '関数シグネチャ',
+                correctTokens: ['function', 'filterByCondition', '<T>', '(', 'arr', ':', 'T[]', ',', 'predicate', ':', '(', 'item', ':', 'T', ')', '=>', 'boolean', ')', ':', 'T[]'],
+                distractorTokens: ['any[]', 'unknown', 'void', 'forEach'],
+              },
+              {
+                id: 'body',
+                label: '実装body',
+                correctTokens: ['return', 'arr.filter', '(', 'predicate', ')'],
+                distractorTokens: ['arr.map', 'arr.forEach', 'arr.reduce', 'arr.find'],
+              },
+            ],
+          },
       },
       {
         id: 'ts-functions-2',
@@ -199,6 +217,24 @@ function applyTwice(value, fn) {
 
 console.log(applyTwice(3, (n) => n * 2));   // 12
 console.log(applyTwice(5, (n) => n + 10));  // 25`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `____0 {\n  ____1\n}\n\nconsole.log(applyTwice(3, (n) => n * 2));\nconsole.log(applyTwice(5, (n) => n + 10));`,
+            blanks: [
+              {
+                id: 'signature',
+                label: '型注釈',
+                correctTokens: ['function', 'applyTwice', '(', 'value', ':', 'number', ',', 'fn', ':', '(', 'n', ':', 'number', ')', '=>', 'number', ')', ':', 'number'],
+                distractorTokens: ['string', 'any', 'void', 'callback'],
+              },
+              {
+                id: 'body',
+                label: '実装',
+                correctTokens: ['return', 'fn', '(', 'fn', '(', 'value', ')', ')'],
+                distractorTokens: ['fn.call', 'fn.apply', 'fn.bind', 'value.fn'],
+              },
+            ],
+          },
       },
     ],
   },

--- a/apps/web/src/content/typescript/steps/ts-generics.ts
+++ b/apps/web/src/content/typescript/steps/ts-generics.ts
@@ -185,6 +185,30 @@ try {
 } catch (e) {
   console.log((e as Error).message); // "取得に失敗しました"
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `____0\n\n____1\n\n____2\n\nconst r1 = succeed(42);\nconst r2 = fail<number>("取得に失敗しました");\nconsole.log(unwrap(r1));\ntry { unwrap(r2); } catch (e) { console.log((e as Error).message); }`,
+            blanks: [
+              {
+                id: 'result-type',
+                label: 'Result型',
+                correctTokens: ['type', 'Result', '<T>', '=', '{', 'ok', ':', 'true', ';', 'value', ':', 'T', '}', '|', '{', 'ok', ':', 'false', ';', 'error', ':', 'string', '}'],
+                distractorTokens: ['any', 'unknown', 'void', 'Promise'],
+              },
+              {
+                id: 'succeed-fail',
+                label: 'succeed/fail',
+                correctTokens: ['function', 'succeed', '<T>', '(', 'value', ':', 'T', ')', ':', 'Result<T>', '{', 'return', '{', 'ok', ':', 'true', ',', 'value', '}', '}', 'function', 'fail', '<T>', '(', 'error', ':', 'string', ')', ':', 'Result<T>', '{', 'return', '{', 'ok', ':', 'false', ',', 'error', '}', '}'],
+                distractorTokens: ['new Result', 'throw', 'Promise.resolve', 'null'],
+              },
+              {
+                id: 'unwrap',
+                label: 'unwrap',
+                correctTokens: ['function', 'unwrap', '<T>', '(', 'result', ':', 'Result<T>', ')', ':', 'T', '{', 'if', '(', '!', 'result.ok', ')', 'throw', 'new', 'Error', '(', 'result.error', ')', 'return', 'result.value', '}'],
+                distractorTokens: ['result.data', 'result.get', 'JSON.parse', 'result.unwrap'],
+              },
+            ],
+          },
       },
       {
         id: 'ts-generics-2',
@@ -210,6 +234,24 @@ const users = [
 ];
 console.log(findById(users, 1));    // { id: 1, name: "Alice" }
 console.log(groupById(users));      // { 1: { id: 1, name: "Alice" }, 2: { id: 2, name: "Bob" } }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `____0\n\n____1\n\nconst users = [\n  { id: 1, name: "Alice" },\n  { id: 2, name: "Bob" },\n];\nconsole.log(findById(users, 1));\nconsole.log(groupById(users));`,
+            blanks: [
+              {
+                id: 'find-by-id',
+                label: 'findById',
+                correctTokens: ['function', 'findById', '<T', 'extends', '{', 'id', ':', 'number', '}>', '(', 'items', ':', 'T[]', ',', 'id', ':', 'number', ')', ':', 'T', '|', 'undefined', '{', 'return', 'items.find', '(', 'item', '=>', 'item.id', '===', 'id', ')', '}'],
+                distractorTokens: ['any', 'object', 'Partial', 'Map'],
+              },
+              {
+                id: 'group-by-id',
+                label: 'groupById',
+                correctTokens: ['function', 'groupById', '<T', 'extends', '{', 'id', ':', 'number', '}>', '(', 'items', ':', 'T[]', ')', ':', 'Record<number, T>', '{', 'const', 'map', '=', '{} as Record<number, T>', 'items.forEach', '(', 'item', '=>', '{', 'map[item.id]', '=', 'item', '}', ')', 'return', 'map', '}'],
+                distractorTokens: ['Array', 'Set', 'WeakMap', 'JSON.stringify'],
+              },
+            ],
+          },
       },
     ],
   },

--- a/apps/web/src/content/typescript/steps/ts-objects.ts
+++ b/apps/web/src/content/typescript/steps/ts-objects.ts
@@ -205,6 +205,24 @@ const draft = createDraft("TypeScriptの学習", "TypeScriptは型安全なJavaS
 console.log(draft.title);       // "TypeScriptの学習"
 console.log(draft.tags);        // []
 console.log(draft.publishedAt); // undefined`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `____0\n\nfunction createDraft(title: string, content: string): Article {\n  ____1\n}\n\nconst draft = createDraft("TypeScriptの学習", "TypeScriptは型安全なJavaScriptです。");\nconsole.log(draft.title);\nconsole.log(draft.tags);\nconsole.log(draft.publishedAt);`,
+            blanks: [
+              {
+                id: 'article-interface',
+                label: 'Article定義',
+                correctTokens: ['interface', 'Article', '{', 'readonly', 'id', ':', 'number', ';', 'title', ':', 'string', ';', 'content', ':', 'string', ';', 'tags', ':', 'string[]', ';', 'publishedAt?', ':', 'Date', '}'],
+                distractorTokens: ['type', 'class', 'const', 'mutable'],
+              },
+              {
+                id: 'create-draft',
+                label: 'createDraft',
+                correctTokens: ['return', '{', 'id', ':', 'Date.now()', ',', 'title', ',', 'content', ',', 'tags', ':', '[', ']', '}'],
+                distractorTokens: ['new Article()', 'Object.create', 'publishedAt', 'new Date()'],
+              },
+            ],
+          },
       },
       {
         id: 'ts-objects-2',
@@ -234,6 +252,24 @@ const admin: AdminUser = { id: 2, name: "Alice", email: "alice@example.com", rol
 
 console.log(isAdmin(regular)); // false
 console.log(isAdmin(admin));   // true`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `interface User {\n  id: number;\n  name: string;\n  email: string;\n}\n\n____0\n\nfunction isAdmin(user: User | AdminUser): user is AdminUser {\n  ____1\n}\n\nconst regular: User = { id: 1, name: "Bob", email: "bob@example.com" };\nconst admin: AdminUser = { id: 2, name: "Alice", email: "alice@example.com", role: "admin", permissions: ["read", "write"] };\nconsole.log(isAdmin(regular));\nconsole.log(isAdmin(admin));`,
+            blanks: [
+              {
+                id: 'admin-extends',
+                label: 'AdminUser',
+                correctTokens: ['interface', 'AdminUser', 'extends', 'User', '{', 'role', ':', "'admin'", ';', 'permissions', ':', 'string[]', '}'],
+                distractorTokens: ['implements', 'typeof', 'instanceof', 'as'],
+              },
+              {
+                id: 'is-admin',
+                label: '型ガード',
+                correctTokens: ['return', "'role'", 'in', 'user'],
+                distractorTokens: ['typeof', 'instanceof', 'user.role', 'user as AdminUser'],
+              },
+            ],
+          },
       },
     ],
   },

--- a/apps/web/src/content/typescript/steps/ts-types.ts
+++ b/apps/web/src/content/typescript/steps/ts-types.ts
@@ -170,6 +170,24 @@ const apple: Product = { name: "りんご", price: 150, inStock: true };
 const soldOut: Product = { name: "みかん", price: 100, inStock: false };
 console.log(formatProduct(apple));   // "商品名: りんご, 価格: ¥150"
 console.log(formatProduct(soldOut)); // "商品名: みかん, 価格: ¥100 (在庫なし)"`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `____0\n\nfunction formatProduct(product: Product): string {\n  ____1\n}\n\nconst apple: Product = { name: "りんご", price: 150, inStock: true };\nconst soldOut: Product = { name: "みかん", price: 100, inStock: false };\nconsole.log(formatProduct(apple));\nconsole.log(formatProduct(soldOut));`,
+            blanks: [
+              {
+                id: 'product-type',
+                label: 'Product型',
+                correctTokens: ['type', 'Product', '=', '{', 'name', ':', 'string', ';', 'price', ':', 'number', ';', 'inStock', ':', 'boolean', '}'],
+                distractorTokens: ['interface', 'any', 'object', 'Array'],
+              },
+              {
+                id: 'format-body',
+                label: '関数body',
+                correctTokens: ['const', 'base', '=', '`商品名: ${product.name}, 価格: ¥${product.price}`', 'return', 'product.inStock', '?', 'base', ':', 'base', '+', "' (在庫なし)'"],
+                distractorTokens: ['product.stock', 'product.available', 'toString', 'JSON.stringify'],
+              },
+            ],
+          },
       },
       {
         id: 'ts-types-2',
@@ -194,6 +212,24 @@ function getStatusLabel(status: UserStatus): string {
 console.log(getStatusLabel("pending"));  // "審査中"
 console.log(getStatusLabel("active"));   // "有効"
 console.log(getStatusLabel("inactive")); // "無効"`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `____0\n\nfunction getStatusLabel(status: UserStatus): string {\n  ____1\n}\n\nconsole.log(getStatusLabel("pending"));\nconsole.log(getStatusLabel("active"));\nconsole.log(getStatusLabel("inactive"));`,
+            blanks: [
+              {
+                id: 'status-type',
+                label: 'UserStatus型',
+                correctTokens: ['type', 'UserStatus', '=', "'pending'", '|', "'active'", '|', "'inactive'"],
+                distractorTokens: ['enum', 'string', 'boolean', 'undefined'],
+              },
+              {
+                id: 'switch-body',
+                label: 'switch文',
+                correctTokens: ['switch', '(', 'status', ')', '{', 'case', "'pending'", ':', 'return', "'審査中'", 'case', "'active'", ':', 'return', "'有効'", 'case', "'inactive'", ':', 'return', "'無効'", '}'],
+                distractorTokens: ['if', 'else', "'disabled'", "'banned'", 'default'],
+              },
+            ],
+          },
       },
     ],
   },

--- a/apps/web/src/content/typescript/steps/ts-union-narrowing.ts
+++ b/apps/web/src/content/typescript/steps/ts-union-narrowing.ts
@@ -206,6 +206,24 @@ const ok: ApiResponse = { status: "success", data: "ユーザー情報" };
 const ng: ApiResponse = { status: "error", message: "認証エラー" };
 console.log(handleResponse(ok)); // "データ: ユーザー情報"
 console.log(handleResponse(ng)); // "エラー: 認証エラー"`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `____0\n\nfunction handleResponse(res: ApiResponse): string {\n  ____1\n}\n\nconst ok: ApiResponse = { status: "success", data: "ユーザー情報" };\nconst ng: ApiResponse = { status: "error", message: "認証エラー" };\nconsole.log(handleResponse(ok));\nconsole.log(handleResponse(ng));`,
+            blanks: [
+              {
+                id: 'api-response',
+                label: 'ApiResponse型',
+                correctTokens: ['type', 'ApiResponse', '=', '{', 'status', ':', "'success'", ';', 'data', ':', 'string', '}', '|', '{', 'status', ':', "'error'", ';', 'message', ':', 'string', '}'],
+                distractorTokens: ['interface', 'enum', 'class', 'typeof'],
+              },
+              {
+                id: 'handle-body',
+                label: '分岐処理',
+                correctTokens: ['if', '(', 'res.status', '===', "'success'", ')', '{', 'return', "'データ: '", '+', 'res.data', '}', 'return', "'エラー: '", '+', 'res.message'],
+                distractorTokens: ['try', 'catch', 'switch', 'res.type'],
+              },
+            ],
+          },
       },
       {
         id: 'ts-union-narrowing-2',
@@ -240,6 +258,30 @@ function getArea(shape: Shape): number {
 
 console.log(getArea({ kind: "circle", radius: 5 }));               // ~78.54
 console.log(getArea({ kind: "rectangle", width: 4, height: 6 }));  // 24`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `____0\n\n____1\n\nfunction getArea(shape: Shape): number {\n  switch (shape.kind) {\n    ____2\n    default:\n      return assertNever(shape);\n  }\n}\n\nconsole.log(getArea({ kind: "circle", radius: 5 }));\nconsole.log(getArea({ kind: "rectangle", width: 4, height: 6 }));`,
+            blanks: [
+              {
+                id: 'shape-type',
+                label: 'Shape型',
+                correctTokens: ['type', 'Shape', '=', '{', 'kind', ':', "'circle'", ';', 'radius', ':', 'number', '}', '|', '{', 'kind', ':', "'rectangle'", ';', 'width', ':', 'number', ';', 'height', ':', 'number', '}'],
+                distractorTokens: ['typeof', 'instanceof', 'enum', 'any'],
+              },
+              {
+                id: 'assert-never',
+                label: 'assertNever',
+                correctTokens: ['function', 'assertNever', '(', 'x', ':', 'never', ')', ':', 'never', '{', 'throw', 'new', 'Error', '(', '`Unexpected: ${x}`', ')', '}'],
+                distractorTokens: ['void', 'undefined', 'unknown', 'any'],
+              },
+              {
+                id: 'switch-cases',
+                label: 'caseブロック',
+                correctTokens: ['case', "'circle'", ':', 'return', 'Math.PI', '*', 'shape.radius', '**', '2', 'case', "'rectangle'", ':', 'return', 'shape.width', '*', 'shape.height'],
+                distractorTokens: ['shape.size', 'shape.area', 'Math.sqrt', 'shape.length'],
+              },
+            ],
+          },
       },
     ],
   },

--- a/apps/web/src/content/typescript/steps/ts-utility-types.ts
+++ b/apps/web/src/content/typescript/steps/ts-utility-types.ts
@@ -224,6 +224,24 @@ const user: UserRecord = {
 };
 const profile = toPublicProfile(user);
 console.log(profile); // { id: 1, name: "Alice", email: "alice@example.com", role: "user" }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `interface UserRecord {\n  id: number;\n  name: string;\n  email: string;\n  passwordHash: string;\n  role: 'admin' | 'user';\n}\n\n____0\n\nfunction toPublicProfile(user: UserRecord): PublicProfile {\n  ____1\n}\n\nconst user: UserRecord = {\n  id: 1, name: "Alice", email: "alice@example.com",\n  passwordHash: "hash_secret", role: "user",\n};\nconsole.log(toPublicProfile(user));`,
+            blanks: [
+              {
+                id: 'public-profile',
+                label: 'PublicProfile型',
+                correctTokens: ['type', 'PublicProfile', '=', 'Omit', '<', 'UserRecord', ',', "'passwordHash'", '>'],
+                distractorTokens: ['Pick', 'Partial', 'Exclude', 'Extract'],
+              },
+              {
+                id: 'to-profile',
+                label: '変換関数',
+                correctTokens: ['const', '{', 'passwordHash', ',', '...profile', '}', '=', 'user', 'return', 'profile'],
+                distractorTokens: ['delete user.passwordHash', 'Object.keys', 'JSON.parse', 'structuredClone'],
+              },
+            ],
+          },
       },
       {
         id: 'ts-utility-types-2',
@@ -251,6 +269,24 @@ function hasPermission(role: Role, perm: Permission): boolean {
 console.log(hasPermission("admin", "delete"));  // true
 console.log(hasPermission("viewer", "write"));  // false
 console.log(hasPermission("editor", "read"));   // true`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `type Role = 'admin' | 'editor' | 'viewer';\ntype Permission = 'read' | 'write' | 'delete';\n\n____0\n\nfunction hasPermission(role: Role, perm: Permission): boolean {\n  ____1\n}\n\nconsole.log(hasPermission("admin", "delete"));\nconsole.log(hasPermission("viewer", "write"));\nconsole.log(hasPermission("editor", "read"));`,
+            blanks: [
+              {
+                id: 'role-permissions',
+                label: 'permissions定義',
+                correctTokens: ['const', 'rolePermissions', ':', 'Record<Role, Permission[]>', '=', '{', 'admin', ':', '[', "'read'", ',', "'write'", ',', "'delete'", ']', ',', 'editor', ':', '[', "'read'", ',', "'write'", ']', ',', 'viewer', ':', '[', "'read'", ']', '}'],
+                distractorTokens: ['Map', 'Object', 'Partial', 'Required'],
+              },
+              {
+                id: 'has-permission',
+                label: 'hasPermission',
+                correctTokens: ['return', 'rolePermissions[role]', '.includes', '(', 'perm', ')'],
+                distractorTokens: ['rolePermissions.get', 'rolePermissions.has', 'indexOf', 'find'],
+              },
+            ],
+          },
       },
     ],
   },


### PR DESCRIPTION
## Summary
- TypeScript基礎コース6ステップ×2パターン = 全12パターンに `mobilePuzzle` (type: 'multi') を追加
- ts-types: Product型定義+formatProduct / UserStatus+switch
- ts-functions: filterByCondition<T>シグネチャ / applyTwice型注釈
- ts-objects: Article interface+createDraft / AdminUser extends+isAdmin
- ts-union-narrowing: ApiResponse判別共用体 / Shape+assertNever+getArea (3ブランク)
- ts-generics: Result<T>+succeed/fail+unwrap (3ブランク) / findById+groupById extends制約
- ts-utility-types: Omit<PublicProfile> / Record<Role>+hasPermission

## Test plan
- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run test` 698テスト全PASS
- [x] `npm run build` 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)