### PR TITLE
feat: Challenge モバイルパズル M6（TypeScript×React 8パターン）

### DIFF
--- a/apps/web/src/content/typescript-react/steps/ts-react-events.ts
+++ b/apps/web/src/content/typescript-react/steps/ts-react-events.ts
@@ -205,6 +205,30 @@ function ContactForm() {
     </form>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useState } from 'react'\\nimport type { ChangeEvent, FormEvent } from 'react'\\n\\n____0\\n\\nfunction ContactForm() {\\n  const [form, setForm] = useState<FormData>({ name: '', email: '' })\\n\\n  ____1\\n\\n  ____2\\n\\n  return (\\n    <form onSubmit={handleSubmit}>\\n      <input name="name" value={form.name} onChange={handleChange} />\\n      <input name="email" value={form.email} onChange={handleChange} />\\n      <button type="submit">送信</button>\\n    </form>\\n  )\\n}`,
+            blanks: [
+              {
+                id: 'form-data',
+                label: 'FormData型',
+                correctTokens: ['interface', 'FormData', '{', 'name', ':', 'string', ';', 'email', ':', 'string', '}'],
+                distractorTokens: ['MouseEvent', 'KeyboardEvent', 'any', 'Event'],
+              },
+              {
+                id: 'change-handler',
+                label: 'onChange',
+                correctTokens: ['const', 'handleChange', '=', '(e: ChangeEvent<HTMLInputElement>)', '=>', '{', 'setForm(prev =>', '({ ...prev,', '[e.target.name]: e.target.value', '}))', '}'],
+                distractorTokens: ['MouseEvent', 'KeyboardEvent', 'onClick', 'onBlur'],
+              },
+              {
+                id: 'submit-handler',
+                label: 'onSubmit',
+                correctTokens: ['const', 'handleSubmit', '=', '(e: FormEvent<HTMLFormElement>)', '=>', '{', 'e.preventDefault()', 'console.log(form)', '}'],
+                distractorTokens: ['MouseEvent', 'Event', 'e.stopPropagation()', 'onBlur'],
+              },
+            ],
+          },
       },
       {
         id: 'ts-react-events-2',
@@ -243,6 +267,24 @@ function SearchField() {
     </div>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useState } from 'react'\\nimport type { ChangeEvent, KeyboardEvent } from 'react'\\n\\nconst DUMMY_DATA = ['TypeScript', 'React', 'JavaScript', 'CSS', 'HTML', 'Node.js']\\n\\nfunction SearchField() {\\n  const [query, setQuery] = useState('')\\n  const [results, setResults] = useState<string[]>([])\\n\\n  ____0\\n\\n  ____1\\n\\n  return (\\n    <div>\\n      <input value={query} onChange={handleChange} onKeyDown={handleKeyDown}\\n        placeholder="Enterで検索、Escapeでクリア" />\\n      <ul>\\n        {results.map(r => <li key={r}>{r}</li>)}\\n      </ul>\\n    </div>\\n  )\\n}`,
+            blanks: [
+              {
+                id: 'search-change',
+                label: 'onChange',
+                correctTokens: ['const', 'handleChange', '=', '(e: ChangeEvent<HTMLInputElement>)', '=>', '{', 'setQuery(e.target.value)', '}'],
+                distractorTokens: ['MouseEvent', 'FocusEvent', 'onClick', 'onBlur'],
+              },
+              {
+                id: 'search-keydown',
+                label: 'onKeyDown',
+                correctTokens: ['const', 'handleKeyDown', '=', '(e: KeyboardEvent<HTMLInputElement>)', '=>', '{', "if (e.key === 'Enter')", '{', 'setResults(', 'DUMMY_DATA.filter(d =>', 'd.toLowerCase().includes(query.toLowerCase()))', ')', '}', "if (e.key === 'Escape')", '{', "setQuery('')", 'setResults([])', '}', '}'],
+                distractorTokens: ['MouseEvent', 'FocusEvent', 'e.keyCode', 'onBlur'],
+              },
+            ],
+          },
       },
     ],
   },

