### PR TITLE
feat: Reactモダン 全12パターンに mobilePuzzle 追加（M7）

### DIFF
--- a/apps/web/src/content/react-modern/steps/concurrent-features.ts
+++ b/apps/web/src/content/react-modern/steps/concurrent-features.ts
@@ -222,6 +222,24 @@ function SearchApp() {
     </div>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useState, useTransition } from 'react'\n\nconst ITEMS = Array.from({ length: 500 }, (_, i) => ({ id: i, name: "Item " + i }))\n\nfunction SearchApp() {\n  const [query, setQuery] = useState('')\n  const [results, setResults] = useState(ITEMS)\n  ____0\n\n  function handleChange(e) {\n    ____1\n  }\n\n  return (\n    <div>\n      <input value={query} onChange={handleChange} placeholder="検索..." />\n      <ul className={isPending ? 'opacity-50' : ''}>\n        {results.map(item => (\n          <li key={item.id}>{item.name}</li>\n        ))}\n      </ul>\n    </div>\n  )\n}`,
+            blanks: [
+              {
+                id: 'use-transition',
+                label: 'useTransition',
+                correctTokens: ['const', '[isPending, startTransition]', '=', 'useTransition()'],
+                distractorTokens: ['useDeferredValue', 'useState', 'useCallback', 'useMemo'],
+              },
+              {
+                id: 'handle-change',
+                label: 'handleChange',
+                correctTokens: ['setQuery(e.target.value)', 'startTransition', '(', '() =>', '{', 'setResults(ITEMS.filter(item => item.name.includes(e.target.value)))', '}', ')'],
+                distractorTokens: ['useDeferredValue', 'useCallback', 'setTimeout', 'useMemo'],
+              },
+            ],
+          },
       },
       {
         id: 'concurrent-features-2',
@@ -258,6 +276,24 @@ function App() {
     </div>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useState, useDeferredValue, memo } from 'react'\n\n____0\n\nfunction App() {\n  const [query, setQuery] = useState('')\n  ____1\n\n  return (\n    <div>\n      <input value={query} onChange={e => setQuery(e.target.value)} />\n      {deferredQuery !== query && <p>更新中...</p>}\n      <SlowList text={deferredQuery} />\n    </div>\n  )\n}`,
+            blanks: [
+              {
+                id: 'memo-wrap',
+                label: 'memo化',
+                correctTokens: ['const', 'SlowList', '=', 'memo', '(', 'function SlowList({ text }) {', 'const items = Array.from({ length: 200 }, (_, i) => `${text} - item ${i}`)', 'return <ul>{items.map((item, i) => <li key={i}>{item}</li>)}</ul>', '}', ')'],
+                distractorTokens: ['useCallback', 'useRef', 'useMemo', 'forwardRef'],
+              },
+              {
+                id: 'deferred-value',
+                label: 'useDeferredValue',
+                correctTokens: ['const', 'deferredQuery', '=', 'useDeferredValue', '(', 'query', ')'],
+                distractorTokens: ['useTransition', 'startTransition', 'useCallback', 'useRef'],
+              },
+            ],
+          },
       },
     ],
   },

--- a/apps/web/src/content/react-modern/steps/error-boundary.ts
+++ b/apps/web/src/content/react-modern/steps/error-boundary.ts
@@ -236,6 +236,30 @@ class ErrorBoundary extends React.Component {
     return this.props.children
   }
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `class ErrorBoundary extends React.Component {\n  constructor(props) {\n    super(props)\n    this.state = { hasError: false, error: null }\n  }\n\n  static getDerivedStateFromError(error) {\n    ____0\n  }\n\n  componentDidCatch(error, info) {\n    ____1\n  }\n\n  handleReset = () => {\n    ____2\n  }\n\n  render() {\n    if (this.state.hasError) {\n      return (\n        <div>\n          <p>エラー: {this.state.error?.message}</p>\n          <button onClick={this.handleReset}>再試行</button>\n        </div>\n      )\n    }\n    return this.props.children\n  }\n}`,
+            blanks: [
+              {
+                id: 'derived-state',
+                label: 'エラー検知',
+                correctTokens: ['return', '{', 'hasError', ':', 'true', ',', 'error', '}'],
+                distractorTokens: ['componentDidMount', 'shouldComponentUpdate', 'useEffect', 'false'],
+              },
+              {
+                id: 'did-catch',
+                label: 'エラーログ',
+                correctTokens: ['console.error', '(', 'error', ',', 'info.componentStack', ')'],
+                distractorTokens: ['componentDidMount', 'useEffect', 'setState', 'console.warn'],
+              },
+              {
+                id: 'handle-reset',
+                label: 'リセット',
+                correctTokens: ['this.setState', '(', '{', 'hasError', ':', 'false', ',', 'error', ':', 'null', '}', ')'],
+                distractorTokens: ['useState', 'setState', 'useEffect', 'forceUpdate'],
+              },
+            ],
+          },
       },
       {
         id: 'error-boundary-2',
@@ -273,6 +297,24 @@ function App() {
     </div>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `class ErrorBoundary extends React.Component {\n  constructor(props) {\n    super(props)\n    this.state = { hasError: false }\n  }\n\n  ____0\n\n  render() {\n    ____1\n  }\n}\n\nfunction App() {\n  return (\n    <div>\n      <ErrorBoundary fallback={<p>ヘッダーエラー</p>}>\n        <Header />\n      </ErrorBoundary>\n      <ErrorBoundary>\n        <Footer />\n      </ErrorBoundary>\n    </div>\n  )\n}`,
+            blanks: [
+              {
+                id: 'derived-state',
+                label: 'エラー検知',
+                correctTokens: ['static', 'getDerivedStateFromError', '(error)', '{', 'return', '{', 'hasError', ':', 'true', '}', '}'],
+                distractorTokens: ['componentDidCatch', 'componentDidMount', 'useEffect', 'try', 'Suspense'],
+              },
+              {
+                id: 'render-fallback',
+                label: 'fallback分岐',
+                correctTokens: ['if', '(this.state.hasError)', '{', 'return', 'this.props.fallback', '??', '<p>予期しないエラーが発生しました</p>', '}', 'return', 'this.props.children'],
+                distractorTokens: ['||', '&&', 'try/catch', 'Suspense', 'componentDidCatch'],
+              },
+            ],
+          },
       },
     ],
   },

