### PR TITLE
feat: v4 管理者ページ M2 ユーザーフィードバック基盤

### DIFF
--- a/apps/web/src/features/dashboard/components/AppHeader.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeader.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
-import { ChevronDown, Flame, Gem, Menu, Shield, X } from 'lucide-react'
+import { ChevronDown, Flame, Gem, MessageSquarePlus, Menu, Shield, X } from 'lucide-react'
 import { CATEGORIES } from '@/content/courseData'
 import { useAuth } from '@/contexts/AuthContext'
 import { useLearningContext } from '@/contexts/LearningContext'
+import { FeedbackDialog } from '@/features/feedback/FeedbackDialog'
 
 interface AppHeaderProps {
   displayName: string
@@ -28,6 +29,7 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
   const location = useLocation()
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const [isFeedbackOpen, setIsFeedbackOpen] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
   const drawerRef = useRef<HTMLElement>(null)
   const menuButtonRef = useRef<HTMLButtonElement>(null)
@@ -178,6 +180,23 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
                       {link.label}
                     </Link>
                   ))}
+
+                  <div className="my-1.5 border-t border-slate-100" />
+                  <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
+                    サポート
+                  </div>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    onClick={() => {
+                      setIsDropdownOpen(false)
+                      setIsFeedbackOpen(true)
+                    }}
+                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50"
+                  >
+                    <MessageSquarePlus className="h-3.5 w-3.5" aria-hidden="true" />
+                    フィードバックを送る
+                  </button>
 
                   {isAdmin ? (
                     <>
@@ -345,6 +364,22 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
             })}
           </div>
 
+          {/* サポート（全ユーザー） */}
+          <div className="border-b border-slate-100 px-4 py-3">
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">サポート</p>
+            <button
+              type="button"
+              onClick={() => {
+                closeDrawer()
+                setIsFeedbackOpen(true)
+              }}
+              className={`${drawerLinkClass(false)} w-full`}
+            >
+              <MessageSquarePlus className="mr-2 h-4 w-4" aria-hidden="true" />
+              フィードバックを送る
+            </button>
+          </div>
+
           {/* 管理（admin のみ） */}
           {isAdmin ? (
             <div className="border-b border-slate-100 px-4 py-3">
@@ -373,6 +408,8 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
         </div>
       </nav>
     ) : null}
+
+    <FeedbackDialog open={isFeedbackOpen} onClose={() => setIsFeedbackOpen(false)} />
     </>
   )
 }