--- a/apps/web/src/content/typescript-react/steps/ts-react-hooks.ts
+++ b/apps/web/src/content/typescript-react/steps/ts-react-hooks.ts
@@ -231,6 +231,24 @@ import type { ReactNode } from 'react'
 function ThemeProvider({ children }: { children: ReactNode }) {
   // TODO: theme state と toggleTheme を実装
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { createContext, useContext, useState } from 'react'\\nimport type { ReactNode } from 'react'\\n\\n____0\\n\\nconst ThemeContext = createContext<ThemeContextType | null>(null)\\n\\n____1\\n\\nfunction ThemeProvider({ children }: { children: ReactNode }) {\\n  const [theme, setTheme] = useState<'light' | 'dark'>('light')\\n  const toggleTheme = () => setTheme(t => t === 'light' ? 'dark' : 'light')\\n  return (\\n    <ThemeContext.Provider value={{ theme, toggleTheme }}>\\n      {children}\\n    </ThemeContext.Provider>\\n  )\\n}`,
+            blanks: [
+              {
+                id: 'theme-context-type',
+                label: 'Context型',
+                correctTokens: ['interface', 'ThemeContextType', '{', 'theme', ':', "'light' | 'dark'", ';', 'toggleTheme', ':', '() => void', '}'],
+                distractorTokens: ['useState', 'useReducer', 'any', 'string'],
+              },
+              {
+                id: 'use-theme',
+                label: 'useTheme',
+                correctTokens: ['function', 'useTheme', '()', ':', 'ThemeContextType', '{', 'const', 'ctx', '=', 'useContext(ThemeContext)', 'if', '(!ctx)', 'throw', "new Error('ThemeProvider外です')", 'return', 'ctx', '}'],
+                distractorTokens: ['null', 'useReducer', 'useState', 'createContext'],
+              },
+            ],
+          },
       },
       {
         id: 'ts-react-hooks-2',
@@ -265,6 +283,24 @@ function App() {
     </div>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useState } from 'react'\\n\\nfunction useLocalStorage<T>(key: string, initialValue: T): [T, (value: T) => void] {\\n  ____0\\n\\n  ____1\\n\\n  return [storedValue, setValue]\\n}\\n\\nfunction App() {\\n  const [name, setName] = useLocalStorage<string>('name', '')\\n  return <input value={name} onChange={e => setName(e.target.value)} />\\n}`,
+            blanks: [
+              {
+                id: 'hook-state',
+                label: 'state初期化',
+                correctTokens: ['const', '[storedValue, setStoredValue]', '=', 'useState<T>', '(', '() => {', 'const item = localStorage.getItem(key)', 'return item ?', 'JSON.parse(item)', ':', 'initialValue', '}', ')'],
+                distractorTokens: ['sessionStorage', 'useRef', 'useEffect', 'any'],
+              },
+              {
+                id: 'set-value',
+                label: 'setValue',
+                correctTokens: ['const', 'setValue', '=', '(value: T)', '=>', '{', 'setStoredValue(value)', 'localStorage.setItem(key, JSON.stringify(value))', '}'],
+                distractorTokens: ['sessionStorage', 'useRef', 'JSON.parse', 'getItem'],
+              },
+            ],
+          },
       },
     ],
   },

--- a/apps/web/src/content/typescript-react/steps/ts-react-props.ts
+++ b/apps/web/src/content/typescript-react/steps/ts-react-props.ts
@@ -184,6 +184,24 @@ function Card({ title, description, children }: CardProps) {
 // 動作確認
 // <Card title="React学習">本文テキスト</Card>
 // <Card title="TypeScript" description="型安全な開発" />`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import type { ReactNode } from 'react'\\n\\n____0\\n\\n____1 {\\n  return (\\n    <div>\\n      <h2>{title}</h2>\\n      {description && <p>{description}</p>}\\n      {children}\\n    </div>\\n  )\\n}`,
+            blanks: [
+              {
+                id: 'card-props',
+                label: 'CardProps定義',
+                correctTokens: ['interface', 'CardProps', '{', 'title', ':', 'string', ';', 'description?', ':', 'string', ';', 'children?', ':', 'ReactNode', '}'],
+                distractorTokens: ['any', 'Element', 'FC', 'HTMLElement'],
+              },
+              {
+                id: 'card-signature',
+                label: 'Card関数',
+                correctTokens: ['function', 'Card', '(', '{', 'title', ',', 'description', ',', 'children', '}', ':', 'CardProps', ')'],
+                distractorTokens: ['Props', 'React.FC', 'const', '=>'],
+              },
+            ],
+          },
       },
       {
         id: 'ts-react-props-2',
@@ -209,6 +227,24 @@ function IconButton({ icon, label, ...rest }: IconButtonProps) {
 
 // 動作確認（disabled などネイティブPropsが使える）
 // <IconButton icon="★" label="お気に入り" disabled />`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import type { ComponentProps, ReactNode } from 'react'\\n\\n____0\\n\\nfunction IconButton({ icon, label, ...rest }: IconButtonProps) {\\n  ____1\\n}`,
+            blanks: [
+              {
+                id: 'iconbutton-props',
+                label: 'Props定義',
+                correctTokens: ['interface', 'IconButtonProps', 'extends', "ComponentProps<'button'>", '{', 'icon', ':', 'ReactNode', ';', 'label', ':', 'string', '}'],
+                distractorTokens: ['HTMLAttributes', 'ButtonHTMLAttributes', 'FC', 'DetailedHTMLProps'],
+              },
+              {
+                id: 'iconbutton-return',
+                label: 'return文',
+                correctTokens: ['return', '(', '<button {...rest}>', '<span>{icon}</span>', '{label}', '</button>', ')'],
+                distractorTokens: ['<div>', '<a>', 'onClick', 'className'],
+              },
+            ],
+          },
       },
     ],
   },