--- a/apps/web/src/content/react-modern/steps/forward-ref.ts
+++ b/apps/web/src/content/react-modern/steps/forward-ref.ts
@@ -263,6 +263,24 @@ function SearchForm() {
     </form>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { forwardRef, useRef } from 'react'\n\n____0\n\nfunction SearchForm() {\n  const inputRef = useRef(null)\n\n  function handleSubmit(e) {\n    e.preventDefault()\n    const query = e.target.search.value\n    console.log('検索:', query)\n    e.target.reset()\n    ____1\n  }\n\n  return (\n    <form onSubmit={handleSubmit}>\n      <Input ref={inputRef} name="search" placeholder="検索..." />\n      <button type="submit">検索</button>\n    </form>\n  )\n}`,
+            blanks: [
+              {
+                id: 'forward-ref-wrap',
+                label: 'forwardRef',
+                correctTokens: ['const', 'Input', '=', 'forwardRef', '(', 'function Input(props, ref) {', 'return', '<input ref={ref} {...props} />', '}', ')'],
+                distractorTokens: ['useRef', 'createRef', 'useCallback', 'memo'],
+              },
+              {
+                id: 'focus-call',
+                label: 'focus呼出',
+                correctTokens: ['inputRef.current', '?.', 'focus()'],
+                distractorTokens: ['useRef', 'blur()', 'click()', 'value'],
+              },
+            ],
+          },
       },
       {
         id: 'forward-ref-2',
@@ -305,6 +323,24 @@ function App() {
     </div>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { forwardRef, useRef, useImperativeHandle } from 'react'\n\nconst VideoPlayer = forwardRef(function VideoPlayer({ src }, ref) {\n  const videoRef = useRef(null)\n\n  ____0\n\n  return <video ref={videoRef} src={src} />\n})\n\nfunction App() {\n  const playerRef = useRef(null)\n\n  return (\n    <div>\n      <VideoPlayer ref={playerRef} src="https://example.com/video.mp4" />\n      ____1\n    </div>\n  )\n}`,
+            blanks: [
+              {
+                id: 'imperative-handle',
+                label: 'useImperativeHandle',
+                correctTokens: ['useImperativeHandle', '(', 'ref', ',', '() => ({', 'play:', '() => videoRef.current.play(),', 'pause:', '() => videoRef.current.pause()', '})', ')'],
+                distractorTokens: ['useRef', 'createRef', 'useCallback', 'useEffect'],
+              },
+              {
+                id: 'control-buttons',
+                label: '制御ボタン',
+                correctTokens: ['<button', 'onClick={() => playerRef.current.play()}>再生</button>', '<button', 'onClick={() => playerRef.current.pause()}>一時停止</button>'],
+                distractorTokens: ['stop()', 'reset()', 'onClick={play}', 'useRef'],
+              },
+            ],
+          },
       },
     ],
   },

