### PR TITLE
feat: v4 M8 実務パターン 全8パターンに mobilePuzzle 追加

### DIFF
--- a/apps/web/src/content/react-patterns/steps/auth-flow.ts
+++ b/apps/web/src/content/react-patterns/steps/auth-flow.ts
@@ -288,6 +288,24 @@ export function AuthProvider({ children }) {
 export function useAuth() {
   // TODO: useContext で取得し、null チェック後に返す
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { createContext, useContext, useState } from 'react'\n\nconst AuthContext = createContext(null)\n\nexport function AuthProvider({ children }) {\n  const [user, setUser] = useState(null)\n  const login = async (email, password) => setUser({ id: '1', email })\n  const logout = () => setUser(null)\n\n  return (\n    <AuthContext.Provider value={____0}>\n      {children}\n    </AuthContext.Provider>\n  )\n}\n\nexport function useAuth() {\n  ____1\n}`,
+            blanks: [
+              {
+                id: 'provider-value',
+                label: 'Provider value',
+                correctTokens: ['{', 'user,', 'isAuthenticated:', '!!user,', 'login,', 'logout', '}'],
+                distractorTokens: ['useReducer', 'useState', 'localStorage', 'useRef'],
+              },
+              {
+                id: 'use-auth-hook',
+                label: 'useAuth hook',
+                correctTokens: ['const ctx', '=', 'useContext(AuthContext)', 'if (!ctx)', 'throw', "new Error('useAuth must be used within AuthProvider')", 'return', 'ctx'],
+                distractorTokens: ['useReducer', 'useState', 'localStorage', 'useRef'],
+              },
+            ],
+          },
       },
       {
         id: 'auth-flow-2',
@@ -332,6 +350,24 @@ function App() {
     </AuthProvider>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { Routes, Route, Navigate, useNavigate, useLocation } from 'react-router-dom'\nimport { useAuth } from './AuthContext'\n\nfunction ProtectedRoute({ children }) {\n  const { isAuthenticated } = useAuth()\n  const location = useLocation()\n\n  ____0\n\n  return children\n}\n\nfunction LoginPage() {\n  const { login } = useAuth()\n  const navigate = useNavigate()\n  const location = useLocation()\n\n  const handleSubmit = async (e) => {\n    e.preventDefault()\n    await login('user@example.com', 'password')\n    ____1\n  }\n\n  return <form onSubmit={handleSubmit}><button>ログイン</button></form>\n}`,
+            blanks: [
+              {
+                id: 'protected-route',
+                label: 'ProtectedRoute',
+                correctTokens: ['if', '(!isAuthenticated)', 'return', '<Navigate', 'to="/login"', 'state={{ from: location.pathname }}', 'replace', '/>'],
+                distractorTokens: ['useParams', 'Redirect', 'history.push', 'window.location'],
+              },
+              {
+                id: 'login-redirect',
+                label: 'ログイン後遷移',
+                correctTokens: ['const from', '=', "location.state?.from ?? '/dashboard'", 'navigate', '(from, { replace: true })'],
+                distractorTokens: ['useParams', 'window.location', 'history.push', 'Redirect'],
+              },
+            ],
+          },
       },
     ],
   },