--- a/apps/web/src/content/typescript-react/steps/ts-react-state.ts
+++ b/apps/web/src/content/typescript-react/steps/ts-react-state.ts
@@ -209,6 +209,24 @@ function UserProfile() {
     </div>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `interface User {\\n  id: number;\\n  name: string;\\n  email: string;\\n}\\n\\nfunction UserProfile() {\\n  ____0\\n\\n  ____1\\n\\n  return (\\n    <div>\\n      {user ? <p>{user.name} ({user.email})</p> : <p>ログインしてください</p>}\\n      <button onClick={handleLogin}>ログイン</button>\\n      <button onClick={handleLogout}>ログアウト</button>\\n    </div>\\n  )\\n}`,
+            blanks: [
+              {
+                id: 'user-state',
+                label: 'useState定義',
+                correctTokens: ['const', '[user, setUser]', '=', 'useState', '<User | null>', '(', 'null', ')'],
+                distractorTokens: ['undefined', 'any', 'string', 'useRef'],
+              },
+              {
+                id: 'login-logout',
+                label: 'login/logout',
+                correctTokens: ['function', 'handleLogin', '()', '{', 'setUser', '(', "{ id: 1, name: 'Alice', email: 'alice@example.com' }", ')', '}', 'function', 'handleLogout', '()', '{', 'setUser', '(', 'null', ')', '}'],
+                distractorTokens: ['dispatch', 'setState', 'resetUser', 'useRef'],
+              },
+            ],
+          },
       },
       {
         id: 'ts-react-state-2',
@@ -241,6 +259,24 @@ function LoginForm() {
     </form>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `type FormState = {\\n  email: string;\\n  password: string;\\n  error: string | null;\\n}\\n\\n____0\\n\\nfunction reducer(state: FormState, action: FormAction): FormState {\\n  ____1\\n}\\n\\nfunction LoginForm() {\\n  const [state, dispatch] = useReducer(reducer, { email: '', password: '', error: null })\\n  return (\\n    <form>\\n      <input value={state.email}\\n        onChange={e => dispatch({ type: 'SET_EMAIL', email: e.target.value })} />\\n      <input type="password" value={state.password}\\n        onChange={e => dispatch({ type: 'SET_PASSWORD', password: e.target.value })} />\\n    </form>\\n  )\\n}`,
+            blanks: [
+              {
+                id: 'form-action',
+                label: 'FormAction型',
+                correctTokens: ['type', 'FormAction', '=', "{ type: 'SET_EMAIL'; email: string }", '|', "{ type: 'SET_PASSWORD'; password: string }", '|', "{ type: 'CLEAR_ERROR' }"],
+                distractorTokens: ['useState', 'setState', 'enum', 'any'],
+              },
+              {
+                id: 'reducer-body',
+                label: 'reducer実装',
+                correctTokens: ['switch', '(action.type)', '{', "case 'SET_EMAIL':", 'return', '{ ...state,', 'email: action.email }', "case 'SET_PASSWORD':", 'return', '{ ...state,', 'password: action.password }', "case 'CLEAR_ERROR':", 'return', '{ ...state,', 'error: null }', 'default:', 'return', 'state', '}'],
+                distractorTokens: ['useState', 'dispatch', 'action.value', 'any'],
+              },
+            ],
+          },
       },
     ],
   },


### PR DESCRIPTION
## Summary
- TypeScript×React コース全4ステップ・8パターンに `mobilePuzzle` (type: 'multi') を追加
  - ts-react-props: CardProps定義 + IconButton extends パターン
  - ts-react-state: useState<User|null> + useReducer FormAction パターン
  - ts-react-hooks: ThemeContext型付き + useLocalStorage ジェネリクス パターン
  - ts-react-events: ChangeEvent/FormEvent + KeyboardEvent パターン
- 4ファイル変更、+150行

## Test plan
- [x] typecheck 通過
- [x] lint 通過
- [x] test 698件 PASS
- [x] build 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)