--- a/apps/web/src/features/feedback/FeedbackDialog.tsx
+++ b/apps/web/src/features/feedback/FeedbackDialog.tsx
@@ -1,0 +1,237 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { AlertCircle, Loader2, X } from 'lucide-react'
+import { useAuth } from '../../contexts/AuthContext'
+import {
+  captureClientMeta,
+  FEEDBACK_CATEGORY_LABELS,
+  MAX_FEEDBACK_MESSAGE_LENGTH,
+  submitFeedback,
+  type FeedbackCategory,
+} from '../../services/feedbackService'
+
+interface FeedbackDialogProps {
+  open: boolean
+  onClose: () => void
+}
+
+const CATEGORY_ORDER: FeedbackCategory[] = ['bug', 'review', 'request', 'other']
+
+export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
+  const { user } = useAuth()
+  const [category, setCategory] = useState<FeedbackCategory>('bug')
+  const [message, setMessage] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitted, setIsSubmitted] = useState(false)
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  // ダイアログを閉じたらフォーム状態をリセット
+  const reset = useCallback(() => {
+    setCategory('bug')
+    setMessage('')
+    setError(null)
+    setIsSubmitted(false)
+    setIsSubmitting(false)
+  }, [])
+
+  const handleClose = useCallback(() => {
+    if (isSubmitting) return
+    reset()
+    onClose()
+  }, [isSubmitting, onClose, reset])
+
+  // ESC キーで閉じる
+  useEffect(() => {
+    if (!open) return
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') handleClose()
+    }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [open, handleClose])
+
+  // 開いたら textarea にフォーカス
+  useEffect(() => {
+    if (!open) return
+    textareaRef.current?.focus()
+  }, [open])
+
+  // body スクロール抑制
+  useEffect(() => {
+    if (!open) return
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = prev
+    }
+  }, [open])
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+    if (isSubmitting) return
+    setError(null)
+
+    if (!user) {
+      setError('送信にはログインが必要です')
+      return
+    }
+
+    const trimmed = message.trim()
+    if (trimmed.length === 0) {
+      setError('本文を入力してください')
+      return
+    }
+    if (trimmed.length > MAX_FEEDBACK_MESSAGE_LENGTH) {
+      setError(`本文は ${MAX_FEEDBACK_MESSAGE_LENGTH} 文字以内で入力してください`)
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      const meta = captureClientMeta()
+      await submitFeedback({
+        userId: user.id,
+        category,
+        message: trimmed,
+        pageUrl: meta.pageUrl,
+        userAgent: meta.userAgent,
+      })
+      setIsSubmitted(true)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '送信に失敗しました')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  if (!open) return null
+
+  const remaining = MAX_FEEDBACK_MESSAGE_LENGTH - message.trim().length
+  const isOverLimit = remaining < 0
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* 背景クリックで閉じる（キーボード操作は ESC / 閉じるボタンに委譲） */}
+      <button
+        type="button"
+        aria-label="背景をクリックして閉じる"
+        tabIndex={-1}
+        onClick={handleClose}
+        className="absolute inset-0 bg-black/40"
+      />
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="feedback-dialog-title"
+        className="relative w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl"
+      >
+        <div className="mb-4 flex items-start justify-between">
+          <div>
+            <h2 id="feedback-dialog-title" className="text-lg font-bold text-slate-900">
+              フィードバックを送る
+            </h2>
+            <p className="mt-1 text-xs text-slate-500">
+              不具合報告・要望・レビューなど、運営宛てに送信できます。
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded-lg p-2 text-slate-500 transition hover:bg-slate-100"
+            aria-label="閉じる"
+            disabled={isSubmitting}
+          >
+            <X className="h-5 w-5" aria-hidden="true" />
+          </button>
+        </div>
+
+        {isSubmitted ? (
+          <div className="py-6 text-center">
+            <p className="text-sm font-semibold text-slate-900">送信しました。ありがとうございます！</p>
+            <p className="mt-1 text-xs text-slate-500">いただいた内容は運営が確認いたします。</p>
+            <button
+              type="button"
+              onClick={handleClose}
+              className="mt-4 rounded-lg bg-primary-mint px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary-dark"
+            >
+              閉じる
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label htmlFor="feedback-category" className="block text-xs font-semibold text-slate-700">
+                カテゴリ
+              </label>
+              <select
+                id="feedback-category"
+                value={category}
+                onChange={(e) => setCategory(e.target.value as FeedbackCategory)}
+                className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary-mint focus:outline-none focus:ring-1 focus:ring-primary-mint"
+                disabled={isSubmitting}
+              >
+                {CATEGORY_ORDER.map((c) => (
+                  <option key={c} value={c}>
+                    {FEEDBACK_CATEGORY_LABELS[c]}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="feedback-message" className="block text-xs font-semibold text-slate-700">
+                本文
+              </label>
+              <textarea
+                ref={textareaRef}
+                id="feedback-message"
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                rows={6}
+                className="mt-1 w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 focus:border-primary-mint focus:outline-none focus:ring-1 focus:ring-primary-mint"
+                placeholder="気づいた点・ご要望など自由に記入してください"
+                disabled={isSubmitting}
+                maxLength={MAX_FEEDBACK_MESSAGE_LENGTH + 100}
+                aria-describedby="feedback-message-help"
+              />
+              <div
+                id="feedback-message-help"
+                className={`mt-1 text-xs ${isOverLimit ? 'text-rose-600' : 'text-slate-500'}`}
+              >
+                残り {remaining} 文字
+              </div>
+            </div>
+
+            {error ? (
+              <div className="flex items-start gap-2 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700">
+                <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
+                <span>{error}</span>
+              </div>
+            ) : null}
+
+            <div className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={handleClose}
+                className="rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+                disabled={isSubmitting}
+              >
+                キャンセル
+              </button>
+              <button
+                type="submit"
+                className="flex items-center gap-2 rounded-lg bg-primary-mint px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary-dark disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={isSubmitting || isOverLimit || message.trim().length === 0}
+              >
+                {isSubmitting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+                送信
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/features/feedback/__tests__/FeedbackDialog.test.tsx
+++ b/apps/web/src/features/feedback/__tests__/FeedbackDialog.test.tsx
@@ -1,0 +1,110 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FeedbackDialog } from '../FeedbackDialog'
+
+const mockAuth = vi.hoisted(() => ({
+  value: { user: { id: '11111111-1111-1111-1111-111111111111' } as { id: string } | null },
+}))
+
+const submitFeedbackMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockAuth.value,
+}))
+
+vi.mock('../../../services/feedbackService', async () => {
+  const actual = await vi.importActual<typeof import('../../../services/feedbackService')>(
+    '../../../services/feedbackService',
+  )
+  return {
+    ...actual,
+    submitFeedback: (...args: unknown[]) => submitFeedbackMock(...args),
+  }
+})
+
+describe('FeedbackDialog', () => {
+  beforeEach(() => {
+    submitFeedbackMock.mockReset()
+    mockAuth.value = { user: { id: '11111111-1111-1111-1111-111111111111' } }
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('open=false のとき何もレンダリングしない', () => {
+    const { container } = render(<FeedbackDialog open={false} onClose={() => undefined} />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('open=true のときダイアログが表示されフォームが見える', () => {
+    render(<FeedbackDialog open={true} onClose={() => undefined} />)
+    expect(screen.getByRole('dialog', { name: 'フィードバックを送る' })).toBeTruthy()
+    expect(screen.getByLabelText('カテゴリ')).toBeTruthy()
+    expect(screen.getByLabelText('本文')).toBeTruthy()
+  })
+
+  it('本文が空のとき送信ボタンが非活性になっている', () => {
+    render(<FeedbackDialog open={true} onClose={() => undefined} />)
+    const submitBtn = screen.getByRole('button', { name: '送信' }) as HTMLButtonElement
+    expect(submitBtn.disabled).toBe(true)
+  })
+
+  it('フォーム送信で submitFeedback を呼び出し成功メッセージを表示する', async () => {
+    submitFeedbackMock.mockResolvedValue({ id: 'fid' })
+    const onClose = vi.fn()
+    render(<FeedbackDialog open={true} onClose={onClose} />)
+
+    fireEvent.change(screen.getByLabelText('カテゴリ'), { target: { value: 'request' } })
+    fireEvent.change(screen.getByLabelText('本文'), { target: { value: 'テストメッセージ' } })
+    fireEvent.submit(screen.getByLabelText('本文').closest('form')!)
+
+    await waitFor(() => {
+      expect(submitFeedbackMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: '11111111-1111-1111-1111-111111111111',
+          category: 'request',
+          message: 'テストメッセージ',
+        }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText(/送信しました/)).toBeTruthy()
+    })
+  })
+
+  it('submitFeedback が失敗したらエラーを表示し onClose を呼ばない', async () => {
+    submitFeedbackMock.mockRejectedValue(new Error('permission denied'))
+    const onClose = vi.fn()
+    render(<FeedbackDialog open={true} onClose={onClose} />)
+
+    fireEvent.change(screen.getByLabelText('本文'), { target: { value: 'hi' } })
+    fireEvent.submit(screen.getByLabelText('本文').closest('form')!)
+
+    await waitFor(() => {
+      expect(screen.getByText('permission denied')).toBeTruthy()
+    })
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('ユーザー未ログインのとき送信でエラーを表示する', async () => {
+    mockAuth.value = { user: null }
+    render(<FeedbackDialog open={true} onClose={() => undefined} />)
+
+    fireEvent.change(screen.getByLabelText('本文'), { target: { value: 'hi' } })
+    fireEvent.submit(screen.getByLabelText('本文').closest('form')!)
+
+    await waitFor(() => {
+      expect(screen.getByText('送信にはログインが必要です')).toBeTruthy()
+    })
+    expect(submitFeedbackMock).not.toHaveBeenCalled()
+  })
+
+  it('閉じるボタンで onClose が呼ばれる', () => {
+    const onClose = vi.fn()
+    render(<FeedbackDialog open={true} onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: '閉じる' }))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -39,6 +39,12 @@ const StepPage = lazy(() => import('./pages/StepPage').then((m) => ({ default: m
 const AdminDashboardPage = lazy(() =>
   import('./pages/admin/AdminDashboardPage').then((m) => ({ default: m.AdminDashboardPage })),
 )
+const AdminFeedbackListPage = lazy(() =>
+  import('./pages/admin/AdminFeedbackListPage').then((m) => ({ default: m.AdminFeedbackListPage })),
+)
+const AdminFeedbackDetailPage = lazy(() =>
+  import('./pages/admin/AdminFeedbackDetailPage').then((m) => ({ default: m.AdminFeedbackDetailPage })),
+)
 
 // ページ遷移中のフォールバック UI
 function PageLoading() {
@@ -183,6 +189,30 @@ const router = createBrowserRouter([
         <AdminGuard>
           <Suspense fallback={<PageLoading />}>
             <AdminDashboardPage />
+          </Suspense>
+        </AdminGuard>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/admin/feedback',
+    element: (
+      <ProtectedRoute>
+        <AdminGuard>
+          <Suspense fallback={<PageLoading />}>
+            <AdminFeedbackListPage />
+          </Suspense>
+        </AdminGuard>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/admin/feedback/:id',
+    element: (
+      <ProtectedRoute>
+        <AdminGuard>
+          <Suspense fallback={<PageLoading />}>
+            <AdminFeedbackDetailPage />
           </Suspense>
         </AdminGuard>
       </ProtectedRoute>

--- a/apps/web/src/pages/admin/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/admin/AdminDashboardPage.tsx
@@ -9,6 +9,7 @@ interface SectionCard {
   description: string
   icon: typeof Inbox
   accent: string
+  available: boolean
 }
 
 const SECTIONS: SectionCard[] = [
@@ -18,6 +19,7 @@ const SECTIONS: SectionCard[] = [
     description: 'ユーザーから届いた不具合報告・要望・レビューを確認する',
     icon: Inbox,
     accent: 'bg-amber-100 text-amber-700',
+    available: true,
   },
   {
     to: '/admin/users',
@@ -25,6 +27,7 @@ const SECTIONS: SectionCard[] = [
     description: '登録ユーザーの学習進捗・ポイント・取得バッジを閲覧する',
     icon: Users,
     accent: 'bg-sky-100 text-sky-700',
+    available: false,
   },
   {
     to: '/admin/stats',
@@ -32,6 +35,7 @@ const SECTIONS: SectionCard[] = [
     description: 'DAU・ステップ別完了率・よく間違える問題などを俯瞰する',
     icon: BarChart3,
     accent: 'bg-emerald-100 text-emerald-700',
+    available: false,
   },
   {
     to: '/admin/ops',
@@ -39,6 +43,7 @@ const SECTIONS: SectionCard[] = [
     description: 'ポイント・バッジの手動付与など、運用オペレーションを実行する',
     icon: Wrench,
     accent: 'bg-violet-100 text-violet-700',
+    available: false,
   },
 ]
 
@@ -57,20 +62,40 @@ export function AdminDashboardPage() {
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {SECTIONS.map((section) => {
           const Icon = section.icon
-          return (
-            <Link
-              key={section.to}
-              to={section.to}
-              className="group flex items-start gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-primary-mint/40 hover:shadow-md"
-            >
+          const content = (
+            <>
               <div className={`rounded-xl p-3 ${section.accent}`}>
                 <Icon className="h-5 w-5" aria-hidden="true" />
               </div>
               <div>
                 <h2 className="font-bold text-slate-900 group-hover:text-primary-dark">{section.title}</h2>
                 <p className="mt-1 text-sm text-slate-500">{section.description}</p>
-                <p className="mt-3 text-xs font-semibold text-slate-400">※ M2 以降で実装予定</p>
+                {section.available ? null : (
+                  <p className="mt-3 text-xs font-semibold text-slate-400">※ 今後のマイルストーンで実装予定</p>
+                )}
               </div>
+            </>
+          )
+
+          if (!section.available) {
+            return (
+              <div
+                key={section.to}
+                className="flex items-start gap-4 rounded-2xl border border-slate-200 bg-slate-50 p-5 opacity-70"
+                aria-disabled="true"
+              >
+                {content}
+              </div>
+            )
+          }
+
+          return (
+            <Link
+              key={section.to}
+              to={section.to}
+              className="group flex items-start gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-primary-mint/40 hover:shadow-md"
+            >
+              {content}
             </Link>
           )
         })}

--- a/apps/web/src/pages/admin/AdminFeedbackDetailPage.tsx
+++ b/apps/web/src/pages/admin/AdminFeedbackDetailPage.tsx
@@ -1,0 +1,399 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { AlertCircle, ArrowLeft, Loader2, Save } from 'lucide-react'
+import { useAuth } from '../../contexts/AuthContext'
+import { AdminLayout } from '../../features/admin/components/AdminLayout'
+import { useDocumentTitle } from '../../hooks/useDocumentTitle'
+import {
+  FEEDBACK_CATEGORIES,
+  FEEDBACK_CATEGORY_LABELS,
+  FEEDBACK_STATUSES,
+  FEEDBACK_STATUS_LABELS,
+  MAX_ADMIN_NOTE_LENGTH,
+  getFeedback,
+  updateFeedbackNote,
+  updateFeedbackStatus,
+} from '../../services/feedbackService'
+import type { FeedbackCategory, FeedbackStatus, UserFeedback } from '../../services/feedbackService'
+
+// ─── Badge helpers ──────────────────────────────────────────────────────────
+
+const CATEGORY_BADGE_CLASSES: Record<FeedbackCategory, string> = {
+  bug: 'bg-rose-100 text-rose-700',
+  review: 'bg-sky-100 text-sky-700',
+  request: 'bg-violet-100 text-violet-700',
+  other: 'bg-slate-100 text-slate-700',
+}
+
+const STATUS_BADGE_CLASSES: Record<FeedbackStatus, string> = {
+  new: 'bg-amber-100 text-amber-700',
+  in_progress: 'bg-sky-100 text-sky-700',
+  resolved: 'bg-emerald-100 text-emerald-700',
+  archived: 'bg-slate-100 text-slate-700',
+}
+
+function isFeedbackCategory(value: string): value is FeedbackCategory {
+  return FEEDBACK_CATEGORIES.has(value)
+}
+
+function isFeedbackStatus(value: string): value is FeedbackStatus {
+  return FEEDBACK_STATUSES.has(value)
+}
+
+function CategoryBadge({ category }: { category: string }) {
+  const label = isFeedbackCategory(category) ? FEEDBACK_CATEGORY_LABELS[category] : category
+  const classes = isFeedbackCategory(category) ? CATEGORY_BADGE_CLASSES[category] : 'bg-slate-100 text-slate-700'
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${classes}`}>
+      {label}
+    </span>
+  )
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const label = isFeedbackStatus(status) ? FEEDBACK_STATUS_LABELS[status] : status
+  const classes = isFeedbackStatus(status) ? STATUS_BADGE_CLASSES[status] : 'bg-slate-100 text-slate-700'
+  return (
+    <span className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${classes}`}>
+      {label}
+    </span>
+  )
+}
+
+// ─── Date formatting ─────────────────────────────────────────────────────────
+
+function formatJst(isoString: string): string {
+  const date = new Date(isoString)
+  return new Intl.DateTimeFormat('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+    .format(date)
+    .replace(/\//g, '/')
+    .replace(',', '')
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function AdminFeedbackDetailPage() {
+  useDocumentTitle('フィードバック詳細 - 管理画面')
+
+  const { id } = useParams<{ id: string }>()
+  const { user } = useAuth()
+
+  const [feedback, setFeedback] = useState<UserFeedback | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [notFound, setNotFound] = useState(false)
+  const [loadError, setLoadError] = useState<string | null>(null)
+
+  // Status update state
+  const [isUpdatingStatus, setIsUpdatingStatus] = useState(false)
+  const [statusError, setStatusError] = useState<string | null>(null)
+
+  // Admin note state
+  const [noteText, setNoteText] = useState('')
+  const [savedNote, setSavedNote] = useState('')
+  const [isSavingNote, setIsSavingNote] = useState(false)
+  const [noteError, setNoteError] = useState<string | null>(null)
+  const [noteSaveSuccess, setNoteSaveSuccess] = useState(false)
+
+  useEffect(() => {
+    if (!id) {
+      setNotFound(true)
+      setIsLoading(false)
+      return
+    }
+
+    const feedbackId = id
+    let isMounted = true
+
+    async function load() {
+      try {
+        const data = await getFeedback(feedbackId)
+        if (!isMounted) return
+        if (data === null) {
+          setNotFound(true)
+        } else {
+          setFeedback(data)
+          const initialNote = data.admin_note ?? ''
+          setNoteText(initialNote)
+          setSavedNote(initialNote)
+        }
+      } catch (e) {
+        if (!isMounted) return
+        setLoadError(e instanceof Error ? e.message : 'フィードバックの取得に失敗しました')
+      } finally {
+        if (isMounted) setIsLoading(false)
+      }
+    }
+
+    void load()
+    return () => {
+      isMounted = false
+    }
+  }, [id])
+
+  async function handleStatusChange(e: React.ChangeEvent<HTMLSelectElement>) {
+    if (!feedback || !user || !id) return
+    const nextStatus = e.target.value
+    if (!isFeedbackStatus(nextStatus)) return
+
+    setIsUpdatingStatus(true)
+    setStatusError(null)
+    try {
+      const updated = await updateFeedbackStatus(id, nextStatus, user.id)
+      setFeedback(updated)
+    } catch (err) {
+      setStatusError(err instanceof Error ? err.message : 'ステータスの更新に失敗しました')
+    } finally {
+      setIsUpdatingStatus(false)
+    }
+  }
+
+  async function handleNoteSave() {
+    if (!feedback || !user || !id) return
+
+    setIsSavingNote(true)
+    setNoteError(null)
+    setNoteSaveSuccess(false)
+
+    const trimmed = noteText.trim()
+    const valueToSave = trimmed.length === 0 ? null : trimmed
+
+    try {
+      const updated = await updateFeedbackNote(id, valueToSave, user.id)
+      setFeedback(updated)
+      const savedValue = updated.admin_note ?? ''
+      setNoteText(savedValue)
+      setSavedNote(savedValue)
+      setNoteSaveSuccess(true)
+    } catch (err) {
+      setNoteError(err instanceof Error ? err.message : 'メモの保存に失敗しました')
+    } finally {
+      setIsSavingNote(false)
+    }
+  }
+
+  const isNoteUnchanged = noteText === savedNote
+  const isNoteOverLimit = noteText.length > MAX_ADMIN_NOTE_LENGTH
+
+  // ── Loading state ──────────────────────────────────────────────────────────
+  if (isLoading) {
+    return (
+      <AdminLayout>
+        <div className="flex items-center justify-center py-24">
+          <Loader2 className="h-8 w-8 animate-spin text-slate-400" aria-label="読み込み中" />
+        </div>
+      </AdminLayout>
+    )
+  }
+
+  // ── Load error ────────────────────────────────────────────────────────────
+  if (loadError) {
+    return (
+      <AdminLayout>
+        <div className="mb-4">
+          <Link
+            to="/admin/feedback"
+            className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-700"
+          >
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+            一覧に戻る
+          </Link>
+        </div>
+        <div className="flex items-start gap-3 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <p>{loadError}</p>
+        </div>
+      </AdminLayout>
+    )
+  }
+
+  // ── Not found ─────────────────────────────────────────────────────────────
+  if (notFound || !feedback) {
+    return (
+      <AdminLayout>
+        <div className="mb-4">
+          <Link
+            to="/admin/feedback"
+            className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-700"
+          >
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+            一覧に戻る
+          </Link>
+        </div>
+        <p className="text-sm text-slate-500">フィードバックが見つかりません</p>
+      </AdminLayout>
+    )
+  }
+
+  // ── Main render ──────────────────────────────────────────────────────────
+  return (
+    <AdminLayout>
+      {/* Back link */}
+      <div className="mb-6">
+        <Link
+          to="/admin/feedback"
+          className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-700"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+          一覧に戻る
+        </Link>
+      </div>
+
+      {/* Page heading */}
+      <div className="mb-6 flex flex-wrap items-center gap-3">
+        <h1 className="text-xl font-bold text-slate-900">フィードバック詳細</h1>
+        <CategoryBadge category={feedback.category} />
+        <StatusBadge status={feedback.status} />
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        {/* Left column: read-only meta + message */}
+        <div className="space-y-6 lg:col-span-2">
+          {/* Message */}
+          <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-3 text-sm font-semibold text-slate-700">メッセージ</h2>
+            <pre className="whitespace-pre-wrap rounded-lg bg-slate-50 p-4 text-sm leading-relaxed text-slate-800">
+              {feedback.message}
+            </pre>
+          </section>
+
+          {/* Meta info */}
+          <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-4 text-sm font-semibold text-slate-700">詳細情報</h2>
+            <dl className="space-y-3 text-sm">
+              <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+                <dt className="w-32 shrink-0 font-medium text-slate-500">ユーザー ID</dt>
+                <dd className="break-all font-mono text-slate-800">{feedback.user_id}</dd>
+              </div>
+              <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+                <dt className="w-32 shrink-0 font-medium text-slate-500">カテゴリ</dt>
+                <dd>
+                  <CategoryBadge category={feedback.category} />
+                </dd>
+              </div>
+              <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+                <dt className="w-32 shrink-0 font-medium text-slate-500">作成日時</dt>
+                <dd className="text-slate-800">{formatJst(feedback.created_at)}</dd>
+              </div>
+              <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+                <dt className="w-32 shrink-0 font-medium text-slate-500">更新日時</dt>
+                <dd className="text-slate-800">{formatJst(feedback.updated_at)}</dd>
+              </div>
+              {feedback.page_url && (
+                <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+                  <dt className="w-32 shrink-0 font-medium text-slate-500">ページ URL</dt>
+                  <dd className="break-all text-slate-800">{feedback.page_url}</dd>
+                </div>
+              )}
+              {feedback.user_agent && (
+                <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+                  <dt className="w-32 shrink-0 font-medium text-slate-500">User Agent</dt>
+                  <dd className="break-all text-xs text-slate-600">{feedback.user_agent}</dd>
+                </div>
+              )}
+            </dl>
+          </section>
+        </div>
+
+        {/* Right column: status + admin note */}
+        <div className="space-y-6">
+          {/* Status */}
+          <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-3 text-sm font-semibold text-slate-700">ステータス</h2>
+
+            {statusError && (
+              <div className="mb-3 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-xs text-red-700">
+                <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                <p>{statusError}</p>
+              </div>
+            )}
+
+            <div className="relative">
+              <select
+                value={feedback.status}
+                onChange={(e) => void handleStatusChange(e)}
+                disabled={isUpdatingStatus || !user}
+                className="w-full appearance-none rounded-lg border border-slate-300 bg-white px-3 py-2 pr-8 text-sm text-slate-800 shadow-sm transition focus:border-primary-mint focus:outline-none focus:ring-1 focus:ring-primary-mint disabled:cursor-not-allowed disabled:opacity-60"
+                aria-label="ステータスを変更"
+              >
+                {(['new', 'in_progress', 'resolved', 'archived'] as FeedbackStatus[]).map((s) => (
+                  <option key={s} value={s}>
+                    {FEEDBACK_STATUS_LABELS[s]}
+                  </option>
+                ))}
+              </select>
+              {isUpdatingStatus && (
+                <span className="absolute right-2 top-1/2 -translate-y-1/2">
+                  <Loader2 className="h-4 w-4 animate-spin text-slate-400" aria-hidden="true" />
+                </span>
+              )}
+            </div>
+
+            {isUpdatingStatus && (
+              <p className="mt-2 text-xs text-slate-500">更新中...</p>
+            )}
+          </section>
+
+          {/* Admin note */}
+          <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-3 text-sm font-semibold text-slate-700">管理者メモ</h2>
+
+            {noteError && (
+              <div className="mb-3 flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-xs text-red-700">
+                <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                <p>{noteError}</p>
+              </div>
+            )}
+
+            {noteSaveSuccess && (
+              <p className="mb-3 text-xs text-emerald-600">メモを保存しました</p>
+            )}
+
+            <textarea
+              rows={5}
+              value={noteText}
+              onChange={(e) => {
+                setNoteText(e.target.value)
+                setNoteSaveSuccess(false)
+              }}
+              maxLength={MAX_ADMIN_NOTE_LENGTH}
+              placeholder="管理者メモを入力..."
+              className="w-full resize-y rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 shadow-sm placeholder:text-slate-400 focus:border-primary-mint focus:outline-none focus:ring-1 focus:ring-primary-mint"
+              aria-label="管理者メモ"
+            />
+
+            <div className="mt-1.5 flex items-center justify-between">
+              <p
+                className={`text-xs ${isNoteOverLimit ? 'text-red-600' : 'text-slate-400'}`}
+                aria-live="polite"
+              >
+                {noteText.length} / {MAX_ADMIN_NOTE_LENGTH}
+              </p>
+
+              <button
+                type="button"
+                onClick={() => void handleNoteSave()}
+                disabled={isNoteUnchanged || isSavingNote || isNoteOverLimit || !user}
+                className="inline-flex items-center gap-1.5 rounded-lg bg-slate-800 px-3 py-1.5 text-xs font-semibold text-white shadow-sm transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label="管理者メモを保存"
+              >
+                {isSavingNote ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                ) : (
+                  <Save className="h-3.5 w-3.5" aria-hidden="true" />
+                )}
+                {isSavingNote ? '保存中...' : '保存'}
+              </button>
+            </div>
+          </section>
+        </div>
+      </div>
+    </AdminLayout>
+  )
+}

--- a/apps/web/src/pages/admin/AdminFeedbackListPage.tsx
+++ b/apps/web/src/pages/admin/AdminFeedbackListPage.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Inbox, Filter, AlertCircle } from 'lucide-react'
+import { AdminLayout } from '../../features/admin/components/AdminLayout'
+import { useDocumentTitle } from '../../hooks/useDocumentTitle'
+import { Spinner } from '../../components/Spinner'
+import {
+  listFeedback,
+  FEEDBACK_CATEGORY_LABELS,
+  FEEDBACK_STATUS_LABELS,
+  type FeedbackCategory,
+  type FeedbackStatus,
+  type ListFeedbackFilter,
+  type UserFeedback,
+} from '../../services/feedbackService'
+
+type CategoryFilter = 'all' | FeedbackCategory
+type StatusFilter = 'all' | FeedbackStatus
+
+const CATEGORY_BADGE: Record<FeedbackCategory, string> = {
+  bug: 'bg-rose-100 text-rose-700',
+  review: 'bg-sky-100 text-sky-700',
+  request: 'bg-violet-100 text-violet-700',
+  other: 'bg-slate-100 text-slate-600',
+}
+
+const STATUS_BADGE: Record<FeedbackStatus, string> = {
+  new: 'bg-amber-100 text-amber-700',
+  in_progress: 'bg-sky-100 text-sky-700',
+  resolved: 'bg-emerald-100 text-emerald-700',
+  archived: 'bg-slate-100 text-slate-600',
+}
+
+function formatJst(dateStr: string): string {
+  return new Date(dateStr).toLocaleString('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+export function AdminFeedbackListPage() {
+  useDocumentTitle('フィードバック一覧 - 管理画面')
+
+  const [feedback, setFeedback] = useState<UserFeedback[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>('all')
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
+
+  useEffect(() => {
+    let isMounted = true
+
+    async function load() {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const filter: ListFeedbackFilter = {}
+        if (categoryFilter !== 'all') filter.category = categoryFilter
+        if (statusFilter !== 'all') filter.status = statusFilter
+        const data = await listFeedback(filter)
+        if (!isMounted) return
+        setFeedback(data)
+      } catch (e) {
+        if (!isMounted) return
+        setError(e instanceof Error ? e.message : 'データの取得に失敗しました')
+      } finally {
+        if (isMounted) setIsLoading(false)
+      }
+    }
+
+    void load()
+    return () => {
+      isMounted = false
+    }
+  }, [categoryFilter, statusFilter])
+
+  return (
+    <AdminLayout>
+      {/* ヘッダー */}
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-slate-900">フィードバック一覧</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          ユーザーから届いた不具合報告・要望・レビューを確認できます。
+        </p>
+      </div>
+
+      {/* フィルター */}
+      <div className="mb-4 flex flex-wrap items-center gap-3 rounded-2xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
+        <Filter className="h-4 w-4 shrink-0 text-slate-400" aria-hidden="true" />
+
+        <div className="flex items-center gap-2">
+          <label htmlFor="category-filter" className="text-sm font-medium text-slate-600">
+            カテゴリ
+          </label>
+          <select
+            id="category-filter"
+            value={categoryFilter}
+            onChange={(e) => setCategoryFilter(e.target.value as CategoryFilter)}
+            className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-mint"
+          >
+            <option value="all">すべて</option>
+            <option value="bug">{FEEDBACK_CATEGORY_LABELS.bug}</option>
+            <option value="review">{FEEDBACK_CATEGORY_LABELS.review}</option>
+            <option value="request">{FEEDBACK_CATEGORY_LABELS.request}</option>
+            <option value="other">{FEEDBACK_CATEGORY_LABELS.other}</option>
+          </select>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label htmlFor="status-filter" className="text-sm font-medium text-slate-600">
+            ステータス
+          </label>
+          <select
+            id="status-filter"
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+            className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-primary-mint"
+          >
+            <option value="all">すべて</option>
+            <option value="new">{FEEDBACK_STATUS_LABELS.new}</option>
+            <option value="in_progress">{FEEDBACK_STATUS_LABELS.in_progress}</option>
+            <option value="resolved">{FEEDBACK_STATUS_LABELS.resolved}</option>
+            <option value="archived">{FEEDBACK_STATUS_LABELS.archived}</option>
+          </select>
+        </div>
+      </div>
+
+      {/* コンテンツ */}
+      {isLoading ? (
+        <div className="flex justify-center py-16">
+          <Spinner size="lg" />
+        </div>
+      ) : error ? (
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-2xl border border-rose-200 bg-rose-50 p-5 text-sm text-rose-700"
+        >
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>{error}</span>
+        </div>
+      ) : feedback.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 rounded-2xl border border-slate-200 bg-white py-16 shadow-sm">
+          <Inbox className="h-10 w-10 text-slate-300" aria-hidden="true" />
+          <p className="text-sm text-slate-500">該当するフィードバックはありません</p>
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <ul className="divide-y divide-slate-100">
+            {feedback.map((item) => (
+              <li key={item.id}>
+                <Link
+                  to={`/admin/feedback/${item.id}`}
+                  className="flex items-start gap-4 px-5 py-4 transition hover:bg-slate-50"
+                >
+                  {/* バッジ列 */}
+                  <div className="flex shrink-0 flex-col gap-1.5 pt-0.5">
+                    <span
+                      className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-semibold ${CATEGORY_BADGE[item.category as FeedbackCategory]}`}
+                    >
+                      {FEEDBACK_CATEGORY_LABELS[item.category as FeedbackCategory]}
+                    </span>
+                    <span
+                      className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-semibold ${STATUS_BADGE[item.status as FeedbackStatus]}`}
+                    >
+                      {FEEDBACK_STATUS_LABELS[item.status as FeedbackStatus]}
+                    </span>
+                  </div>
+
+                  {/* メッセージ */}
+                  <div className="min-w-0 flex-1">
+                    <p className="line-clamp-2 text-sm text-slate-700">
+                      {item.message.length > 200 ? item.message.slice(0, 200) : item.message}
+                    </p>
+                  </div>
+
+                  {/* 日時 */}
+                  <time
+                    dateTime={item.created_at}
+                    className="shrink-0 text-xs text-slate-400"
+                  >
+                    {formatJst(item.created_at)}
+                  </time>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </AdminLayout>
+  )
+}

--- a/apps/web/src/pages/admin/__tests__/AdminFeedbackListPage.test.tsx
+++ b/apps/web/src/pages/admin/__tests__/AdminFeedbackListPage.test.tsx
@@ -1,0 +1,124 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const listFeedbackMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../services/feedbackService', async () => {
+  const actual = await vi.importActual<typeof import('../../../services/feedbackService')>(
+    '../../../services/feedbackService',
+  )
+  return {
+    ...actual,
+    listFeedback: (...args: unknown[]) => listFeedbackMock(...args),
+  }
+})
+
+// AdminLayout は useGreetingName/useSignOut/AppHeader 等を連鎖的に使うため、簡易モックに差し替える
+vi.mock('../../../features/admin/components/AdminLayout', () => ({
+  AdminLayout: ({ children }: { children: React.ReactNode }) => <div data-testid="admin-layout">{children}</div>,
+}))
+
+vi.mock('../../../hooks/useDocumentTitle', () => ({
+  useDocumentTitle: () => undefined,
+}))
+
+import { AdminFeedbackListPage } from '../AdminFeedbackListPage'
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminFeedbackListPage />
+    </MemoryRouter>,
+  )
+}
+
+const SAMPLE = [
+  {
+    id: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    user_id: 'uuuuuuuu-uuuu-uuuu-uuuu-uuuuuuuuuuuu',
+    category: 'bug',
+    message: 'バグ発見',
+    page_url: '/x',
+    user_agent: null,
+    status: 'new',
+    admin_note: null,
+    created_at: '2026-04-17T00:00:00Z',
+    updated_at: '2026-04-17T00:00:00Z',
+  },
+  {
+    id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    user_id: 'uuuuuuuu-uuuu-uuuu-uuuu-uuuuuuuuuuuu',
+    category: 'request',
+    message: '機能追加希望',
+    page_url: null,
+    user_agent: null,
+    status: 'resolved',
+    admin_note: null,
+    created_at: '2026-04-16T00:00:00Z',
+    updated_at: '2026-04-16T00:00:00Z',
+  },
+]
+
+describe('AdminFeedbackListPage', () => {
+  beforeEach(() => {
+    listFeedbackMock.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('マウント時にフィルタなしで listFeedback を呼ぶ', async () => {
+    listFeedbackMock.mockResolvedValue([])
+    renderPage()
+    await waitFor(() => {
+      expect(listFeedbackMock).toHaveBeenCalledWith({})
+    })
+  })
+
+  it('一覧を表示し /admin/feedback/:id へのリンクを持つ', async () => {
+    listFeedbackMock.mockResolvedValue(SAMPLE)
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText('バグ発見')).toBeTruthy()
+    })
+
+    const links = screen.getAllByRole('link')
+    const hrefs = links.map((a) => a.getAttribute('href'))
+    expect(hrefs).toContain(`/admin/feedback/${SAMPLE[0]?.id}`)
+    expect(hrefs).toContain(`/admin/feedback/${SAMPLE[1]?.id}`)
+  })
+
+  it('空のときは空状態メッセージを表示する', async () => {
+    listFeedbackMock.mockResolvedValue([])
+    renderPage()
+    await waitFor(() => {
+      expect(screen.getByText('該当するフィードバックはありません')).toBeTruthy()
+    })
+  })
+
+  it('カテゴリ/ステータスを変更すると listFeedback が再呼び出しされる', async () => {
+    listFeedbackMock.mockResolvedValue([])
+    renderPage()
+
+    await waitFor(() => {
+      expect(listFeedbackMock).toHaveBeenCalledTimes(1)
+    })
+
+    fireEvent.change(screen.getByLabelText('カテゴリ'), { target: { value: 'bug' } })
+    fireEvent.change(screen.getByLabelText('ステータス'), { target: { value: 'resolved' } })
+
+    await waitFor(() => {
+      expect(listFeedbackMock).toHaveBeenLastCalledWith({ category: 'bug', status: 'resolved' })
+    })
+  })
+
+  it('fetch エラーは alert で表示する', async () => {
+    listFeedbackMock.mockRejectedValue(new Error('rls violation'))
+    renderPage()
+    const alert = await screen.findByRole('alert')
+    expect(within(alert).getByText('rls violation')).toBeTruthy()
+  })
+})

--- a/apps/web/src/services/__tests__/feedbackService.test.ts
+++ b/apps/web/src/services/__tests__/feedbackService.test.ts
@@ -1,0 +1,438 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  FEEDBACK_CATEGORIES,
+  FEEDBACK_STATUSES,
+  getFeedback,
+  listFeedback,
+  submitFeedback,
+  updateFeedbackNote,
+  updateFeedbackStatus,
+} from '../feedbackService'
+
+// Supabase chain mocks. 単一テーブルごとにビルダーを返す `from` を作成する。
+
+type Row = Record<string, unknown>
+
+const userFeedbackState = {
+  insertPayload: null as Row | null,
+  insertResult: { data: null as Row | null, error: null as unknown },
+  updatePayload: null as Row | null,
+  updateResult: { data: null as Row | null, error: null as unknown },
+  selectCalled: false,
+  lastEq: null as [string, unknown] | null,
+  orderCalls: [] as Array<{ column: string; options: Record<string, unknown> | undefined }>,
+  filterEqCalls: [] as Array<[string, unknown]>,
+  listResult: { data: null as Row[] | null, error: null as unknown },
+  maybeSingleResult: { data: null as Row | null, error: null as unknown },
+  limitCalls: [] as number[],
+}
+
+const auditLogState = {
+  lastInsertPayload: null as Row | null,
+  insertResult: { error: null as unknown },
+}
+
+function createUserFeedbackBuilder() {
+  const builder: Record<string, unknown> = {}
+
+  const insertResolve = () => ({
+    select: () => ({
+      single: () => Promise.resolve(userFeedbackState.insertResult),
+    }),
+  })
+
+  const updateResolve = () => ({
+    eq: () => ({
+      select: () => ({
+        single: () => Promise.resolve(userFeedbackState.updateResult),
+      }),
+    }),
+  })
+
+  builder.insert = (payload: Row) => {
+    userFeedbackState.insertPayload = payload
+    return insertResolve()
+  }
+
+  builder.update = (payload: Row) => {
+    userFeedbackState.updatePayload = payload
+    return updateResolve()
+  }
+
+  // select/.order/.eq/.limit chains. Both maybeSingle (detail) and array-style (list).
+  builder.select = () => {
+    userFeedbackState.selectCalled = true
+    const chain = {
+      eq(col: string, val: unknown) {
+        userFeedbackState.lastEq = [col, val]
+        return {
+          maybeSingle: () => Promise.resolve(userFeedbackState.maybeSingleResult),
+        }
+      },
+      order(col: string, options?: Record<string, unknown>) {
+        userFeedbackState.orderCalls.push({ column: col, options })
+        return filterChain()
+      },
+    }
+    return chain
+  }
+
+  function filterChain() {
+    const chain = {
+      eq(col: string, val: unknown) {
+        userFeedbackState.filterEqCalls.push([col, val])
+        return chain
+      },
+      limit(n: number) {
+        userFeedbackState.limitCalls.push(n)
+        return chain
+      },
+      then(resolve: (value: unknown) => unknown, reject: (reason: unknown) => unknown) {
+        return Promise.resolve(userFeedbackState.listResult).then(resolve, reject)
+      },
+    }
+    return chain
+  }
+
+  return builder
+}
+
+function createAuditLogBuilder() {
+  return {
+    insert: (payload: Row) => {
+      auditLogState.lastInsertPayload = payload
+      return Promise.resolve(auditLogState.insertResult)
+    },
+  }
+}
+
+const from = vi.fn((table: string) => {
+  if (table === 'user_feedback') return createUserFeedbackBuilder()
+  if (table === 'admin_audit_log') return createAuditLogBuilder()
+  throw new Error(`unexpected table: ${table}`)
+})
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {
+    from: (...args: unknown[]) => from(...(args as [string])),
+  },
+}))
+
+const VALID_USER_ID = '11111111-1111-1111-1111-111111111111'
+const VALID_ADMIN_ID = '22222222-2222-2222-2222-222222222222'
+const VALID_FEEDBACK_ID = '33333333-3333-3333-3333-333333333333'
+
+function resetState() {
+  vi.clearAllMocks()
+  userFeedbackState.insertPayload = null
+  userFeedbackState.insertResult = { data: null, error: null }
+  userFeedbackState.updatePayload = null
+  userFeedbackState.updateResult = { data: null, error: null }
+  userFeedbackState.selectCalled = false
+  userFeedbackState.lastEq = null
+  userFeedbackState.orderCalls = []
+  userFeedbackState.filterEqCalls = []
+  userFeedbackState.listResult = { data: null, error: null }
+  userFeedbackState.maybeSingleResult = { data: null, error: null }
+  userFeedbackState.limitCalls = []
+  auditLogState.lastInsertPayload = null
+  auditLogState.insertResult = { error: null }
+}
+
+describe('FEEDBACK_CATEGORIES / FEEDBACK_STATUSES', () => {
+  it('4種類のカテゴリを保持する', () => {
+    expect(FEEDBACK_CATEGORIES.size).toBe(4)
+    expect(FEEDBACK_CATEGORIES.has('bug')).toBe(true)
+    expect(FEEDBACK_CATEGORIES.has('review')).toBe(true)
+    expect(FEEDBACK_CATEGORIES.has('request')).toBe(true)
+    expect(FEEDBACK_CATEGORIES.has('other')).toBe(true)
+  })
+
+  it('4種類のステータスを保持する', () => {
+    expect(FEEDBACK_STATUSES.size).toBe(4)
+    expect(FEEDBACK_STATUSES.has('new')).toBe(true)
+    expect(FEEDBACK_STATUSES.has('in_progress')).toBe(true)
+    expect(FEEDBACK_STATUSES.has('resolved')).toBe(true)
+    expect(FEEDBACK_STATUSES.has('archived')).toBe(true)
+  })
+})
+
+describe('submitFeedback', () => {
+  beforeEach(resetState)
+
+  it('user_feedback テーブルに INSERT して作成レコードを返す', async () => {
+    userFeedbackState.insertResult = {
+      data: {
+        id: VALID_FEEDBACK_ID,
+        user_id: VALID_USER_ID,
+        category: 'bug',
+        message: 'hello',
+        page_url: '/step/abc',
+        user_agent: 'UA',
+        status: 'new',
+        admin_note: null,
+        created_at: '2026-04-17T00:00:00Z',
+        updated_at: '2026-04-17T00:00:00Z',
+      },
+      error: null,
+    }
+
+    const result = await submitFeedback({
+      userId: VALID_USER_ID,
+      category: 'bug',
+      message: '  hello  ',
+      pageUrl: '/step/abc',
+      userAgent: 'UA',
+    })
+
+    expect(from).toHaveBeenCalledWith('user_feedback')
+    expect(userFeedbackState.insertPayload).toEqual({
+      user_id: VALID_USER_ID,
+      category: 'bug',
+      message: 'hello',
+      page_url: '/step/abc',
+      user_agent: 'UA',
+    })
+    expect(result.id).toBe(VALID_FEEDBACK_ID)
+  })
+
+  it('空文字列の本文は例外を投げ INSERT を呼ばない', async () => {
+    await expect(
+      submitFeedback({ userId: VALID_USER_ID, category: 'bug', message: '   ' }),
+    ).rejects.toThrow('message must not be empty')
+    expect(userFeedbackState.insertPayload).toBeNull()
+  })
+
+  it('不正なカテゴリは例外を投げる', async () => {
+    await expect(
+      // @ts-expect-error - テスト用に不正な値を意図的に渡している
+      submitFeedback({ userId: VALID_USER_ID, category: 'hack', message: 'x' }),
+    ).rejects.toThrow('category is not a valid value')
+  })
+
+  it('4000文字を超える本文は例外を投げる', async () => {
+    await expect(
+      submitFeedback({ userId: VALID_USER_ID, category: 'other', message: 'a'.repeat(4001) }),
+    ).rejects.toThrow('message must be at most 4000 characters')
+  })
+
+  it('不正な userId は例外を投げる', async () => {
+    await expect(
+      submitFeedback({ userId: 'not-a-uuid', category: 'bug', message: 'hi' }),
+    ).rejects.toThrow('userId must be a valid UUID')
+  })
+
+  it('pageUrl が 500 文字超過時は 500 文字に丸める', async () => {
+    userFeedbackState.insertResult = { data: {}, error: null }
+    await submitFeedback({
+      userId: VALID_USER_ID,
+      category: 'bug',
+      message: 'x',
+      pageUrl: 'a'.repeat(600),
+    })
+    expect(userFeedbackState.insertPayload?.page_url).toHaveLength(500)
+  })
+
+  it('Supabase エラーをアプリ共通エラーに変換する', async () => {
+    userFeedbackState.insertResult = {
+      data: null,
+      error: { code: 'DB_ERROR', message: 'permission denied' },
+    }
+    await expect(
+      submitFeedback({ userId: VALID_USER_ID, category: 'bug', message: 'x' }),
+    ).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: 'フィードバックの送信に失敗しました',
+    })
+  })
+})
+
+describe('listFeedback', () => {
+  beforeEach(resetState)
+
+  it('created_at 降順で取得する', async () => {
+    userFeedbackState.listResult = { data: [], error: null }
+    await listFeedback()
+    expect(userFeedbackState.orderCalls).toEqual([
+      { column: 'created_at', options: { ascending: false } },
+    ])
+    expect(userFeedbackState.filterEqCalls).toEqual([])
+  })
+
+  it('category / status フィルタを eq として適用する', async () => {
+    userFeedbackState.listResult = { data: [], error: null }
+    await listFeedback({ category: 'bug', status: 'new' })
+    expect(userFeedbackState.filterEqCalls).toEqual([
+      ['category', 'bug'],
+      ['status', 'new'],
+    ])
+  })
+
+  it('limit を 500 上限でクランプする', async () => {
+    userFeedbackState.listResult = { data: [], error: null }
+    await listFeedback({ limit: 9999 })
+    expect(userFeedbackState.limitCalls).toEqual([500])
+  })
+
+  it('不正なカテゴリは例外を投げる', async () => {
+    await expect(
+      // @ts-expect-error - テスト用に不正な値を意図的に渡している
+      listFeedback({ category: 'hack' }),
+    ).rejects.toThrow('category is not a valid value')
+  })
+
+  it('Supabase エラーをアプリ共通エラーに変換する', async () => {
+    userFeedbackState.listResult = {
+      data: null,
+      error: { code: 'DB_ERROR', message: 'rls violation' },
+    }
+    await expect(listFeedback()).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: 'フィードバック一覧の取得に失敗しました',
+    })
+  })
+})
+
+describe('getFeedback', () => {
+  beforeEach(resetState)
+
+  it('id で user_feedback を取得する', async () => {
+    userFeedbackState.maybeSingleResult = {
+      data: { id: VALID_FEEDBACK_ID },
+      error: null,
+    }
+    const result = await getFeedback(VALID_FEEDBACK_ID)
+    expect(userFeedbackState.lastEq).toEqual(['id', VALID_FEEDBACK_ID])
+    expect(result).toEqual({ id: VALID_FEEDBACK_ID })
+  })
+
+  it('該当なしのときは null を返す', async () => {
+    userFeedbackState.maybeSingleResult = { data: null, error: null }
+    expect(await getFeedback(VALID_FEEDBACK_ID)).toBeNull()
+  })
+
+  it('不正な id は例外を投げる', async () => {
+    await expect(getFeedback('xxx')).rejects.toThrow('id must be a valid UUID')
+  })
+})
+
+describe('updateFeedbackStatus', () => {
+  beforeEach(resetState)
+
+  it('user_feedback UPDATE と admin_audit_log INSERT を行う', async () => {
+    userFeedbackState.updateResult = {
+      data: { id: VALID_FEEDBACK_ID, status: 'resolved' },
+      error: null,
+    }
+    const result = await updateFeedbackStatus(VALID_FEEDBACK_ID, 'resolved', VALID_ADMIN_ID)
+
+    expect(userFeedbackState.updatePayload).toEqual({ status: 'resolved' })
+    expect(auditLogState.lastInsertPayload).toEqual({
+      admin_id: VALID_ADMIN_ID,
+      action: 'feedback.status_updated',
+      target_type: 'user_feedback',
+      target_id: VALID_FEEDBACK_ID,
+      payload: { status: 'resolved' },
+    })
+    expect(result.status).toBe('resolved')
+  })
+
+  it('UPDATE が失敗したら audit_log INSERT しない', async () => {
+    userFeedbackState.updateResult = {
+      data: null,
+      error: { code: 'DB_ERROR', message: 'rls denied' },
+    }
+
+    await expect(
+      updateFeedbackStatus(VALID_FEEDBACK_ID, 'resolved', VALID_ADMIN_ID),
+    ).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: 'フィードバックのステータス更新に失敗しました',
+    })
+
+    expect(auditLogState.lastInsertPayload).toBeNull()
+  })
+
+  it('audit_log INSERT 失敗は例外を握り潰さず投げる', async () => {
+    userFeedbackState.updateResult = {
+      data: { id: VALID_FEEDBACK_ID, status: 'resolved' },
+      error: null,
+    }
+    auditLogState.insertResult = { error: { code: 'DB_ERROR', message: 'log failed' } }
+
+    await expect(
+      updateFeedbackStatus(VALID_FEEDBACK_ID, 'resolved', VALID_ADMIN_ID),
+    ).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: '監査ログの記録に失敗しました',
+    })
+  })
+
+  it('不正なステータスは例外を投げる', async () => {
+    await expect(
+      // @ts-expect-error - テスト用に不正な値を意図的に渡している
+      updateFeedbackStatus(VALID_FEEDBACK_ID, 'done', VALID_ADMIN_ID),
+    ).rejects.toThrow('status is not a valid value')
+  })
+
+  it('不正な adminId は例外を投げる', async () => {
+    await expect(
+      updateFeedbackStatus(VALID_FEEDBACK_ID, 'resolved', 'not-uuid'),
+    ).rejects.toThrow('adminId must be a valid UUID')
+  })
+})
+
+describe('updateFeedbackNote', () => {
+  beforeEach(resetState)
+
+  it('admin_note を UPDATE し audit_log に長さを記録する', async () => {
+    userFeedbackState.updateResult = {
+      data: { id: VALID_FEEDBACK_ID, admin_note: 'hi' },
+      error: null,
+    }
+    const result = await updateFeedbackNote(VALID_FEEDBACK_ID, '  hi  ', VALID_ADMIN_ID)
+
+    expect(userFeedbackState.updatePayload).toEqual({ admin_note: 'hi' })
+    expect(auditLogState.lastInsertPayload).toEqual({
+      admin_id: VALID_ADMIN_ID,
+      action: 'feedback.note_updated',
+      target_type: 'user_feedback',
+      target_id: VALID_FEEDBACK_ID,
+      payload: { note_length: 2 },
+    })
+    expect(result.admin_note).toBe('hi')
+  })
+
+  it('空文字列は null として保存する', async () => {
+    userFeedbackState.updateResult = { data: { id: VALID_FEEDBACK_ID, admin_note: null }, error: null }
+    await updateFeedbackNote(VALID_FEEDBACK_ID, '   ', VALID_ADMIN_ID)
+    expect(userFeedbackState.updatePayload).toEqual({ admin_note: null })
+    expect(auditLogState.lastInsertPayload?.payload).toEqual({ note_length: 0 })
+  })
+
+  it('null は null として保存する', async () => {
+    userFeedbackState.updateResult = { data: { id: VALID_FEEDBACK_ID, admin_note: null }, error: null }
+    await updateFeedbackNote(VALID_FEEDBACK_ID, null, VALID_ADMIN_ID)
+    expect(userFeedbackState.updatePayload).toEqual({ admin_note: null })
+  })
+
+  it('2000文字超過時は 2000 文字に丸める', async () => {
+    userFeedbackState.updateResult = { data: {}, error: null }
+    await updateFeedbackNote(VALID_FEEDBACK_ID, 'a'.repeat(2500), VALID_ADMIN_ID)
+    expect((userFeedbackState.updatePayload?.admin_note as string).length).toBe(2000)
+  })
+
+  it('UPDATE 失敗は例外を投げ audit_log を呼ばない', async () => {
+    userFeedbackState.updateResult = {
+      data: null,
+      error: { code: 'DB_ERROR', message: 'rls denied' },
+    }
+    await expect(
+      updateFeedbackNote(VALID_FEEDBACK_ID, 'hi', VALID_ADMIN_ID),
+    ).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: 'フィードバックのメモ更新に失敗しました',
+    })
+    expect(auditLogState.lastInsertPayload).toBeNull()
+  })
+})

--- a/apps/web/src/services/feedbackService.ts
+++ b/apps/web/src/services/feedbackService.ts
@@ -1,0 +1,263 @@
+import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+import { assertMaxLength, assertOneOf, assertUuid } from '../shared/validation'
+import type { Json, Tables } from '../shared/types/database.types'
+
+export type UserFeedback = Tables<'user_feedback'>
+
+export type FeedbackCategory = 'bug' | 'review' | 'request' | 'other'
+export type FeedbackStatus = 'new' | 'in_progress' | 'resolved' | 'archived'
+
+export const FEEDBACK_CATEGORIES: ReadonlySet<string> = new Set([
+  'bug',
+  'review',
+  'request',
+  'other',
+])
+
+export const FEEDBACK_STATUSES: ReadonlySet<string> = new Set([
+  'new',
+  'in_progress',
+  'resolved',
+  'archived',
+])
+
+export const FEEDBACK_CATEGORY_LABELS: Record<FeedbackCategory, string> = {
+  bug: '不具合報告',
+  review: 'レビュー',
+  request: '要望',
+  other: 'その他',
+}
+
+export const FEEDBACK_STATUS_LABELS: Record<FeedbackStatus, string> = {
+  new: '新規',
+  in_progress: '対応中',
+  resolved: '対応済み',
+  archived: 'アーカイブ',
+}
+
+/** 本文の最大文字数（DB 側制約 4000 と一致させる） */
+export const MAX_FEEDBACK_MESSAGE_LENGTH = 4000
+/** page_url の最大文字数（長大な URL で DB を肥大化させないため短めに丸める） */
+export const MAX_PAGE_URL_LENGTH = 500
+/** user_agent の最大文字数 */
+export const MAX_USER_AGENT_LENGTH = 500
+/** admin_note の最大文字数 */
+export const MAX_ADMIN_NOTE_LENGTH = 2000
+
+type AuditAction =
+  | 'feedback.status_updated'
+  | 'feedback.note_updated'
+
+/**
+ * admin_audit_log に INSERT する。
+ * 監査ログの失敗はユーザー向け操作を巻き戻したくないため、呼び出し側で例外を握り潰さず
+ * そのままスローする（= 監査ログに記録できないときは元操作も失敗扱いにする）。
+ *
+ * RLS: `admin_audit_log_insert_admin` により `auth.uid() = admin_id` が強制される。
+ */
+async function insertAuditLog(entry: {
+  adminId: string
+  action: AuditAction
+  targetType: string
+  targetId: string
+  payload: Record<string, unknown>
+}): Promise<void> {
+  assertUuid(entry.adminId, 'adminId')
+  const { error } = await supabase.from('admin_audit_log').insert({
+    admin_id: entry.adminId,
+    action: entry.action,
+    target_type: entry.targetType,
+    target_id: entry.targetId,
+    payload: entry.payload as Json,
+  })
+  if (error) {
+    throw fromSupabaseError(error, '監査ログの記録に失敗しました')
+  }
+}
+
+// ─── ユーザー操作 ────────────────────────────────────────
+
+export interface SubmitFeedbackInput {
+  userId: string
+  category: FeedbackCategory
+  message: string
+  pageUrl?: string | null
+  userAgent?: string | null
+}
+
+/**
+ * ユーザーがフィードバックを送信する。
+ * RLS `user_feedback_insert_own` により `auth.uid() = user_id` が強制されるため、
+ * クライアント側で user_id を詐称しても DB 側で弾かれる。
+ */
+export async function submitFeedback(input: SubmitFeedbackInput): Promise<UserFeedback> {
+  assertUuid(input.userId, 'userId')
+  assertOneOf(input.category, FEEDBACK_CATEGORIES, 'category')
+
+  const trimmedMessage = input.message.trim()
+  if (trimmedMessage.length === 0) {
+    throw new Error('message must not be empty')
+  }
+  assertMaxLength(trimmedMessage, MAX_FEEDBACK_MESSAGE_LENGTH, 'message')
+
+  const normalizedPageUrl = normalizeOptionalText(input.pageUrl, MAX_PAGE_URL_LENGTH)
+  const normalizedUserAgent = normalizeOptionalText(input.userAgent, MAX_USER_AGENT_LENGTH)
+
+  const { data, error } = await supabase
+    .from('user_feedback')
+    .insert({
+      user_id: input.userId,
+      category: input.category,
+      message: trimmedMessage,
+      page_url: normalizedPageUrl,
+      user_agent: normalizedUserAgent,
+    })
+    .select()
+    .single()
+
+  if (error) {
+    throw fromSupabaseError(error, 'フィードバックの送信に失敗しました')
+  }
+
+  return data
+}
+
+function normalizeOptionalText(value: string | null | undefined, maxLength: number): string | null {
+  if (value === null || value === undefined) return null
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return null
+  return trimmed.length > maxLength ? trimmed.slice(0, maxLength) : trimmed
+}
+
+// ─── 管理者操作 ───────────────────────────────────────────
+
+export interface ListFeedbackFilter {
+  category?: FeedbackCategory
+  status?: FeedbackStatus
+  limit?: number
+}
+
+/** admin 向けにフィードバック一覧を取得する（新着順） */
+export async function listFeedback(filter: ListFeedbackFilter = {}): Promise<UserFeedback[]> {
+  let query = supabase
+    .from('user_feedback')
+    .select('*')
+    .order('created_at', { ascending: false })
+
+  if (filter.category) {
+    assertOneOf(filter.category, FEEDBACK_CATEGORIES, 'category')
+    query = query.eq('category', filter.category)
+  }
+  if (filter.status) {
+    assertOneOf(filter.status, FEEDBACK_STATUSES, 'status')
+    query = query.eq('status', filter.status)
+  }
+  if (filter.limit !== undefined) {
+    const safeLimit = Math.max(1, Math.min(filter.limit, 500))
+    query = query.limit(safeLimit)
+  }
+
+  const { data, error } = await query
+  if (error) {
+    throw fromSupabaseError(error, 'フィードバック一覧の取得に失敗しました')
+  }
+  return data ?? []
+}
+
+/** 単一のフィードバックを取得する */
+export async function getFeedback(id: string): Promise<UserFeedback | null> {
+  assertUuid(id, 'id')
+  const { data, error } = await supabase
+    .from('user_feedback')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle()
+  if (error) {
+    throw fromSupabaseError(error, 'フィードバックの取得に失敗しました')
+  }
+  return data
+}
+
+/**
+ * フィードバックのステータスを更新し、同時に admin_audit_log に記録する。
+ * - adminId は必ず `auth.uid()` と一致させる必要がある（RLS で強制）
+ * - UPDATE と監査ログ INSERT は 2 クエリで実行するが、
+ *   監査ログ側のエラーは握り潰さず例外を投げる（追跡不能を防ぐ）
+ */
+export async function updateFeedbackStatus(
+  id: string,
+  nextStatus: FeedbackStatus,
+  adminId: string,
+): Promise<UserFeedback> {
+  assertUuid(id, 'id')
+  assertUuid(adminId, 'adminId')
+  assertOneOf(nextStatus, FEEDBACK_STATUSES, 'status')
+
+  const { data, error } = await supabase
+    .from('user_feedback')
+    .update({ status: nextStatus })
+    .eq('id', id)
+    .select()
+    .single()
+
+  if (error) {
+    throw fromSupabaseError(error, 'フィードバックのステータス更新に失敗しました')
+  }
+
+  await insertAuditLog({
+    adminId,
+    action: 'feedback.status_updated',
+    targetType: 'user_feedback',
+    targetId: id,
+    payload: { status: nextStatus },
+  })
+
+  return data
+}
+
+/** フィードバックの admin_note を更新し、同時に admin_audit_log に記録する */
+export async function updateFeedbackNote(
+  id: string,
+  nextNote: string | null,
+  adminId: string,
+): Promise<UserFeedback> {
+  assertUuid(id, 'id')
+  assertUuid(adminId, 'adminId')
+
+  const normalizedNote = normalizeOptionalText(nextNote, MAX_ADMIN_NOTE_LENGTH)
+
+  const { data, error } = await supabase
+    .from('user_feedback')
+    .update({ admin_note: normalizedNote })
+    .eq('id', id)
+    .select()
+    .single()
+
+  if (error) {
+    throw fromSupabaseError(error, 'フィードバックのメモ更新に失敗しました')
+  }
+
+  await insertAuditLog({
+    adminId,
+    action: 'feedback.note_updated',
+    targetType: 'user_feedback',
+    targetId: id,
+    payload: { note_length: normalizedNote?.length ?? 0 },
+  })
+
+  return data
+}
+
+// ─── ユーティリティ ──────────────────────────────────────
+
+/** 現在のページ情報から送信元メタデータを取得する（クライアント専用） */
+export function captureClientMeta(): { pageUrl: string; userAgent: string } {
+  const pathname = typeof window === 'undefined' ? '' : window.location.pathname
+  const search = typeof window === 'undefined' ? '' : window.location.search
+  const userAgent = typeof navigator === 'undefined' ? '' : navigator.userAgent
+  return {
+    pageUrl: `${pathname}${search}`.slice(0, MAX_PAGE_URL_LENGTH),
+    userAgent: userAgent.slice(0, MAX_USER_AGENT_LENGTH),
+  }
+}


### PR DESCRIPTION
## Summary
- `services/feedbackService.ts` 実装（submit / list / get / updateStatus / updateNote）
- `FeedbackDialog` と AppHeader 導線で、ユーザーが任意画面からフィードバック送信可能に
- `/admin/feedback` 一覧・`/admin/feedback/:id` 詳細で、admin がカテゴリ/ステータスフィルター・ステータス更新・admin_note 追記ができる
- ステータス変更・ノート更新は `admin_audit_log` に記録（INSERT 失敗は握り潰さず例外化）

## 主な設計判断
- **監査ログの失敗は握り潰さない**: 追跡不能な管理者操作を避けるため、audit_log INSERT 失敗時は元操作が成功していても例外を投げる
- **背景クリック閉じる a11y**: 背景を独立 `<button tabIndex={-1}>` に分離し、X ボタンとの aria-label 衝突を回避
- **exactOptionalPropertyTypes 対応**: `ListFeedbackFilter` はオプショナルキーを条件付きで埋める
- **Dashboard のプレースホルダー**: 他3セクションは aria-disabled な div にして未実装であることを明示

## テスト
- feedbackService: 21 ケース（入力検証 / Supabase チェーン mock / audit_log エラー伝播）
- FeedbackDialog: 7 ケース（描画 / submit / 未ログイン / エラー / close）
- AdminFeedbackListPage: 5 ケース（初回 fetch / 一覧描画 / 空状態 / フィルター変更 / エラー）
- 合計 +39 件、全テスト 745 件 PASS

## Test plan
- [ ] typecheck / lint / test (745件) / build 全パス（ローカル確認済み）
- [ ] 非 admin で `/admin/feedback` にアクセスするとトップに戻される
- [ ] admin で `/admin/feedback` が開き、一覧・詳細・ステータス変更・メモ保存が動作する
- [ ] 非 admin でフィードバック送信ダイアログから送信でき、admin 側一覧に反映される
- [ ] 未ログイン状態でダイアログを開き、送信時に「ログインが必要です」表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)