--- a/apps/web/src/content/react-patterns/steps/infinite-scroll.ts
+++ b/apps/web/src/content/react-patterns/steps/infinite-scroll.ts
@@ -252,6 +252,24 @@ useEffect(() => {
     </div>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `function InfiniteList() {\n  const [items, setItems] = useState(generateItems(1, 10))\n  const [hasMore, setHasMore] = useState(true)\n  const [page, setPage] = useState(1)\n  const sentinelRef = useRef(null)\n\n  function generateItems(start, count) {\n    return Array.from({ length: count }, (_, i) => ({ id: start + i, name: "アイテム " + (start + i) }))\n  }\n\n  useEffect(() => {\n    ____0\n  }, [hasMore, page])\n\n  const loadMore = () => {\n    const newItems = generateItems(page * 10 + 1, 10)\n    setItems((prev) => [...prev, ...newItems])\n    setPage((p) => p + 1)\n    if (page >= 4) setHasMore(false)\n  }\n\n  return (\n    <div style={{ height: '400px', overflowY: 'auto' }}>\n      {items.map((item) => (<div key={item.id}>{item.name}</div>))}\n      ____1\n    </div>\n  )\n}`,
+            blanks: [
+              {
+                id: 'observer-setup',
+                label: 'Observer設定',
+                correctTokens: ['const observer', '=', 'new IntersectionObserver', '(', '(entries) => {', 'if (entries[0].isIntersecting && hasMore) loadMore()', '}', ')', 'if (sentinelRef.current) observer.observe(sentinelRef.current)', 'return', '() => observer.disconnect()'],
+                distractorTokens: ['MutationObserver', 'addEventListener', 'ResizeObserver', 'scroll'],
+              },
+              {
+                id: 'sentinel-element',
+                label: 'センチネル表示',
+                correctTokens: ['{hasMore', '&&', '<div ref={sentinelRef}>', '読み込み中...', '</div>', '}'],
+                distractorTokens: ['useRef', 'useState', 'hasLess', '!isLoading'],
+              },
+            ],
+          },
       },
       {
         id: 'infinite-scroll-2',
@@ -312,6 +330,24 @@ useEffect(() => {
     </div>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `function InfiniteListWithLoading() {\n  const [items, setItems] = useState([])\n  const [hasMore, setHasMore] = useState(true)\n  const [isLoading, setIsLoading] = useState(false)\n  const sentinelRef = useRef(null)\n\n  const loadMore = async () => {\n    if (isLoading || !hasMore) return\n    setIsLoading(true)\n    await new Promise((r) => setTimeout(r, 500))\n    setItems((prev) => [...prev, ...Array.from({ length: 10 }, (_, i) => ({ id: prev.length + i + 1 }))])\n    setIsLoading(false)\n  }\n\n  useEffect(() => {\n    const observer = new IntersectionObserver((entries) => {\n      ____0\n    }, ____1)\n    if (sentinelRef.current) observer.observe(sentinelRef.current)\n    return () => observer.disconnect()\n  }, [hasMore, isLoading])\n\n  return (\n    <div>\n      {items.map((item) => <div key={item.id}>Item {item.id}</div>)}\n      {isLoading && <p>読み込み中...</p>}\n      <div ref={sentinelRef} />\n    </div>\n  )\n}`,
+            blanks: [
+              {
+                id: 'loading-guard',
+                label: 'isLoading guard',
+                correctTokens: ['if', '(', 'entries[0].isIntersecting', '&&', '!isLoading', '&&', 'hasMore', ')', 'loadMore()'],
+                distractorTokens: ['MutationObserver', 'addEventListener', 'scroll', 'useState'],
+              },
+              {
+                id: 'root-margin',
+                label: 'rootMargin設定',
+                correctTokens: ['{', 'rootMargin:', "'0px 0px 200px 0px'", '}'],
+                distractorTokens: ['threshold:', 'root:', 'MutationObserver', 'scroll'],
+              },
+            ],
+          },
       },
     ],
   },