--- a/apps/web/src/content/react-modern/steps/portals.ts
+++ b/apps/web/src/content/react-modern/steps/portals.ts
@@ -235,6 +235,24 @@ function App() {
     </div>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { createPortal } from 'react-dom'\nimport { useState } from 'react'\n\nfunction Modal({ isOpen, onClose, children }) {\n  ____0\n\n  ____1\n}\n\nfunction App() {\n  const [isOpen, setIsOpen] = useState(false)\n  return (\n    <div style={{ overflow: 'hidden', height: '100px' }}>\n      <button onClick={() => setIsOpen(true)}>モーダルを開く</button>\n      <Modal isOpen={isOpen} onClose={() => setIsOpen(false)}>\n        <h2>モーダル</h2>\n      </Modal>\n    </div>\n  )\n}`,
+            blanks: [
+              {
+                id: 'early-return',
+                label: '早期return',
+                correctTokens: ['if', '(!isOpen)', 'return', 'null'],
+                distractorTokens: ['if (isOpen)', 'return false', 'return undefined', 'throw'],
+              },
+              {
+                id: 'create-portal',
+                label: 'createPortal',
+                correctTokens: ['return', 'createPortal', '(', '<div className="overlay" onClick={onClose}>', '<div className="content" onClick={(e) => e.stopPropagation()}>', '{children}', '<button onClick={onClose}>閉じる</button>', '</div>', '</div>', ',', 'document.body', ')'],
+                distractorTokens: ['render', 'appendChild', 'document.getElementById', 'e.preventDefault()'],
+              },
+            ],
+          },
       },
       {
         id: 'portals-2',
@@ -277,6 +295,24 @@ function App() {
     </div>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useRef, useEffect, useState } from 'react'\nimport { createPortal } from 'react-dom'\n\nfunction DynamicPortal({ children }) {\n  const [mounted, setMounted] = useState(false)\n  const containerRef = useRef(null)\n\n  useEffect(() => {\n    ____0\n  }, [])\n\n  ____1\n}\n\nfunction App() {\n  return (\n    <div>\n      <DynamicPortal>\n        <p>動的コンテナにレンダリングされた要素</p>\n      </DynamicPortal>\n    </div>\n  )\n}`,
+            blanks: [
+              {
+                id: 'effect-body',
+                label: 'Effect本体',
+                correctTokens: ['containerRef.current', '=', "document.createElement('div')", 'document.body.appendChild(containerRef.current)', 'setMounted(true)', 'return', '() => {', 'document.body.removeChild(containerRef.current)', '}'],
+                distractorTokens: ['useRef', 'useState', 'innerHTML', 'render'],
+              },
+              {
+                id: 'render-portal',
+                label: 'Portal描画',
+                correctTokens: ['if', '(!mounted)', 'return', 'null', 'return', 'createPortal', '(children,', 'containerRef.current)'],
+                distractorTokens: ['render', 'appendChild', 'removeChild', 'useRef'],
+              },
+            ],
+          },
       },
     ],
   },

--- a/apps/web/src/content/react-modern/steps/suspense-lazy.ts
+++ b/apps/web/src/content/react-modern/steps/suspense-lazy.ts
@@ -209,6 +209,24 @@ function App() {
     </Routes>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { Suspense, lazy } from 'react'\nimport { Routes, Route } from 'react-router-dom'\n\n____0\n\nfunction App() {\n  return (\n    ____1\n  )\n}`,
+            blanks: [
+              {
+                id: 'lazy-imports',
+                label: 'lazy定義',
+                correctTokens: ['const', 'HomePage', '=', "lazy(() => import('./pages/HomePage'))", 'const', 'AboutPage', '=', "lazy(() => import('./pages/AboutPage'))", 'const', 'ContactPage', '=', "lazy(() => import('./pages/ContactPage'))"],
+                distractorTokens: ['require', 'useEffect', 'useState', 'memo'],
+              },
+              {
+                id: 'suspense-routes',
+                label: 'Suspense+Routes',
+                correctTokens: ['<Suspense fallback={<p>読み込み中...</p>}>', '<Routes>', '<Route path="/" element={<HomePage />} />', '<Route path="/about" element={<AboutPage />} />', '<Route path="/contact" element={<ContactPage />} />', '</Routes>', '</Suspense>'],
+                distractorTokens: ['<ErrorBoundary>', '<Provider>', 'fallback=""', 'children'],
+              },
+            ],
+          },
       },
       {
         id: 'suspense-lazy-2',
@@ -236,6 +254,24 @@ function App() {
     <div>ここに実装</div>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { Suspense, lazy } from 'react'\n\n____0\n\nfunction App() {\n  return (\n    ____1\n  )\n}`,
+            blanks: [
+              {
+                id: 'lazy-imports',
+                label: 'lazy定義',
+                correctTokens: ['const', 'AppHeader', '=', "lazy(() => import('./AppHeader'))", 'const', 'MainContent', '=', "lazy(() => import('./MainContent'))"],
+                distractorTokens: ['require', 'useEffect', 'useState', 'memo'],
+              },
+              {
+                id: 'nested-suspense',
+                label: 'Suspenseネスト',
+                correctTokens: ['<Suspense fallback={<p>ヘッダー読み込み中...</p>}>', '<AppHeader />', '<Suspense fallback={<p>コンテンツ読み込み中...</p>}>', '<MainContent />', '</Suspense>', '</Suspense>'],
+                distractorTokens: ['<ErrorBoundary>', 'fallback=""', 'children', '<Provider>'],
+              },
+            ],
+          },
       },
     ],
   },