--- a/apps/web/src/content/react-patterns/steps/pagination.ts
+++ b/apps/web/src/content/react-patterns/steps/pagination.ts
@@ -273,6 +273,24 @@ function PaginatedList() {
     </div>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `const items = Array.from({ length: 23 }, (_, i) => ({ id: i + 1, name: "アイテム " + (i + 1) }))\nconst ITEMS_PER_PAGE = 5\n\nfunction PaginatedList() {\n  const [currentPage, setCurrentPage] = useState(1)\n\n  ____0\n\n  return (\n    <div>\n      <ul>\n        {currentItems.map((item) => (\n          <li key={item.id}>{item.name}</li>\n        ))}\n      </ul>\n      <button onClick={() => setCurrentPage((p) => p - 1)} ____1>前へ</button>\n      <span>{currentPage} / {totalPages}</span>\n      <button onClick={() => setCurrentPage((p) => p + 1)} disabled={currentPage >= totalPages}>次へ</button>\n    </div>\n  )\n}`,
+            blanks: [
+              {
+                id: 'page-calc',
+                label: 'ページ計算',
+                correctTokens: ['const totalPages', '=', 'Math.ceil', '(', 'items.length / ITEMS_PER_PAGE', ')', 'const startIndex', '=', '(currentPage - 1) * ITEMS_PER_PAGE', 'const currentItems', '=', 'items.slice(startIndex, startIndex + ITEMS_PER_PAGE)'],
+                distractorTokens: ['Math.floor', 'Math.round', 'splice', 'filter', 'forEach'],
+              },
+              {
+                id: 'prev-disabled',
+                label: '前へdisabled',
+                correctTokens: ['disabled={currentPage <= 1}'],
+                distractorTokens: ['disabled={!currentPage}', 'hidden', 'readOnly', 'disabled'],
+              },
+            ],
+          },
       },
       {
         id: 'pagination-2',
@@ -312,6 +330,24 @@ function PaginatedList() {
     </div>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useSearchParams } from 'react-router-dom'\n\nconst items = Array.from({ length: 30 }, (_, i) => "アイテム " + (i + 1))\nconst ITEMS_PER_PAGE = 8\n\nfunction PaginatedList() {\n  ____0\n\n  const totalPages = Math.ceil(items.length / ITEMS_PER_PAGE)\n  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE\n  const currentItems = items.slice(startIndex, startIndex + ITEMS_PER_PAGE)\n\n  return (\n    <div>\n      <ul>\n        {currentItems.map((item, i) => (<li key={i}>{item}</li>))}\n      </ul>\n      {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (\n        <button key={page} ____1>{page}</button>\n      ))}\n    </div>\n  )\n}`,
+            blanks: [
+              {
+                id: 'use-search-params',
+                label: 'useSearchParams',
+                correctTokens: ['const', '[searchParams, setSearchParams]', '=', 'useSearchParams()', 'const currentPage', '=', "Number(searchParams.get('page') ?? '1')"],
+                distractorTokens: ['useParams', 'useNavigate', 'useLocation', 'window.location'],
+              },
+              {
+                id: 'page-change',
+                label: 'ページ変更',
+                correctTokens: ['onClick={() => setSearchParams({ page: String(page) })}'],
+                distractorTokens: ['useNavigate', 'history.push', 'window.location', 'onChange'],
+              },
+            ],
+          },
       },
     ],
   },

--- a/apps/web/src/content/react-patterns/steps/rhf-zod.ts
+++ b/apps/web/src/content/react-patterns/steps/rhf-zod.ts
@@ -252,6 +252,24 @@ function LoginForm() {
     </form>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useForm } from 'react-hook-form'\nimport { zodResolver } from '@hookform/resolvers/zod'\nimport { z } from 'zod'\n\nconst schema = z.object({\n  email: z.string().email('有効なメールアドレス'),\n  password: z.string().min(8, '8文字以上'),\n})\n\ntype FormData = z.infer<typeof schema>\n\nfunction LoginForm() {\n  const { register, handleSubmit, formState: { errors } } = useForm<FormData>({\n    ____0\n  })\n\n  return (\n    <form onSubmit={handleSubmit((data) => console.log(data))}>\n      <input {...register('email')} placeholder="メール" />\n      ____1\n      <button type="submit">ログイン</button>\n    </form>\n  )\n}`,
+            blanks: [
+              {
+                id: 'zod-resolver',
+                label: 'zodResolver設定',
+                correctTokens: ['resolver:', 'zodResolver', '(', 'schema', ')'],
+                distractorTokens: ['yupResolver', 'useFormik', 'Formik', 'validate'],
+              },
+              {
+                id: 'error-display',
+                label: 'エラー表示',
+                correctTokens: ['{errors.email', '&&', '<p>', '{errors.email.message}', '</p>', '}'],
+                distractorTokens: ['errors.root', 'validate', 'useState', 'useForm'],
+              },
+            ],
+          },
       },
       {
         id: 'rhf-zod-2',
@@ -295,6 +313,24 @@ function SignupForm() {
     </form>
   )
 }`,
+          mobilePuzzle: {
+            type: 'multi',
+            codeContext: `import { useForm } from 'react-hook-form'\nimport { zodResolver } from '@hookform/resolvers/zod'\nimport { z } from 'zod'\n\nconst signupSchema = z.object({\n  email: z.string().email(),\n  password: z.string().min(8),\n  confirmPassword: z.string(),\n}).refine(\n  ____0\n)\n\ntype SignupData = z.infer<typeof signupSchema>\n\nfunction SignupForm() {\n  const { register, handleSubmit, formState: { errors } } = useForm<SignupData>({\n    resolver: zodResolver(signupSchema),\n  })\n\n  return (\n    <form onSubmit={handleSubmit((data) => console.log(data))}>\n      <input {...register('email')} />\n      <input {...register('password')} type="password" />\n      <input {...register('confirmPassword')} type="password" />\n      ____1\n      <button type="submit">登録</button>\n    </form>\n  )\n}`,
+            blanks: [
+              {
+                id: 'refine',
+                label: 'refine定義',
+                correctTokens: ['(data) => data.password === data.confirmPassword', ',', '{', 'message:', "'パスワードが一致しません'", ',', 'path:', "['confirmPassword']", '}'],
+                distractorTokens: ['superRefine', 'validate', 'yup', 'parse'],
+              },
+              {
+                id: 'confirm-error',
+                label: 'エラー表示',
+                correctTokens: ['{errors.confirmPassword', '&&', '<p>', '{errors.confirmPassword.message}', '</p>', '}'],
+                distractorTokens: ['errors.root', 'validate', 'useState', 'Formik'],
+              },
+            ],
+          },
       },
     ],
   },


### PR DESCRIPTION
## Summary

v4roadmap01 M8 完了。実務パターン（react-patterns）コースの全4ステップ × 2パターン = 8パターンに `mobilePuzzle: { type: 'multi' }` を追加しました。

- **rhf-zod × 2**: zodResolver 設定 / refine 定義 / エラー表示ブランク
- **pagination × 2**: Math.ceil + slice 計算 / useSearchParams URL連動ブランク
- **infinite-scroll × 2**: IntersectionObserver 設定 / isLoading guard + rootMargin ブランク
- **auth-flow × 2**: AuthProvider value + useAuth hook / ProtectedRoute + Login redirect ブランク

## 変更

- `apps/web/src/content/react-patterns/steps/rhf-zod.ts` (+36)
- `apps/web/src/content/react-patterns/steps/pagination.ts` (+36)
- `apps/web/src/content/react-patterns/steps/infinite-scroll.ts` (+36)
- `apps/web/src/content/react-patterns/steps/auth-flow.ts` (+36)

計 **144行追加 / 4ファイル**。各パターンに 2 blanks（3-5 distractors）。設計は v4roadmap01.md §5 M8 セクションに準拠。

## CI

- ✅ typecheck
- ✅ lint
- ✅ test（698件 PASS）
- ✅ build

## Test plan

- [ ] モバイル Challenge モードで react-patterns の全8パターンが multi puzzle UI で表示されること
- [ ] トークン並び替え→判定が期待通り動作すること
- [ ] PC レイアウトでも従来通り starterCode エディタ表示に戻ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)