--- a/apps/web/src/content/react-modern/steps/use-optimistic.ts
+++ b/apps/web/src/content/react-modern/steps/use-optimistic.ts
@@ -247,6 +247,24 @@ function LikeButton({ post, toggleLike }) {
     </button>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useOptimistic, useTransition } from 'react'\n\nfunction LikeButton({ post, toggleLike }) {\n  const [isPending, startTransition] = useTransition()\n  ____0\n\n  function handleClick() {\n    startTransition(async () => {\n      ____1\n    })\n  }\n\n  return (\n    <button onClick={handleClick} disabled={isPending}>\n      {optimisticPost.liked ? '❤️' : '🤍'} {optimisticPost.likes}\n    </button>\n  )\n}`,
+            blanks: [
+              {
+                id: 'use-optimistic',
+                label: 'useOptimistic',
+                correctTokens: ['const', '[optimisticPost, addOptimisticLike]', '=', 'useOptimistic', '(', 'post', ',', '(state) => ({', '...state,', 'likes: state.likes + 1,', 'liked: !state.liked', '})', ')'],
+                distractorTokens: ['useState', 'useReducer', 'setState', 'dispatch'],
+              },
+              {
+                id: 'optimistic-update',
+                label: '楽観的更新',
+                correctTokens: ['addOptimisticLike()', 'await', 'toggleLike(post.id)'],
+                distractorTokens: ['setState', 'dispatch', 'useState', 'useReducer'],
+              },
+            ],
+          },
       },
       {
         id: 'use-optimistic-2',
@@ -290,6 +308,24 @@ function TodoList({ todos, createTodo }) {
     </div>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useOptimistic } from 'react'\n\nfunction TodoList({ todos, createTodo }) {\n  ____0\n\n  async function handleSubmit(e) {\n    e.preventDefault()\n    const title = e.target.title.value\n    e.target.reset()\n    addOptimisticTodo(title)\n    await createTodo(title)\n  }\n\n  return (\n    <div>\n      <ul>\n        {optimisticTodos.map((todo) => (\n          ____1\n        ))}\n      </ul>\n      <form onSubmit={handleSubmit}>\n        <input name="title" placeholder="新しい Todo" />\n        <button type="submit">追加</button>\n      </form>\n    </div>\n  )\n}`,
+            blanks: [
+              {
+                id: 'use-optimistic',
+                label: 'useOptimistic',
+                correctTokens: ['const', '[optimisticTodos, addOptimisticTodo]', '=', 'useOptimistic', '(', 'todos', ',', '(state, title) => [', '...state,', '{', 'id: `temp-${Date.now()}`,', 'title,', 'pending: true', '}', ']', ')'],
+                distractorTokens: ['useState', 'useTransition', 'filter', 'reduce'],
+              },
+              {
+                id: 'pending-item',
+                label: 'pending表示',
+                correctTokens: ['<li', 'key={todo.id}', "className={todo.pending ? 'opacity-50' : ''}>", '{todo.title}', '</li>'],
+                distractorTokens: ['<div>', 'className', 'hidden', 'disabled'],
+              },
+            ],
+          },
       },
     ],
   },


### PR DESCRIPTION
## Summary
- v4roadmap01 M7 対応: react-modern コース 6ステップ × 2パターン全12ヶ所に `mobilePuzzle`（type: 'multi'）を追加
- モバイル環境でもチャレンジモードを触れるようになる
- 222 行追加（6ファイル）

## 対象パターン
- error-boundary (31): derived-state / did-catch / handle-reset / render-fallback
- suspense-lazy (32): lazy-imports / suspense-routes / nested-suspense
- concurrent-features (33): use-transition / handle-change / memo-wrap / deferred-value
- use-optimistic (34): use-optimistic / optimistic-update / pending-item
- portals (35): early-return / create-portal / effect-body / render-portal
- forward-ref (36): forward-ref-wrap / focus-call / imperative-handle / control-buttons

## CI
- [x] typecheck
- [x] lint
- [x] test (698/698 PASS)
- [x] build

## Test plan
- [ ] dev マージ後、Vercel Preview にてモバイル幅でチャレンジページの各パターンを開き、ブランクとトークンが表示されること
- [ ] 正答トークンで正解判定、ダミートークンが干渉しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)