### PR TITLE
feat: v4 管理者ページ M3 ユーザーデータ閲覧・統計・運用操作

### DIFF
--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -45,6 +45,18 @@ const AdminFeedbackListPage = lazy(() =>
 const AdminFeedbackDetailPage = lazy(() =>
   import('./pages/admin/AdminFeedbackDetailPage').then((m) => ({ default: m.AdminFeedbackDetailPage })),
 )
+const AdminUsersPage = lazy(() =>
+  import('./pages/admin/AdminUsersPage').then((m) => ({ default: m.AdminUsersPage })),
+)
+const AdminUserDetailPage = lazy(() =>
+  import('./pages/admin/AdminUserDetailPage').then((m) => ({ default: m.AdminUserDetailPage })),
+)
+const AdminStatsPage = lazy(() =>
+  import('./pages/admin/AdminStatsPage').then((m) => ({ default: m.AdminStatsPage })),
+)
+const AdminOpsPage = lazy(() =>
+  import('./pages/admin/AdminOpsPage').then((m) => ({ default: m.AdminOpsPage })),
+)
 
 // ページ遷移中のフォールバック UI
 function PageLoading() {
@@ -213,6 +225,54 @@ const router = createBrowserRouter([
         <AdminGuard>
           <Suspense fallback={<PageLoading />}>
             <AdminFeedbackDetailPage />
+          </Suspense>
+        </AdminGuard>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/admin/users',
+    element: (
+      <ProtectedRoute>
+        <AdminGuard>
+          <Suspense fallback={<PageLoading />}>
+            <AdminUsersPage />
+          </Suspense>
+        </AdminGuard>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/admin/users/:id',
+    element: (
+      <ProtectedRoute>
+        <AdminGuard>
+          <Suspense fallback={<PageLoading />}>
+            <AdminUserDetailPage />
+          </Suspense>
+        </AdminGuard>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/admin/stats',
+    element: (
+      <ProtectedRoute>
+        <AdminGuard>
+          <Suspense fallback={<PageLoading />}>
+            <AdminStatsPage />
+          </Suspense>
+        </AdminGuard>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/admin/ops',
+    element: (
+      <ProtectedRoute>
+        <AdminGuard>
+          <Suspense fallback={<PageLoading />}>
+            <AdminOpsPage />
           </Suspense>
         </AdminGuard>
       </ProtectedRoute>

--- a/apps/web/src/pages/admin/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/admin/AdminDashboardPage.tsx
@@ -1,7 +1,9 @@
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Inbox, Users, BarChart3, Wrench } from 'lucide-react'
+import { AlertCircle, BarChart3, Inbox, Loader2, Users, Wrench } from 'lucide-react'
 import { useDocumentTitle } from '../../hooks/useDocumentTitle'
 import { AdminLayout } from '../../features/admin/components/AdminLayout'
+import { getGlobalStatsSummary, type GlobalStatsSummary } from '../../services/adminStatsService'
 
 interface SectionCard {
   to: string
@@ -9,7 +11,10 @@ interface SectionCard {
   description: string
   icon: typeof Inbox
   accent: string
-  available: boolean
+  /** 表示するメトリクスキー（summary から取得） */
+  metricKey?: keyof GlobalStatsSummary
+  /** 「新規◯件」のようにカードの補足バッジに表示するメトリクスキー */
+  badgeKey?: keyof GlobalStatsSummary
 }
 
 const SECTIONS: SectionCard[] = [
@@ -19,7 +24,8 @@ const SECTIONS: SectionCard[] = [
     description: 'ユーザーから届いた不具合報告・要望・レビューを確認する',
     icon: Inbox,
     accent: 'bg-amber-100 text-amber-700',
-    available: true,
+    metricKey: 'totalFeedback',
+    badgeKey: 'newFeedback',
   },
   {
     to: '/admin/users',
@@ -27,7 +33,7 @@ const SECTIONS: SectionCard[] = [
     description: '登録ユーザーの学習進捗・ポイント・取得バッジを閲覧する',
     icon: Users,
     accent: 'bg-sky-100 text-sky-700',
-    available: false,
+    metricKey: 'totalUsers',
   },
   {
     to: '/admin/stats',
@@ -35,7 +41,7 @@ const SECTIONS: SectionCard[] = [
     description: 'DAU・ステップ別完了率・よく間違える問題などを俯瞰する',
     icon: BarChart3,
     accent: 'bg-emerald-100 text-emerald-700',
-    available: false,
+    metricKey: 'totalPointsDistributed',
   },
   {
     to: '/admin/ops',
@@ -43,12 +49,42 @@ const SECTIONS: SectionCard[] = [
     description: 'ポイント・バッジの手動付与など、運用オペレーションを実行する',
     icon: Wrench,
     accent: 'bg-violet-100 text-violet-700',
-    available: false,
   },
 ]
 
+const METRIC_LABELS: Record<keyof GlobalStatsSummary, string> = {
+  totalUsers: '登録ユーザー',
+  totalPointsDistributed: '配布済 Pt',
+  totalFeedback: '累計件数',
+  newFeedback: '新規',
+}
+
 export function AdminDashboardPage() {
   useDocumentTitle('管理画面')
+
+  const [summary, setSummary] = useState<GlobalStatsSummary | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+    async function load() {
+      try {
+        const data = await getGlobalStatsSummary()
+        if (!isMounted) return
+        setSummary(data)
+      } catch (e) {
+        if (!isMounted) return
+        setError(e instanceof Error ? e.message : 'ダッシュボードの取得に失敗しました')
+      } finally {
+        if (isMounted) setIsLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      isMounted = false
+    }
+  }, [])
 
   return (
     <AdminLayout>
@@ -59,35 +95,23 @@ export function AdminDashboardPage() {
         </p>
       </div>
 
+      {error && (
+        <div
+          role="alert"
+          className="mb-4 flex items-start gap-3 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700"
+        >
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>{error}</span>
+        </div>
+      )}
+
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {SECTIONS.map((section) => {
           const Icon = section.icon
-          const content = (
-            <>
-              <div className={`rounded-xl p-3 ${section.accent}`}>
-                <Icon className="h-5 w-5" aria-hidden="true" />
-              </div>
-              <div>
-                <h2 className="font-bold text-slate-900 group-hover:text-primary-dark">{section.title}</h2>
-                <p className="mt-1 text-sm text-slate-500">{section.description}</p>
-                {section.available ? null : (
-                  <p className="mt-3 text-xs font-semibold text-slate-400">※ 今後のマイルストーンで実装予定</p>
-                )}
-              </div>
-            </>
-          )
-
-          if (!section.available) {
-            return (
-              <div
-                key={section.to}
-                className="flex items-start gap-4 rounded-2xl border border-slate-200 bg-slate-50 p-5 opacity-70"
-                aria-disabled="true"
-              >
-                {content}
-              </div>
-            )
-          }
+          const metricValue =
+            section.metricKey && summary ? summary[section.metricKey] : null
+          const badgeValue =
+            section.badgeKey && summary ? summary[section.badgeKey] : null
 
           return (
             <Link
@@ -95,7 +119,37 @@ export function AdminDashboardPage() {
               to={section.to}
               className="group flex items-start gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm transition hover:border-primary-mint/40 hover:shadow-md"
             >
-              {content}
+              <div className={`rounded-xl p-3 ${section.accent}`}>
+                <Icon className="h-5 w-5" aria-hidden="true" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-start justify-between gap-2">
+                  <h2 className="font-bold text-slate-900 group-hover:text-primary-dark">
+                    {section.title}
+                  </h2>
+                  {badgeValue !== null && badgeValue > 0 && (
+                    <span className="shrink-0 rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-semibold text-amber-700">
+                      {METRIC_LABELS[section.badgeKey as keyof GlobalStatsSummary]} {badgeValue}
+                    </span>
+                  )}
+                </div>
+                <p className="mt-1 text-sm text-slate-500">{section.description}</p>
+
+                {section.metricKey && (
+                  <p className="mt-3 text-xs text-slate-500">
+                    <span className="font-semibold text-slate-700">
+                      {METRIC_LABELS[section.metricKey]}:{' '}
+                    </span>
+                    {isLoading ? (
+                      <Loader2 className="inline h-3 w-3 animate-spin text-slate-400" aria-hidden="true" />
+                    ) : (
+                      <span className="font-mono text-slate-800">
+                        {metricValue !== null ? metricValue.toLocaleString() : '—'}
+                      </span>
+                    )}
+                  </p>
+                )}
+              </div>
             </Link>
           )
         })}

--- a/apps/web/src/pages/admin/AdminOpsPage.tsx
+++ b/apps/web/src/pages/admin/AdminOpsPage.tsx
@@ -1,0 +1,318 @@
+import { useEffect, useState } from 'react'
+import { AlertCircle, Award, CheckCircle2, Loader2, Plus } from 'lucide-react'
+import { AdminLayout } from '../../features/admin/components/AdminLayout'
+import { useDocumentTitle } from '../../hooks/useDocumentTitle'
+import {
+  MAX_GRANT_POINTS_AMOUNT,
+  MAX_GRANT_POINTS_REASON_LENGTH,
+  grantBadge,
+  grantPoints,
+} from '../../services/adminOpsService'
+import { BADGE_DEFINITIONS, type BadgeId } from '../../services/achievementService'
+import { listUsers, type AdminUserSummary } from '../../services/adminUsersService'
+
+type Feedback =
+  | { kind: 'idle' }
+  | { kind: 'success'; message: string }
+  | { kind: 'error'; message: string }
+
+export function AdminOpsPage() {
+  useDocumentTitle('運用 - 管理画面')
+
+  const [users, setUsers] = useState<AdminUserSummary[]>([])
+  const [isLoadingUsers, setIsLoadingUsers] = useState(true)
+  const [usersError, setUsersError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+    async function load() {
+      try {
+        const data = await listUsers()
+        if (!isMounted) return
+        setUsers(data)
+      } catch (e) {
+        if (!isMounted) return
+        setUsersError(e instanceof Error ? e.message : 'ユーザー一覧の取得に失敗しました')
+      } finally {
+        if (isMounted) setIsLoadingUsers(false)
+      }
+    }
+    void load()
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  return (
+    <AdminLayout>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-slate-900">運用</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          ポイント・バッジの手動付与を実行します。操作は admin_audit_log に記録されます。
+        </p>
+      </div>
+
+      {usersError && (
+        <div
+          role="alert"
+          className="mb-4 flex items-start gap-3 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-700"
+        >
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>{usersError}</span>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <GrantPointsForm users={users} disabled={isLoadingUsers} />
+        <GrantBadgeForm users={users} disabled={isLoadingUsers} />
+      </div>
+    </AdminLayout>
+  )
+}
+
+// ─── ポイント手動付与 ─────────────────────────────────────
+
+function GrantPointsForm({ users, disabled }: { users: AdminUserSummary[]; disabled: boolean }) {
+  const [targetUserId, setTargetUserId] = useState('')
+  const [amount, setAmount] = useState<number | ''>(100)
+  const [reason, setReason] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [feedback, setFeedback] = useState<Feedback>({ kind: 'idle' })
+
+  const canSubmit =
+    !disabled &&
+    !isSubmitting &&
+    targetUserId.length > 0 &&
+    typeof amount === 'number' &&
+    amount > 0 &&
+    amount <= MAX_GRANT_POINTS_AMOUNT &&
+    reason.trim().length > 0 &&
+    reason.length <= MAX_GRANT_POINTS_REASON_LENGTH
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!canSubmit || typeof amount !== 'number') return
+
+    setIsSubmitting(true)
+    setFeedback({ kind: 'idle' })
+    try {
+      await grantPoints({ targetUserId, amount, reason: reason.trim() })
+      setFeedback({ kind: 'success', message: `${amount} Pt を付与しました` })
+      // 成功後はフィールドを初期化（対象は残す）
+      setReason('')
+    } catch (e) {
+      setFeedback({
+        kind: 'error',
+        message: e instanceof Error ? e.message : 'ポイントの付与に失敗しました',
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <form
+      onSubmit={(e) => void handleSubmit(e)}
+      className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"
+    >
+      <h2 className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+        <Plus className="h-4 w-4" aria-hidden="true" />
+        ポイント手動付与
+      </h2>
+
+      <FormFeedback feedback={feedback} />
+
+      <UserSelect value={targetUserId} onChange={setTargetUserId} users={users} disabled={disabled} />
+
+      <div>
+        <label htmlFor="grant-amount" className="mb-1 block text-xs font-semibold text-slate-600">
+          金額 (Pt, 1〜{MAX_GRANT_POINTS_AMOUNT.toLocaleString()})
+        </label>
+        <input
+          id="grant-amount"
+          type="number"
+          min={1}
+          max={MAX_GRANT_POINTS_AMOUNT}
+          step={1}
+          value={amount}
+          onChange={(e) => {
+            const v = e.target.value
+            setAmount(v === '' ? '' : Number(v))
+          }}
+          className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-primary-mint focus:outline-none focus:ring-1 focus:ring-primary-mint"
+          required
+        />
+      </div>
+
+      <div>
+        <label htmlFor="grant-reason" className="mb-1 block text-xs font-semibold text-slate-600">
+          理由 ({reason.length} / {MAX_GRANT_POINTS_REASON_LENGTH})
+        </label>
+        <input
+          id="grant-reason"
+          type="text"
+          value={reason}
+          maxLength={MAX_GRANT_POINTS_REASON_LENGTH}
+          onChange={(e) => setReason(e.target.value)}
+          placeholder="例: キャンペーン参加ボーナス"
+          className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-primary-mint focus:outline-none focus:ring-1 focus:ring-primary-mint"
+          required
+        />
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-slate-800 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isSubmitting ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <Plus className="h-4 w-4" aria-hidden="true" />
+          )}
+          {isSubmitting ? '付与中...' : 'ポイントを付与'}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+// ─── バッジ手動付与 ───────────────────────────────────────
+
+function GrantBadgeForm({ users, disabled }: { users: AdminUserSummary[]; disabled: boolean }) {
+  const [targetUserId, setTargetUserId] = useState('')
+  const [badgeId, setBadgeId] = useState<BadgeId>(BADGE_DEFINITIONS[0].id)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [feedback, setFeedback] = useState<Feedback>({ kind: 'idle' })
+
+  const canSubmit = !disabled && !isSubmitting && targetUserId.length > 0
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    if (!canSubmit) return
+    setIsSubmitting(true)
+    setFeedback({ kind: 'idle' })
+    try {
+      await grantBadge({ targetUserId, badgeId })
+      const def = BADGE_DEFINITIONS.find((b) => b.id === badgeId)
+      setFeedback({
+        kind: 'success',
+        message: `バッジ「${def?.name ?? badgeId}」を付与しました`,
+      })
+    } catch (e) {
+      setFeedback({
+        kind: 'error',
+        message: e instanceof Error ? e.message : 'バッジの付与に失敗しました',
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <form
+      onSubmit={(e) => void handleSubmit(e)}
+      className="flex flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"
+    >
+      <h2 className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+        <Award className="h-4 w-4" aria-hidden="true" />
+        バッジ手動付与
+      </h2>
+
+      <FormFeedback feedback={feedback} />
+
+      <UserSelect value={targetUserId} onChange={setTargetUserId} users={users} disabled={disabled} />
+
+      <div>
+        <label htmlFor="grant-badge" className="mb-1 block text-xs font-semibold text-slate-600">
+          バッジ
+        </label>
+        <select
+          id="grant-badge"
+          value={badgeId}
+          onChange={(e) => setBadgeId(e.target.value as BadgeId)}
+          className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-primary-mint focus:outline-none focus:ring-1 focus:ring-primary-mint"
+        >
+          {BADGE_DEFINITIONS.map((b) => (
+            <option key={b.id} value={b.id}>
+              {b.name} — {b.description}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          type="submit"
+          disabled={!canSubmit}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-slate-800 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isSubmitting ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <Award className="h-4 w-4" aria-hidden="true" />
+          )}
+          {isSubmitting ? '付与中...' : 'バッジを付与'}
+        </button>
+      </div>
+    </form>
+  )
+}
+
+// ─── 共通部品 ─────────────────────────────────────────────
+
+function UserSelect({
+  value,
+  onChange,
+  users,
+  disabled,
+}: {
+  value: string
+  onChange: (v: string) => void
+  users: AdminUserSummary[]
+  disabled: boolean
+}) {
+  return (
+    <div>
+      <label htmlFor={`user-select-${Math.random().toString(36).slice(2, 7)}`} className="mb-1 block text-xs font-semibold text-slate-600">
+        対象ユーザー
+      </label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-primary-mint focus:outline-none focus:ring-1 focus:ring-primary-mint disabled:cursor-not-allowed disabled:opacity-60"
+        required
+      >
+        <option value="">-- 選択してください --</option>
+        {users.map((u) => (
+          <option key={u.userId} value={u.userId}>
+            {u.displayName ?? '(未設定)'} / {u.email ?? u.userId.slice(0, 8)}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}
+
+function FormFeedback({ feedback }: { feedback: Feedback }) {
+  if (feedback.kind === 'idle') return null
+  if (feedback.kind === 'success') {
+    return (
+      <div className="flex items-start gap-2 rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-xs text-emerald-700">
+        <CheckCircle2 className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <p>{feedback.message}</p>
+      </div>
+    )
+  }
+  return (
+    <div
+      role="alert"
+      className="flex items-start gap-2 rounded-lg border border-rose-200 bg-rose-50 p-3 text-xs text-rose-700"
+    >
+      <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      <p>{feedback.message}</p>
+    </div>
+  )
+}

--- a/apps/web/src/pages/admin/AdminStatsPage.tsx
+++ b/apps/web/src/pages/admin/AdminStatsPage.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useState } from 'react'
+import { AlertCircle, Loader2 } from 'lucide-react'
+import { AdminLayout } from '../../features/admin/components/AdminLayout'
+import { useDocumentTitle } from '../../hooks/useDocumentTitle'
+import {
+  getDauLast30Days,
+  getGlobalStatsSummary,
+  getStepCompletionRates,
+  getTopMissedQuestions,
+  type DauPoint,
+  type GlobalStatsSummary,
+  type MissedQuestion,
+  type StepCompletionRate,
+} from '../../services/adminStatsService'
+import { findStepById } from '../../content/courseData'
+
+function stepLabel(stepId: string): string {
+  return findStepById(stepId)?.title ?? stepId
+}
+
+function formatPercent(rate: number): string {
+  return `${(rate * 100).toFixed(1)}%`
+}
+
+interface StatsState {
+  summary: GlobalStatsSummary | null
+  dau: DauPoint[]
+  completion: StepCompletionRate[]
+  missed: MissedQuestion[]
+}
+
+export function AdminStatsPage() {
+  useDocumentTitle('統計 - 管理画面')
+
+  const [state, setState] = useState<StatsState>({ summary: null, dau: [], completion: [], missed: [] })
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+    async function load() {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const [summary, dau, completion, missed] = await Promise.all([
+          getGlobalStatsSummary(),
+          getDauLast30Days(),
+          getStepCompletionRates(),
+          getTopMissedQuestions(10, 3),
+        ])
+        if (!isMounted) return
+        setState({ summary, dau, completion, missed })
+      } catch (e) {
+        if (!isMounted) return
+        setError(e instanceof Error ? e.message : '統計データの取得に失敗しました')
+      } finally {
+        if (isMounted) setIsLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  return (
+    <AdminLayout>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-slate-900">統計</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          DAU・ステップ別完了率・よく間違える問題を俯瞰します。
+        </p>
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-24">
+          <Loader2 className="h-8 w-8 animate-spin text-slate-400" aria-label="読み込み中" />
+        </div>
+      ) : error ? (
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-2xl border border-rose-200 bg-rose-50 p-5 text-sm text-rose-700"
+        >
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>{error}</span>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {/* サマリー */}
+          <section className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            <SummaryCard label="登録ユーザー" value={state.summary?.totalUsers ?? 0} />
+            <SummaryCard
+              label="配布済 Pt"
+              value={(state.summary?.totalPointsDistributed ?? 0).toLocaleString()}
+            />
+            <SummaryCard label="フィードバック" value={state.summary?.totalFeedback ?? 0} />
+            <SummaryCard
+              label="新規フィードバック"
+              value={state.summary?.newFeedback ?? 0}
+              {...(state.summary && state.summary.newFeedback > 0
+                ? { accent: 'text-amber-700' }
+                : {})}
+            />
+          </section>
+
+          {/* DAU 棒グラフ */}
+          <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-3 text-sm font-semibold text-slate-700">DAU（過去 30 日 / JST）</h2>
+            <DauChart points={state.dau} />
+          </section>
+
+          {/* ステップ別完了率 */}
+          <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-3 text-sm font-semibold text-slate-700">
+              ステップ別完了率（着手ユーザー中の完了割合 / 低い順）
+            </h2>
+            {state.completion.length === 0 ? (
+              <p className="text-sm text-slate-500">データがありません</p>
+            ) : (
+              <ul className="space-y-2">
+                {state.completion.map((row) => (
+                  <li key={row.stepId} className="space-y-1">
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="truncate text-slate-700">{stepLabel(row.stepId)}</span>
+                      <span className="shrink-0 font-mono text-xs text-slate-500">
+                        {row.completedUsers} / {row.totalUsers} ({formatPercent(row.completionRate)})
+                      </span>
+                    </div>
+                    <div className="h-2 w-full overflow-hidden rounded-full bg-slate-100">
+                      <div
+                        className="h-full bg-primary-mint transition-[width] duration-500"
+                        style={{ width: `${Math.max(2, row.completionRate * 100)}%` }}
+                      />
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {/* 失敗率が高い問題 */}
+          <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <h2 className="mb-3 text-sm font-semibold text-slate-700">
+              よく間違える問題 TOP 10（試行 3 回以上）
+            </h2>
+            {state.missed.length === 0 ? (
+              <p className="text-sm text-slate-500">該当データがありません</p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-slate-100 text-sm">
+                  <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    <tr>
+                      <th scope="col" className="px-3 py-2">ステップ</th>
+                      <th scope="col" className="px-3 py-2">試行</th>
+                      <th scope="col" className="px-3 py-2">不正解</th>
+                      <th scope="col" className="px-3 py-2">失敗率</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-slate-100">
+                    {state.missed.map((row) => (
+                      <tr key={row.stepId}>
+                        <td className="px-3 py-2 text-slate-700">{stepLabel(row.stepId)}</td>
+                        <td className="px-3 py-2 font-mono text-slate-600">{row.attemptCount}</td>
+                        <td className="px-3 py-2 font-mono text-rose-700">{row.failureCount}</td>
+                        <td className="px-3 py-2 font-mono text-rose-700">{formatPercent(row.failureRate)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        </div>
+      )}
+    </AdminLayout>
+  )
+}
+
+// ─── 内部部品 ──────────────────────────────────────────────
+
+function SummaryCard({
+  label,
+  value,
+  accent,
+}: {
+  label: string
+  value: React.ReactNode
+  accent?: string
+}) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</p>
+      <p className={`mt-1 font-mono text-2xl font-semibold ${accent ?? 'text-slate-900'}`}>{value}</p>
+    </div>
+  )
+}
+
+function DauChart({ points }: { points: DauPoint[] }) {
+  if (points.length === 0) {
+    return <p className="text-sm text-slate-500">データがありません</p>
+  }
+  const max = Math.max(1, ...points.map((p) => p.activeUsers))
+  return (
+    <div>
+      <div className="flex h-40 items-end gap-1">
+        {points.map((p) => {
+          const h = Math.max(2, (p.activeUsers / max) * 100)
+          return (
+            <div key={p.date} className="group relative flex-1 min-w-0">
+              <div
+                className="w-full rounded-t bg-primary-mint/70 transition group-hover:bg-primary-mint"
+                style={{ height: `${h}%` }}
+                aria-label={`${p.date}: ${p.activeUsers} 人`}
+              />
+              <span className="pointer-events-none absolute -top-7 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-slate-800 px-1.5 py-0.5 text-[10px] text-white opacity-0 transition group-hover:opacity-100">
+                {p.date}: {p.activeUsers}
+              </span>
+            </div>
+          )
+        })}
+      </div>
+      <div className="mt-2 flex justify-between text-[10px] text-slate-400">
+        <span>{points[0]?.date}</span>
+        <span>{points[points.length - 1]?.date}</span>
+      </div>
+      <p className="mt-1 text-xs text-slate-500">
+        最大 {max} 人 / 平均{' '}
+        {(points.reduce((s, p) => s + p.activeUsers, 0) / points.length).toFixed(1)} 人
+      </p>
+    </div>
+  )
+}

--- a/apps/web/src/pages/admin/AdminUserDetailPage.tsx
+++ b/apps/web/src/pages/admin/AdminUserDetailPage.tsx
@@ -1,0 +1,327 @@
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { AlertCircle, ArrowLeft, Loader2, Shield } from 'lucide-react'
+import { AdminLayout } from '../../features/admin/components/AdminLayout'
+import { useDocumentTitle } from '../../hooks/useDocumentTitle'
+import { getUserDetail, type AdminUserDetail } from '../../services/adminUsersService'
+import { findStepById } from '../../content/courseData'
+import { BADGE_DEFINITIONS } from '../../services/achievementService'
+
+const BADGE_LABEL: Record<string, string> = Object.fromEntries(
+  BADGE_DEFINITIONS.map((b) => [b.id, b.name]),
+)
+
+function formatJstDateTime(iso: string | null): string {
+  if (!iso) return '—'
+  return new Date(iso).toLocaleString('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function formatJstDate(value: string | null): string {
+  if (!value) return '—'
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) return value
+  return new Date(value).toLocaleDateString('ja-JP', { timeZone: 'Asia/Tokyo' })
+}
+
+function stepLabel(stepId: string): string {
+  return findStepById(stepId)?.title ?? stepId
+}
+
+export function AdminUserDetailPage() {
+  useDocumentTitle('ユーザー詳細 - 管理画面')
+  const { id } = useParams<{ id: string }>()
+
+  const [detail, setDetail] = useState<AdminUserDetail | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [notFound, setNotFound] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id) {
+      setNotFound(true)
+      setIsLoading(false)
+      return
+    }
+
+    let isMounted = true
+    const userId = id
+    async function load() {
+      try {
+        const data = await getUserDetail(userId)
+        if (!isMounted) return
+        if (data === null) {
+          setNotFound(true)
+        } else {
+          setDetail(data)
+        }
+      } catch (e) {
+        if (!isMounted) return
+        setError(e instanceof Error ? e.message : 'ユーザー情報の取得に失敗しました')
+      } finally {
+        if (isMounted) setIsLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      isMounted = false
+    }
+  }, [id])
+
+  if (isLoading) {
+    return (
+      <AdminLayout>
+        <div className="flex items-center justify-center py-24">
+          <Loader2 className="h-8 w-8 animate-spin text-slate-400" aria-label="読み込み中" />
+        </div>
+      </AdminLayout>
+    )
+  }
+
+  if (error) {
+    return (
+      <AdminLayout>
+        <BackLink />
+        <div className="flex items-start gap-3 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <p>{error}</p>
+        </div>
+      </AdminLayout>
+    )
+  }
+
+  if (notFound || !detail) {
+    return (
+      <AdminLayout>
+        <BackLink />
+        <p className="text-sm text-slate-500">ユーザーが見つかりません</p>
+      </AdminLayout>
+    )
+  }
+
+  const { profile, stats, stepProgress, recentSubmissions, dailyHistory, achievements, codeDoctor, miniProject, codeReading, baseNook, pointHistory } = detail
+
+  return (
+    <AdminLayout>
+      <BackLink />
+
+      {/* プロフィールヘッダー */}
+      <section className="mb-6 flex flex-wrap items-start gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="flex-1">
+          <h1 className="flex items-center gap-2 text-xl font-bold text-slate-900">
+            {profile.displayName ?? '(未設定)'}
+            {profile.isAdmin && (
+              <span className="inline-flex items-center gap-0.5 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700">
+                <Shield className="h-3 w-3" aria-hidden="true" />
+                ADMIN
+              </span>
+            )}
+          </h1>
+          <p className="mt-1 break-all font-mono text-xs text-slate-500">{profile.userId}</p>
+          <p className="mt-0.5 text-xs text-slate-400">登録: {formatJstDateTime(profile.createdAt)}</p>
+        </div>
+        <dl className="grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+          <Metric label="累計 Pt" value={(stats?.totalPoints ?? 0).toLocaleString()} />
+          <Metric label="連続日数" value={stats?.currentStreak ?? 0} />
+          <Metric label="最大連続" value={stats?.maxStreak ?? 0} />
+          <Metric label="最終学習" value={formatJstDate(stats?.lastStudyDate ?? null)} />
+        </dl>
+      </section>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        {/* ステップ進捗 */}
+        <Section title={`ステップ進捗 (${stepProgress.length})`}>
+          {stepProgress.length === 0 ? (
+            <EmptyRow>進捗はありません</EmptyRow>
+          ) : (
+            <ul className="divide-y divide-slate-100 text-sm">
+              {stepProgress.map((p) => (
+                <li key={p.id} className="flex items-center justify-between px-1 py-2">
+                  <div className="min-w-0">
+                    <p className="truncate font-medium text-slate-700">{stepLabel(p.step_id)}</p>
+                    <p className="text-xs text-slate-400">{p.step_id}</p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-1 text-xs">
+                    <Flag on={p.read_done} label="R" />
+                    <Flag on={p.practice_done} label="P" />
+                    <Flag on={p.test_done} label="T" />
+                    <Flag on={p.challenge_done} label="C" />
+                    {p.completed_at && (
+                      <span className="ml-2 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-semibold text-emerald-700">
+                        完了
+                      </span>
+                    )}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Section>
+
+        {/* 実績バッジ */}
+        <Section title={`取得バッジ (${achievements.length})`}>
+          {achievements.length === 0 ? (
+            <EmptyRow>バッジは未取得です</EmptyRow>
+          ) : (
+            <ul className="flex flex-wrap gap-2">
+              {achievements.map((a) => (
+                <li
+                  key={a.id}
+                  className="rounded-full bg-primary-mint/20 px-3 py-1 text-xs font-semibold text-primary-dark"
+                  title={formatJstDateTime(a.earned_at)}
+                >
+                  {BADGE_LABEL[a.badge_id] ?? a.badge_id}
+                </li>
+              ))}
+            </ul>
+          )}
+        </Section>
+
+        {/* 提出履歴 */}
+        <Section title={`直近の提出 (${recentSubmissions.length})`}>
+          {recentSubmissions.length === 0 ? (
+            <EmptyRow>提出はありません</EmptyRow>
+          ) : (
+            <ul className="divide-y divide-slate-100 text-sm">
+              {recentSubmissions.map((s) => (
+                <li key={s.id} className="flex items-center justify-between gap-3 py-2">
+                  <div className="min-w-0">
+                    <p className="truncate text-slate-700">{stepLabel(s.step_id)}</p>
+                    <p className="text-xs text-slate-400">{formatJstDateTime(s.submitted_at)}</p>
+                  </div>
+                  <span
+                    className={`shrink-0 rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+                      s.is_passed ? 'bg-emerald-100 text-emerald-700' : 'bg-rose-100 text-rose-700'
+                    }`}
+                  >
+                    {s.is_passed ? '合格' : '不合格'}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Section>
+
+        {/* デイリー履歴 */}
+        <Section title={`デイリー実施 (${dailyHistory.length})`}>
+          {dailyHistory.length === 0 ? (
+            <EmptyRow>実施履歴はありません</EmptyRow>
+          ) : (
+            <ul className="divide-y divide-slate-100 text-sm">
+              {dailyHistory.slice(0, 14).map((d) => (
+                <li key={d.id} className="flex items-center justify-between gap-3 py-2">
+                  <div className="min-w-0">
+                    <p className="font-mono text-xs text-slate-500">{d.challenge_date}</p>
+                    <p className="truncate text-xs text-slate-400">{d.challenge_id}</p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2 text-xs">
+                    <span className="text-slate-500">+{d.points_earned} Pt</span>
+                    <span
+                      className={`rounded-full px-2 py-0.5 text-[10px] font-semibold ${
+                        d.completed ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-500'
+                      }`}
+                    >
+                      {d.completed ? '完了' : '未完了'}
+                    </span>
+                  </div>
+                </li>
+              ))}
+              {dailyHistory.length > 14 && (
+                <li className="pt-2 text-center text-xs text-slate-400">
+                  ... ほか {dailyHistory.length - 14} 件
+                </li>
+              )}
+            </ul>
+          )}
+        </Section>
+
+        {/* 実践モード進捗サマリ */}
+        <Section title="実践モード">
+          <dl className="grid grid-cols-2 gap-3 text-sm">
+            <Metric label="コードドクター" value={codeDoctor.filter((p) => p.solved).length} />
+            <Metric label="ミニプロジェクト" value={miniProject.filter((p) => p.status === 'completed').length} />
+            <Metric label="コードリーディング" value={codeReading.filter((p) => p.completed).length} />
+            <Metric label="Base Nook 解答" value={baseNook.length} />
+          </dl>
+        </Section>
+
+        {/* 直近のポイント履歴 */}
+        <Section title={`直近のポイント (${pointHistory.length})`}>
+          {pointHistory.length === 0 ? (
+            <EmptyRow>ポイント履歴はありません</EmptyRow>
+          ) : (
+            <ul className="divide-y divide-slate-100 text-sm">
+              {pointHistory.map((p) => (
+                <li key={p.id} className="flex items-center justify-between gap-3 py-2">
+                  <div className="min-w-0">
+                    <p className="truncate text-slate-700">{p.reason}</p>
+                    <p className="text-xs text-slate-400">{formatJstDateTime(p.created_at)}</p>
+                  </div>
+                  <span className={`shrink-0 font-mono text-xs ${p.amount >= 0 ? 'text-emerald-700' : 'text-rose-700'}`}>
+                    {p.amount >= 0 ? '+' : ''}{p.amount}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Section>
+      </div>
+    </AdminLayout>
+  )
+}
+
+// ─── 内部部品 ──────────────────────────────────────────────
+
+function BackLink() {
+  return (
+    <div className="mb-4">
+      <Link
+        to="/admin/users"
+        className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-700"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+        ユーザー一覧に戻る
+      </Link>
+    </div>
+  )
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <h2 className="mb-3 text-sm font-semibold text-slate-700">{title}</h2>
+      {children}
+    </section>
+  )
+}
+
+function EmptyRow({ children }: { children: React.ReactNode }) {
+  return <p className="py-2 text-xs text-slate-400">{children}</p>
+}
+
+function Metric({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="rounded-xl bg-slate-50 px-3 py-2">
+      <dt className="text-[10px] font-semibold uppercase tracking-wide text-slate-500">{label}</dt>
+      <dd className="mt-0.5 font-mono text-sm font-semibold text-slate-800">{value}</dd>
+    </div>
+  )
+}
+
+function Flag({ on, label }: { on: boolean; label: string }) {
+  return (
+    <span
+      className={`inline-flex h-5 w-5 items-center justify-center rounded text-[10px] font-bold ${
+        on ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-400'
+      }`}
+      aria-label={`${label}: ${on ? '完了' : '未完了'}`}
+    >
+      {label}
+    </span>
+  )
+}

--- a/apps/web/src/pages/admin/AdminUsersPage.tsx
+++ b/apps/web/src/pages/admin/AdminUsersPage.tsx
@@ -1,0 +1,159 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { AlertCircle, Search, Shield, Users } from 'lucide-react'
+import { AdminLayout } from '../../features/admin/components/AdminLayout'
+import { useDocumentTitle } from '../../hooks/useDocumentTitle'
+import { Spinner } from '../../components/Spinner'
+import { listUsers, type AdminUserSummary } from '../../services/adminUsersService'
+
+function formatJstDate(isoOrDate: string | null): string {
+  if (!isoOrDate) return '—'
+  // learning_stats.last_study_date は DATE 型なので YYYY-MM-DD のまま
+  if (/^\d{4}-\d{2}-\d{2}$/.test(isoOrDate)) return isoOrDate
+  return new Date(isoOrDate).toLocaleDateString('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+}
+
+export function AdminUsersPage() {
+  useDocumentTitle('ユーザー一覧 - 管理画面')
+
+  const [users, setUsers] = useState<AdminUserSummary[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [keyword, setKeyword] = useState('')
+
+  useEffect(() => {
+    let isMounted = true
+    async function load() {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const data = await listUsers()
+        if (!isMounted) return
+        setUsers(data)
+      } catch (e) {
+        if (!isMounted) return
+        setError(e instanceof Error ? e.message : 'ユーザー一覧の取得に失敗しました')
+      } finally {
+        if (isMounted) setIsLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  const filtered = useMemo(() => {
+    const q = keyword.trim().toLowerCase()
+    if (q === '') return users
+    return users.filter((u) => {
+      const email = (u.email ?? '').toLowerCase()
+      const name = (u.displayName ?? '').toLowerCase()
+      return email.includes(q) || name.includes(q) || u.userId.toLowerCase().includes(q)
+    })
+  }, [users, keyword])
+
+  return (
+    <AdminLayout>
+      {/* ヘッダー */}
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-slate-900">ユーザー一覧</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          登録ユーザーの学習状況・累計ポイント・取得バッジ数を確認できます。
+        </p>
+      </div>
+
+      {/* 検索 */}
+      <div className="mb-4 flex items-center gap-2 rounded-2xl border border-slate-200 bg-white px-5 py-3 shadow-sm">
+        <Search className="h-4 w-4 shrink-0 text-slate-400" aria-hidden="true" />
+        <label htmlFor="user-search" className="sr-only">
+          ユーザーを検索
+        </label>
+        <input
+          id="user-search"
+          type="search"
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          placeholder="メールアドレス・表示名・ユーザー ID で検索"
+          className="w-full bg-transparent text-sm text-slate-700 placeholder:text-slate-400 focus:outline-none"
+        />
+        <span className="shrink-0 text-xs text-slate-400">
+          {filtered.length} / {users.length}
+        </span>
+      </div>
+
+      {/* コンテンツ */}
+      {isLoading ? (
+        <div className="flex justify-center py-16">
+          <Spinner size="lg" />
+        </div>
+      ) : error ? (
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-2xl border border-rose-200 bg-rose-50 p-5 text-sm text-rose-700"
+        >
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>{error}</span>
+        </div>
+      ) : filtered.length === 0 ? (
+        <div className="flex flex-col items-center gap-3 rounded-2xl border border-slate-200 bg-white py-16 shadow-sm">
+          <Users className="h-10 w-10 text-slate-300" aria-hidden="true" />
+          <p className="text-sm text-slate-500">該当するユーザーはいません</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <table className="min-w-full divide-y divide-slate-100 text-sm">
+            <thead className="bg-slate-50 text-left text-xs font-semibold uppercase tracking-wide text-slate-500">
+              <tr>
+                <th scope="col" className="px-5 py-3">ユーザー</th>
+                <th scope="col" className="px-5 py-3">ポイント</th>
+                <th scope="col" className="px-5 py-3">連続 / 最大</th>
+                <th scope="col" className="px-5 py-3">最終学習日</th>
+                <th scope="col" className="px-5 py-3">バッジ</th>
+                <th scope="col" className="px-5 py-3">登録日</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {filtered.map((u) => (
+                <tr key={u.userId} className="transition hover:bg-slate-50">
+                  <td className="px-5 py-3">
+                    <Link
+                      to={`/admin/users/${u.userId}`}
+                      className="inline-flex flex-col gap-0.5 text-slate-800 hover:text-primary-dark"
+                    >
+                      <span className="flex items-center gap-1.5 font-medium">
+                        {u.displayName ?? '(未設定)'}
+                        {u.isAdmin && (
+                          <span
+                            className="inline-flex items-center gap-0.5 rounded-full bg-amber-100 px-1.5 py-0.5 text-[10px] font-semibold text-amber-700"
+                            title="管理者"
+                          >
+                            <Shield className="h-3 w-3" aria-hidden="true" />
+                            ADMIN
+                          </span>
+                        )}
+                      </span>
+                      <span className="text-xs text-slate-500">{u.email ?? '(email 取得不可)'}</span>
+                    </Link>
+                  </td>
+                  <td className="px-5 py-3 font-mono text-slate-700">{u.totalPoints.toLocaleString()}</td>
+                  <td className="px-5 py-3 text-slate-600">
+                    {u.currentStreak} / {u.maxStreak}
+                  </td>
+                  <td className="px-5 py-3 text-slate-600">{formatJstDate(u.lastStudyDate)}</td>
+                  <td className="px-5 py-3 text-slate-600">{u.badgeCount}</td>
+                  <td className="px-5 py-3 text-xs text-slate-500">{formatJstDate(u.createdAt)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </AdminLayout>
+  )
+}

--- a/apps/web/src/services/__tests__/adminOpsService.test.ts
+++ b/apps/web/src/services/__tests__/adminOpsService.test.ts
@@ -1,0 +1,129 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  MAX_GRANT_POINTS_AMOUNT,
+  MAX_GRANT_POINTS_REASON_LENGTH,
+  grantBadge,
+  grantPoints,
+} from '../adminOpsService'
+
+const rpc = vi.fn()
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => rpc(...args),
+  },
+}))
+
+const TARGET = '11111111-1111-1111-1111-111111111111'
+
+describe('grantPoints', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('admin_grant_points RPC を正しい引数で呼び出す', async () => {
+    rpc.mockResolvedValue({ error: null })
+    await grantPoints({ targetUserId: TARGET, amount: 100, reason: 'キャンペーン' })
+    expect(rpc).toHaveBeenCalledWith('admin_grant_points', {
+      p_target_user_id: TARGET,
+      p_amount: 100,
+      p_reason: 'キャンペーン',
+    })
+  })
+
+  it('reason の前後空白は trim して送る', async () => {
+    rpc.mockResolvedValue({ error: null })
+    await grantPoints({ targetUserId: TARGET, amount: 10, reason: '  hi  ' })
+    expect(rpc).toHaveBeenCalledWith('admin_grant_points', expect.objectContaining({ p_reason: 'hi' }))
+  })
+
+  it('不正な UUID は RPC を呼ばずに例外を投げる', async () => {
+    await expect(
+      grantPoints({ targetUserId: 'not-uuid', amount: 10, reason: 'x' }),
+    ).rejects.toThrow('targetUserId must be a valid UUID')
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('amount が 0 以下は例外を投げる', async () => {
+    await expect(
+      grantPoints({ targetUserId: TARGET, amount: 0, reason: 'x' }),
+    ).rejects.toThrow('amount must be a positive integer')
+    await expect(
+      grantPoints({ targetUserId: TARGET, amount: -1, reason: 'x' }),
+    ).rejects.toThrow('amount must be a positive integer')
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('amount が上限超過は例外を投げる', async () => {
+    await expect(
+      grantPoints({
+        targetUserId: TARGET,
+        amount: MAX_GRANT_POINTS_AMOUNT + 1,
+        reason: 'x',
+      }),
+    ).rejects.toThrow(`amount must be at most ${MAX_GRANT_POINTS_AMOUNT}`)
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('空の reason は例外を投げる', async () => {
+    await expect(
+      grantPoints({ targetUserId: TARGET, amount: 10, reason: '   ' }),
+    ).rejects.toThrow('reason must not be empty')
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('reason が上限超過は例外を投げる', async () => {
+    await expect(
+      grantPoints({
+        targetUserId: TARGET,
+        amount: 10,
+        reason: 'a'.repeat(MAX_GRANT_POINTS_REASON_LENGTH + 1),
+      }),
+    ).rejects.toThrow(`reason must be at most ${MAX_GRANT_POINTS_REASON_LENGTH} characters`)
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('Supabase エラーを AppError に変換する', async () => {
+    rpc.mockResolvedValue({ error: { code: 'DB_ERROR', message: 'rls denied' } })
+    await expect(
+      grantPoints({ targetUserId: TARGET, amount: 10, reason: 'x' }),
+    ).rejects.toMatchObject({ name: 'AppError', userMessage: 'ポイントの付与に失敗しました' })
+  })
+})
+
+describe('grantBadge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('admin_grant_badge RPC を正しい引数で呼び出す', async () => {
+    rpc.mockResolvedValue({ error: null })
+    await grantBadge({ targetUserId: TARGET, badgeId: 'first-step' })
+    expect(rpc).toHaveBeenCalledWith('admin_grant_badge', {
+      p_target_user_id: TARGET,
+      p_badge_id: 'first-step',
+    })
+  })
+
+  it('未知のバッジ ID は例外を投げる', async () => {
+    await expect(
+      // @ts-expect-error - 意図的に不正な値を渡す
+      grantBadge({ targetUserId: TARGET, badgeId: 'unknown-badge' }),
+    ).rejects.toThrow('unknown badge_id')
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('不正な UUID は例外を投げる', async () => {
+    await expect(
+      grantBadge({ targetUserId: 'not-uuid', badgeId: 'first-step' }),
+    ).rejects.toThrow('targetUserId must be a valid UUID')
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('Supabase エラーを AppError に変換する', async () => {
+    rpc.mockResolvedValue({ error: { code: 'DB_ERROR', message: 'rls denied' } })
+    await expect(
+      grantBadge({ targetUserId: TARGET, badgeId: 'first-step' }),
+    ).rejects.toMatchObject({ name: 'AppError', userMessage: 'バッジの付与に失敗しました' })
+  })
+})

--- a/apps/web/src/services/__tests__/adminStatsService.test.ts
+++ b/apps/web/src/services/__tests__/adminStatsService.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  getDauLast30Days,
+  getGlobalStatsSummary,
+  getStepCompletionRates,
+  getTopMissedQuestions,
+} from '../adminStatsService'
+
+const rpc = vi.fn()
+
+// PostgREST の head:true / count / select / eq をモックするための状態
+const tableState = {
+  profilesCount: 0 as number | null,
+  pointHistoryRows: [] as Array<{ amount: number }>,
+  pointHistoryError: null as unknown,
+  profilesError: null as unknown,
+  feedbackTotalCount: 0 as number | null,
+  feedbackTotalError: null as unknown,
+  feedbackNewCount: 0 as number | null,
+  feedbackNewError: null as unknown,
+}
+
+function createProfilesBuilder() {
+  return {
+    select: () =>
+      Promise.resolve({ count: tableState.profilesCount, error: tableState.profilesError }),
+  }
+}
+
+function createPointHistoryBuilder() {
+  return {
+    select: () =>
+      Promise.resolve({ data: tableState.pointHistoryRows, error: tableState.pointHistoryError }),
+  }
+}
+
+function createUserFeedbackBuilder() {
+  // select() は thenable を返し、eq() を呼ぶと status=new のカウントに切り替わる
+  return {
+    select: () => {
+      const chain = {
+        eq() {
+          return Promise.resolve({
+            count: tableState.feedbackNewCount,
+            error: tableState.feedbackNewError,
+          })
+        },
+        then(resolve: (v: unknown) => unknown, reject: (r: unknown) => unknown) {
+          return Promise.resolve({
+            count: tableState.feedbackTotalCount,
+            error: tableState.feedbackTotalError,
+          }).then(resolve, reject)
+        },
+      }
+      return chain
+    },
+  }
+}
+
+const from = vi.fn((table: string) => {
+  if (table === 'profiles') return createProfilesBuilder()
+  if (table === 'point_history') return createPointHistoryBuilder()
+  if (table === 'user_feedback') return createUserFeedbackBuilder()
+  throw new Error(`unexpected table: ${table}`)
+})
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => rpc(...args),
+    from: (...args: unknown[]) => from(...(args as [string])),
+  },
+}))
+
+function resetState() {
+  vi.clearAllMocks()
+  tableState.profilesCount = 0
+  tableState.pointHistoryRows = []
+  tableState.pointHistoryError = null
+  tableState.profilesError = null
+  tableState.feedbackTotalCount = 0
+  tableState.feedbackTotalError = null
+  tableState.feedbackNewCount = 0
+  tableState.feedbackNewError = null
+}
+
+describe('getDauLast30Days', () => {
+  beforeEach(resetState)
+
+  it('get_dau_last_30_days RPC を呼び DauPoint[] に変換する', async () => {
+    rpc.mockResolvedValue({
+      data: [
+        { activity_date: '2026-04-01', active_users: 3 },
+        { activity_date: '2026-04-02', active_users: 5 },
+      ],
+      error: null,
+    })
+    const result = await getDauLast30Days()
+    expect(rpc).toHaveBeenCalledWith('get_dau_last_30_days')
+    expect(result).toEqual([
+      { date: '2026-04-01', activeUsers: 3 },
+      { date: '2026-04-02', activeUsers: 5 },
+    ])
+  })
+
+  it('data が null なら空配列を返す', async () => {
+    rpc.mockResolvedValue({ data: null, error: null })
+    expect(await getDauLast30Days()).toEqual([])
+  })
+
+  it('RPC エラーを AppError に変換する', async () => {
+    rpc.mockResolvedValue({ data: null, error: { code: 'DB_ERROR', message: 'forbidden' } })
+    await expect(getDauLast30Days()).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: 'DAU の取得に失敗しました',
+    })
+  })
+})
+
+describe('getStepCompletionRates', () => {
+  beforeEach(resetState)
+
+  it('get_step_completion_rates RPC 結果を変換する', async () => {
+    rpc.mockResolvedValue({
+      data: [
+        { step_id: 'usestate-basic', total_users: 10, completed_users: 7, completion_rate: 0.7 },
+      ],
+      error: null,
+    })
+    const result = await getStepCompletionRates()
+    expect(rpc).toHaveBeenCalledWith('get_step_completion_rates')
+    expect(result).toEqual([
+      { stepId: 'usestate-basic', totalUsers: 10, completedUsers: 7, completionRate: 0.7 },
+    ])
+  })
+
+  it('RPC エラーを AppError に変換する', async () => {
+    rpc.mockResolvedValue({ data: null, error: { code: 'DB_ERROR', message: 'x' } })
+    await expect(getStepCompletionRates()).rejects.toMatchObject({
+      userMessage: 'ステップ完了率の取得に失敗しました',
+    })
+  })
+})
+
+describe('getTopMissedQuestions', () => {
+  beforeEach(resetState)
+
+  it('get_top_missed_questions RPC を limit/min で呼ぶ', async () => {
+    rpc.mockResolvedValue({ data: [], error: null })
+    await getTopMissedQuestions(5, 2)
+    expect(rpc).toHaveBeenCalledWith('get_top_missed_questions', {
+      p_limit: 5,
+      p_min_attempts: 2,
+    })
+  })
+
+  it('limit を 1..100 にクランプ', async () => {
+    rpc.mockResolvedValue({ data: [], error: null })
+    await getTopMissedQuestions(999, 3)
+    expect(rpc).toHaveBeenCalledWith('get_top_missed_questions', {
+      p_limit: 100,
+      p_min_attempts: 3,
+    })
+    await getTopMissedQuestions(0, 3)
+    expect(rpc).toHaveBeenLastCalledWith('get_top_missed_questions', {
+      p_limit: 1,
+      p_min_attempts: 3,
+    })
+  })
+
+  it('min_attempts は最小 1', async () => {
+    rpc.mockResolvedValue({ data: [], error: null })
+    await getTopMissedQuestions(10, 0)
+    expect(rpc).toHaveBeenCalledWith('get_top_missed_questions', {
+      p_limit: 10,
+      p_min_attempts: 1,
+    })
+  })
+
+  it('RPC 結果を変換する', async () => {
+    rpc.mockResolvedValue({
+      data: [
+        { step_id: 'events', attempt_count: 10, failure_count: 7, failure_rate: 0.7 },
+      ],
+      error: null,
+    })
+    const result = await getTopMissedQuestions()
+    expect(result).toEqual([
+      { stepId: 'events', attemptCount: 10, failureCount: 7, failureRate: 0.7 },
+    ])
+  })
+})
+
+describe('getGlobalStatsSummary', () => {
+  beforeEach(resetState)
+
+  it('4 つのクエリを並列呼びし集計結果を返す', async () => {
+    tableState.profilesCount = 42
+    tableState.pointHistoryRows = [{ amount: 10 }, { amount: 20 }, { amount: 5 }]
+    tableState.feedbackTotalCount = 8
+    tableState.feedbackNewCount = 3
+
+    const summary = await getGlobalStatsSummary()
+
+    expect(from).toHaveBeenCalledWith('profiles')
+    expect(from).toHaveBeenCalledWith('point_history')
+    expect(from).toHaveBeenCalledWith('user_feedback')
+    expect(summary).toEqual({
+      totalUsers: 42,
+      totalPointsDistributed: 35,
+      totalFeedback: 8,
+      newFeedback: 3,
+    })
+  })
+
+  it('いずれかのクエリエラーで AppError を投げる', async () => {
+    tableState.pointHistoryError = { code: 'DB_ERROR', message: 'boom' }
+    await expect(getGlobalStatsSummary()).rejects.toMatchObject({
+      userMessage: 'ポイント履歴の取得に失敗しました',
+    })
+  })
+})

--- a/apps/web/src/services/__tests__/adminUsersService.test.ts
+++ b/apps/web/src/services/__tests__/adminUsersService.test.ts
@@ -1,0 +1,222 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getUserDetail, listUsers } from '../adminUsersService'
+
+const rpc = vi.fn()
+
+// 各テーブル用の最終応答を保持するシンプルなバケット。
+// ビルダーは select().eq().(maybeSingle|order.limit|...) のチェーンを受け付けるが、
+// どのチェーンでも最終的にこのバケットの応答を返す。
+type TableKey =
+  | 'profiles'
+  | 'learning_stats'
+  | 'step_progress'
+  | 'challenge_submissions'
+  | 'daily_challenge_history'
+  | 'achievements'
+  | 'code_doctor_progress'
+  | 'mini_project_progress'
+  | 'code_reading_progress'
+  | 'base_nook_progress'
+  | 'point_history'
+
+type Bucket = { data: unknown; error: unknown }
+
+const state: Record<TableKey, Bucket> = {
+  profiles: { data: null, error: null },
+  learning_stats: { data: null, error: null },
+  step_progress: { data: [], error: null },
+  challenge_submissions: { data: [], error: null },
+  daily_challenge_history: { data: [], error: null },
+  achievements: { data: [], error: null },
+  code_doctor_progress: { data: [], error: null },
+  mini_project_progress: { data: [], error: null },
+  code_reading_progress: { data: [], error: null },
+  base_nook_progress: { data: [], error: null },
+  point_history: { data: [], error: null },
+}
+
+function createBuilder(key: TableKey) {
+  const resolved = () => Promise.resolve(state[key])
+  const chain = {
+    eq() {
+      return chain
+    },
+    order() {
+      return chain
+    },
+    limit() {
+      return chain
+    },
+    maybeSingle() {
+      return resolved()
+    },
+    then(resolve: (v: unknown) => unknown, reject: (r: unknown) => unknown) {
+      return resolved().then(resolve, reject)
+    },
+  }
+  return {
+    select: () => chain,
+  }
+}
+
+const from = vi.fn((table: string) => {
+  if (table in state) return createBuilder(table as TableKey)
+  throw new Error(`unexpected table: ${table}`)
+})
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {
+    rpc: (...args: unknown[]) => rpc(...args),
+    from: (...args: unknown[]) => from(...(args as [string])),
+  },
+}))
+
+const VALID = '11111111-1111-1111-1111-111111111111'
+
+function resetState() {
+  vi.clearAllMocks()
+  ;(Object.keys(state) as TableKey[]).forEach((k) => {
+    const isArray = [
+      'step_progress',
+      'challenge_submissions',
+      'daily_challenge_history',
+      'achievements',
+      'code_doctor_progress',
+      'mini_project_progress',
+      'code_reading_progress',
+      'base_nook_progress',
+      'point_history',
+    ].includes(k)
+    state[k] = { data: isArray ? [] : null, error: null }
+  })
+}
+
+describe('listUsers', () => {
+  beforeEach(resetState)
+
+  it('admin_list_users RPC を呼び AdminUserSummary[] に変換する', async () => {
+    rpc.mockResolvedValue({
+      data: [
+        {
+          user_id: VALID,
+          email: 'a@example.com',
+          display_name: 'Alice',
+          is_admin: true,
+          total_points: 500,
+          current_streak: 3,
+          max_streak: 7,
+          last_study_date: '2026-04-10',
+          badge_count: 4,
+          created_at: '2026-03-01T00:00:00Z',
+        },
+      ],
+      error: null,
+    })
+
+    const result = await listUsers()
+    expect(rpc).toHaveBeenCalledWith('admin_list_users')
+    expect(result).toEqual([
+      {
+        userId: VALID,
+        email: 'a@example.com',
+        displayName: 'Alice',
+        isAdmin: true,
+        totalPoints: 500,
+        currentStreak: 3,
+        maxStreak: 7,
+        lastStudyDate: '2026-04-10',
+        badgeCount: 4,
+        createdAt: '2026-03-01T00:00:00Z',
+      },
+    ])
+  })
+
+  it('data が null のときは空配列を返す', async () => {
+    rpc.mockResolvedValue({ data: null, error: null })
+    expect(await listUsers()).toEqual([])
+  })
+
+  it('RPC エラーを AppError に変換する', async () => {
+    rpc.mockResolvedValue({ data: null, error: { code: 'DB_ERROR', message: 'forbidden' } })
+    await expect(listUsers()).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: 'ユーザー一覧の取得に失敗しました',
+    })
+  })
+})
+
+describe('getUserDetail', () => {
+  beforeEach(resetState)
+
+  it('不正な UUID は例外を投げる', async () => {
+    await expect(getUserDetail('not-uuid')).rejects.toThrow('userId must be a valid UUID')
+  })
+
+  it('profile が 0 件なら null を返す', async () => {
+    state.profiles = { data: null, error: null }
+    const result = await getUserDetail(VALID)
+    expect(result).toBeNull()
+  })
+
+  it('全テーブルを取得し AdminUserDetail を組み立てる', async () => {
+    state.profiles = {
+      data: {
+        id: VALID,
+        display_name: 'Bob',
+        is_admin: false,
+        created_at: '2026-03-01T00:00:00Z',
+      },
+      error: null,
+    }
+    state.learning_stats = {
+      data: {
+        total_points: 120,
+        current_streak: 2,
+        max_streak: 5,
+        last_study_date: '2026-04-10',
+        updated_at: '2026-04-10T00:00:00Z',
+      },
+      error: null,
+    }
+    state.step_progress = { data: [{ id: 's1' }], error: null }
+    state.challenge_submissions = { data: [{ id: 'c1' }], error: null }
+    state.daily_challenge_history = { data: [{ id: 'd1' }], error: null }
+    state.achievements = { data: [{ id: 'a1', badge_id: 'first-step' }], error: null }
+    state.code_doctor_progress = { data: [{ id: 'cd1', solved: true }], error: null }
+    state.mini_project_progress = { data: [{ id: 'mp1', status: 'completed' }], error: null }
+    state.code_reading_progress = { data: [{ id: 'cr1', completed: true }], error: null }
+    state.base_nook_progress = { data: [{ id: 'bn1' }], error: null }
+    state.point_history = { data: [{ id: 'ph1', amount: 10 }], error: null }
+
+    const result = await getUserDetail(VALID)
+    expect(result).not.toBeNull()
+    expect(result?.profile).toEqual({
+      userId: VALID,
+      displayName: 'Bob',
+      isAdmin: false,
+      createdAt: '2026-03-01T00:00:00Z',
+    })
+    expect(result?.stats?.totalPoints).toBe(120)
+    expect(result?.stepProgress).toHaveLength(1)
+    expect(result?.achievements).toHaveLength(1)
+    expect(result?.pointHistory).toHaveLength(1)
+  })
+
+  it('いずれかのテーブルがエラーなら AppError を投げる', async () => {
+    state.profiles = {
+      data: { id: VALID, display_name: 'X', is_admin: false, created_at: '2026-03-01T00:00:00Z' },
+      error: null,
+    }
+    state.point_history = { data: null, error: { code: 'DB_ERROR', message: 'x' } }
+    await expect(getUserDetail(VALID)).rejects.toMatchObject({
+      userMessage: 'ユーザー詳細の取得に失敗しました',
+    })
+  })
+
+  it('profile エラーは専用メッセージで AppError を投げる', async () => {
+    state.profiles = { data: null, error: { code: 'DB_ERROR', message: 'rls denied' } }
+    await expect(getUserDetail(VALID)).rejects.toMatchObject({
+      userMessage: 'ユーザー情報の取得に失敗しました',
+    })
+  })
+})

--- a/apps/web/src/services/adminOpsService.ts
+++ b/apps/web/src/services/adminOpsService.ts
@@ -1,0 +1,72 @@
+/**
+ * 管理者向け運用サービス
+ *
+ * 015_admin_ops_rpc.sql の RPC を薄くラップする。
+ * DB 側でも is_admin() ガード + バリデーションが走るが、
+ * クライアント側でも UX のために事前バリデーションする。
+ */
+
+import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+import { assertMaxLength, assertPositiveInteger, assertUuid } from '../shared/validation'
+import { BADGE_DEFINITIONS, type BadgeId } from './achievementService'
+
+/** 単一ポイント付与の上限（過剰な一括付与を防ぐ） */
+export const MAX_GRANT_POINTS_AMOUNT = 10000
+/** 理由の最大文字数（DB 側の制約と揃える） */
+export const MAX_GRANT_POINTS_REASON_LENGTH = 200
+
+const BADGE_ID_SET = new Set<string>(BADGE_DEFINITIONS.map((b) => b.id))
+
+export interface GrantPointsInput {
+  targetUserId: string
+  amount: number
+  reason: string
+}
+
+export interface GrantBadgeInput {
+  targetUserId: string
+  badgeId: BadgeId
+}
+
+/**
+ * 任意ユーザーにポイントを手動付与する。
+ * DB 側で admin_audit_log への INSERT も同時に実行される（fail-loud）。
+ */
+export async function grantPoints(input: GrantPointsInput): Promise<void> {
+  assertUuid(input.targetUserId, 'targetUserId')
+  assertPositiveInteger(input.amount, 'amount')
+  if (input.amount > MAX_GRANT_POINTS_AMOUNT) {
+    throw new Error(`amount must be at most ${MAX_GRANT_POINTS_AMOUNT}`)
+  }
+  const trimmed = input.reason.trim()
+  if (trimmed.length === 0) {
+    throw new Error('reason must not be empty')
+  }
+  assertMaxLength(trimmed, MAX_GRANT_POINTS_REASON_LENGTH, 'reason')
+
+  const { error } = await supabase.rpc('admin_grant_points', {
+    p_target_user_id: input.targetUserId,
+    p_amount: input.amount,
+    p_reason: trimmed,
+  })
+  if (error) {
+    throw fromSupabaseError(error, 'ポイントの付与に失敗しました')
+  }
+}
+
+/** 任意ユーザーにバッジを手動付与する（既に所持していれば no-op 扱い。監査ログは記録） */
+export async function grantBadge(input: GrantBadgeInput): Promise<void> {
+  assertUuid(input.targetUserId, 'targetUserId')
+  if (!BADGE_ID_SET.has(input.badgeId)) {
+    throw new Error('unknown badge_id')
+  }
+
+  const { error } = await supabase.rpc('admin_grant_badge', {
+    p_target_user_id: input.targetUserId,
+    p_badge_id: input.badgeId,
+  })
+  if (error) {
+    throw fromSupabaseError(error, 'バッジの付与に失敗しました')
+  }
+}

--- a/apps/web/src/services/adminStatsService.ts
+++ b/apps/web/src/services/adminStatsService.ts
@@ -1,0 +1,110 @@
+/**
+ * 管理者向け統計サービス
+ *
+ * 014_admin_stats_rpc.sql で定義された 3 つの RPC をラップする。
+ * 加えて、シンプルに count / sum で済む集計は PostgREST を直接使う。
+ * いずれも admin 用 RLS / RPC ガードで非 admin からの呼び出しは拒否される。
+ */
+
+import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+
+export interface DauPoint {
+  date: string // YYYY-MM-DD (JST)
+  activeUsers: number
+}
+
+export interface StepCompletionRate {
+  stepId: string
+  totalUsers: number
+  completedUsers: number
+  completionRate: number // 0.0 - 1.0
+}
+
+export interface MissedQuestion {
+  stepId: string
+  attemptCount: number
+  failureCount: number
+  failureRate: number // 0.0 - 1.0
+}
+
+export interface GlobalStatsSummary {
+  totalUsers: number
+  totalPointsDistributed: number
+  totalFeedback: number
+  newFeedback: number
+}
+
+/** 過去 30 日分の DAU を取得（直近が末尾の昇順） */
+export async function getDauLast30Days(): Promise<DauPoint[]> {
+  const { data, error } = await supabase.rpc('get_dau_last_30_days')
+  if (error) {
+    throw fromSupabaseError(error, 'DAU の取得に失敗しました')
+  }
+  return (data ?? []).map((row) => ({
+    date: row.activity_date,
+    activeUsers: row.active_users,
+  }))
+}
+
+/** ステップ別完了率（低い順） */
+export async function getStepCompletionRates(): Promise<StepCompletionRate[]> {
+  const { data, error } = await supabase.rpc('get_step_completion_rates')
+  if (error) {
+    throw fromSupabaseError(error, 'ステップ完了率の取得に失敗しました')
+  }
+  return (data ?? []).map((row) => ({
+    stepId: row.step_id,
+    totalUsers: row.total_users,
+    completedUsers: row.completed_users,
+    completionRate: Number(row.completion_rate),
+  }))
+}
+
+/** 失敗率が高い問題 TOP N */
+export async function getTopMissedQuestions(
+  limit = 10,
+  minAttempts = 3,
+): Promise<MissedQuestion[]> {
+  const safeLimit = Math.max(1, Math.min(limit, 100))
+  const safeMin = Math.max(1, minAttempts)
+  const { data, error } = await supabase.rpc('get_top_missed_questions', {
+    p_limit: safeLimit,
+    p_min_attempts: safeMin,
+  })
+  if (error) {
+    throw fromSupabaseError(error, 'よく間違える問題の取得に失敗しました')
+  }
+  return (data ?? []).map((row) => ({
+    stepId: row.step_id,
+    attemptCount: row.attempt_count,
+    failureCount: row.failure_count,
+    failureRate: Number(row.failure_rate),
+  }))
+}
+
+/** グローバルサマリー（ユーザー総数・総配布ポイント・フィードバック集計） */
+export async function getGlobalStatsSummary(): Promise<GlobalStatsSummary> {
+  const [usersRes, pointsRes, feedbackTotalRes, feedbackNewRes] = await Promise.all([
+    supabase.from('profiles').select('*', { count: 'exact', head: true }),
+    supabase.from('point_history').select('amount'),
+    supabase.from('user_feedback').select('*', { count: 'exact', head: true }),
+    supabase.from('user_feedback').select('*', { count: 'exact', head: true }).eq('status', 'new'),
+  ])
+
+  if (usersRes.error) throw fromSupabaseError(usersRes.error, 'ユーザー総数の取得に失敗しました')
+  if (pointsRes.error) throw fromSupabaseError(pointsRes.error, 'ポイント履歴の取得に失敗しました')
+  if (feedbackTotalRes.error)
+    throw fromSupabaseError(feedbackTotalRes.error, 'フィードバック件数の取得に失敗しました')
+  if (feedbackNewRes.error)
+    throw fromSupabaseError(feedbackNewRes.error, '新規フィードバック件数の取得に失敗しました')
+
+  const totalPoints = (pointsRes.data ?? []).reduce((sum, row) => sum + (row.amount ?? 0), 0)
+
+  return {
+    totalUsers: usersRes.count ?? 0,
+    totalPointsDistributed: totalPoints,
+    totalFeedback: feedbackTotalRes.count ?? 0,
+    newFeedback: feedbackNewRes.count ?? 0,
+  }
+}

--- a/apps/web/src/services/adminUsersService.ts
+++ b/apps/web/src/services/adminUsersService.ts
@@ -1,0 +1,175 @@
+/**
+ * 管理者向けユーザー閲覧サービス
+ *
+ * - listUsers: admin_list_users RPC（auth.users.email を取得するため SECURITY DEFINER RPC）
+ * - getUserDetail: 複数テーブルを横断取得（013/014 で追加した admin 用 SELECT ポリシーに依存）
+ *
+ * RPC / クエリ失敗時は fromSupabaseError で AppError に変換する。
+ * 日付指定が無い系の統計以外、ユーザー ID は常に UUID バリデーションする。
+ */
+
+import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+import { assertUuid } from '../shared/validation'
+import type { Tables } from '../shared/types/database.types'
+
+export interface AdminUserSummary {
+  userId: string
+  email: string | null
+  displayName: string | null
+  isAdmin: boolean
+  totalPoints: number
+  currentStreak: number
+  maxStreak: number
+  lastStudyDate: string | null
+  badgeCount: number
+  createdAt: string
+}
+
+export interface AdminUserDetail {
+  profile: {
+    userId: string
+    displayName: string | null
+    isAdmin: boolean
+    createdAt: string
+  }
+  stats: {
+    totalPoints: number
+    currentStreak: number
+    maxStreak: number
+    lastStudyDate: string | null
+    updatedAt: string
+  } | null
+  stepProgress: Tables<'step_progress'>[]
+  recentSubmissions: Tables<'challenge_submissions'>[]
+  dailyHistory: Tables<'daily_challenge_history'>[]
+  achievements: Tables<'achievements'>[]
+  codeDoctor: Tables<'code_doctor_progress'>[]
+  miniProject: Tables<'mini_project_progress'>[]
+  codeReading: Tables<'code_reading_progress'>[]
+  baseNook: Tables<'base_nook_progress'>[]
+  pointHistory: Tables<'point_history'>[]
+}
+
+/** 管理者向けユーザー一覧を取得（admin_list_users RPC） */
+export async function listUsers(): Promise<AdminUserSummary[]> {
+  const { data, error } = await supabase.rpc('admin_list_users')
+  if (error) {
+    throw fromSupabaseError(error, 'ユーザー一覧の取得に失敗しました')
+  }
+  return (data ?? []).map((row) => ({
+    userId: row.user_id,
+    email: row.email,
+    displayName: row.display_name,
+    isAdmin: row.is_admin,
+    totalPoints: row.total_points,
+    currentStreak: row.current_streak,
+    maxStreak: row.max_streak,
+    lastStudyDate: row.last_study_date,
+    badgeCount: row.badge_count,
+    createdAt: row.created_at,
+  }))
+}
+
+/**
+ * ユーザー詳細（各種進捗・履歴）を並列取得する。
+ * 監視対象ユーザーの各テーブルを admin 用 RLS ポリシー経由で SELECT する。
+ * 一部テーブルで 0 件でもエラーではない（取得できない列のみエラー扱い）。
+ */
+export async function getUserDetail(userId: string): Promise<AdminUserDetail | null> {
+  assertUuid(userId, 'userId')
+
+  const [
+    profileRes,
+    statsRes,
+    stepRes,
+    submissionsRes,
+    dailyRes,
+    achievementsRes,
+    doctorRes,
+    projectRes,
+    readingRes,
+    baseNookRes,
+    pointsRes,
+  ] = await Promise.all([
+    supabase.from('profiles').select('*').eq('id', userId).maybeSingle(),
+    supabase.from('learning_stats').select('*').eq('user_id', userId).maybeSingle(),
+    supabase.from('step_progress').select('*').eq('user_id', userId).order('updated_at', { ascending: false }),
+    supabase
+      .from('challenge_submissions')
+      .select('*')
+      .eq('user_id', userId)
+      .order('submitted_at', { ascending: false })
+      .limit(30),
+    supabase
+      .from('daily_challenge_history')
+      .select('*')
+      .eq('user_id', userId)
+      .order('challenge_date', { ascending: false })
+      .limit(60),
+    supabase.from('achievements').select('*').eq('user_id', userId).order('earned_at', { ascending: false }),
+    supabase.from('code_doctor_progress').select('*').eq('user_id', userId),
+    supabase.from('mini_project_progress').select('*').eq('user_id', userId),
+    supabase.from('code_reading_progress').select('*').eq('user_id', userId),
+    supabase.from('base_nook_progress').select('*').eq('user_id', userId).order('answered_at', { ascending: false }),
+    supabase
+      .from('point_history')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+      .limit(30),
+  ])
+
+  // profile 取得が 0 件ならユーザー自体が存在しない扱い
+  if (profileRes.error) {
+    throw fromSupabaseError(profileRes.error, 'ユーザー情報の取得に失敗しました')
+  }
+  if (profileRes.data === null) {
+    return null
+  }
+
+  // 他テーブルの error は fail-loud で例外化
+  for (const res of [
+    statsRes,
+    stepRes,
+    submissionsRes,
+    dailyRes,
+    achievementsRes,
+    doctorRes,
+    projectRes,
+    readingRes,
+    baseNookRes,
+    pointsRes,
+  ] as const) {
+    if (res.error) {
+      throw fromSupabaseError(res.error, 'ユーザー詳細の取得に失敗しました')
+    }
+  }
+
+  return {
+    profile: {
+      userId: profileRes.data.id,
+      displayName: profileRes.data.display_name,
+      isAdmin: profileRes.data.is_admin,
+      createdAt: profileRes.data.created_at,
+    },
+    stats: statsRes.data
+      ? {
+          totalPoints: statsRes.data.total_points,
+          currentStreak: statsRes.data.current_streak,
+          maxStreak: statsRes.data.max_streak,
+          lastStudyDate: statsRes.data.last_study_date,
+          updatedAt: statsRes.data.updated_at,
+        }
+      : null,
+    stepProgress: stepRes.data ?? [],
+    recentSubmissions: submissionsRes.data ?? [],
+    dailyHistory: dailyRes.data ?? [],
+    achievements: achievementsRes.data ?? [],
+    codeDoctor: doctorRes.data ?? [],
+    miniProject: projectRes.data ?? [],
+    codeReading: readingRes.data ?? [],
+    baseNook: baseNookRes.data ?? [],
+    pointHistory: pointsRes.data ?? [],
+  }
+}

--- a/apps/web/src/shared/types/database.types.ts
+++ b/apps/web/src/shared/types/database.types.ts
@@ -367,6 +367,64 @@ export type Database = {
         Args: Record<string, never>
         Returns: boolean
       }
+      get_dau_last_30_days: {
+        Args: Record<string, never>
+        Returns: {
+          activity_date: string
+          active_users: number
+        }[]
+      }
+      get_step_completion_rates: {
+        Args: Record<string, never>
+        Returns: {
+          step_id: string
+          total_users: number
+          completed_users: number
+          completion_rate: number
+        }[]
+      }
+      get_top_missed_questions: {
+        Args: {
+          p_limit?: number
+          p_min_attempts?: number
+        }
+        Returns: {
+          step_id: string
+          attempt_count: number
+          failure_count: number
+          failure_rate: number
+        }[]
+      }
+      admin_list_users: {
+        Args: Record<string, never>
+        Returns: {
+          user_id: string
+          email: string | null
+          display_name: string | null
+          is_admin: boolean
+          total_points: number
+          current_streak: number
+          max_streak: number
+          last_study_date: string | null
+          badge_count: number
+          created_at: string
+        }[]
+      }
+      admin_grant_points: {
+        Args: {
+          p_target_user_id: string
+          p_amount: number
+          p_reason: string
+        }
+        Returns: undefined
+      }
+      admin_grant_badge: {
+        Args: {
+          p_target_user_id: string
+          p_badge_id: string
+        }
+        Returns: undefined
+      }
     }
     Enums: {
       [_ in never]: never

--- a/apps/web/supabase/sql/014_admin_stats_rpc.sql
+++ b/apps/web/supabase/sql/014_admin_stats_rpc.sql
@@ -1,0 +1,275 @@
+-- v4roadmap02 M3: 管理者向け閲覧ポリシー + 統計 RPC + ユーザー一覧 RPC
+-- Run this in Supabase SQL Editor (または supabase db push)
+--
+-- 構成:
+--   1. admin 向け SELECT ポリシー（各進捗・ポイント系テーブル）
+--   2. 統計 RPC
+--      - get_dau_last_30_days
+--      - get_step_completion_rates
+--      - get_top_missed_questions
+--   3. admin_list_users RPC（auth.users.email を含めるため SECURITY DEFINER）
+--
+-- セキュリティ:
+--   - RPC は全て SECURITY DEFINER + set search_path = public
+--   - 先頭で public.is_admin() を確認し、非 admin からの呼び出しを拒否する
+--   - RLS ポリシーは public.is_admin() で保護（既存 own_* ポリシーはそのまま残す）
+
+-- =========================================================================
+-- 1. 管理者閲覧用 RLS ポリシー
+--    既存の own_* ポリシー (auth.uid() = user_id) に加えて
+--    admin は横断的に SELECT できるポリシーを追加する。
+--    UPDATE/INSERT/DELETE は own_* のままで、admin からの書き込みは
+--    SECURITY DEFINER RPC (015_admin_ops_rpc.sql) 経由に限定する。
+-- =========================================================================
+
+drop policy if exists admin_select_profiles on public.profiles;
+create policy admin_select_profiles on public.profiles
+  for select using (public.is_admin());
+
+drop policy if exists admin_select_step_progress on public.step_progress;
+create policy admin_select_step_progress on public.step_progress
+  for select using (public.is_admin());
+
+drop policy if exists admin_select_challenge_submissions on public.challenge_submissions;
+create policy admin_select_challenge_submissions on public.challenge_submissions
+  for select using (public.is_admin());
+
+drop policy if exists admin_select_learning_stats on public.learning_stats;
+create policy admin_select_learning_stats on public.learning_stats
+  for select using (public.is_admin());
+
+drop policy if exists admin_select_achievements on public.achievements;
+create policy admin_select_achievements on public.achievements
+  for select using (public.is_admin());
+
+drop policy if exists admin_select_point_history on public.point_history;
+create policy admin_select_point_history on public.point_history
+  for select using (public.is_admin());
+
+drop policy if exists admin_select_daily_challenge_history on public.daily_challenge_history;
+create policy admin_select_daily_challenge_history on public.daily_challenge_history
+  for select using (public.is_admin());
+
+drop policy if exists admin_select_code_doctor_progress on public.code_doctor_progress;
+create policy admin_select_code_doctor_progress on public.code_doctor_progress
+  for select using (public.is_admin());
+
+drop policy if exists admin_select_mini_project_progress on public.mini_project_progress;
+create policy admin_select_mini_project_progress on public.mini_project_progress
+  for select using (public.is_admin());
+
+drop policy if exists admin_select_code_reading_progress on public.code_reading_progress;
+create policy admin_select_code_reading_progress on public.code_reading_progress
+  for select using (public.is_admin());
+
+drop policy if exists admin_select_base_nook_progress on public.base_nook_progress;
+create policy admin_select_base_nook_progress on public.base_nook_progress
+  for select using (public.is_admin());
+
+-- =========================================================================
+-- 2-1. get_dau_last_30_days
+--      過去 30 日の DAU（日次アクティブユーザー）を返す。
+--      point_history を「ポイントを獲得する操作 = 学習アクティビティ」と定義。
+--      ポイント付与は各 mode（read/practice/test/challenge 等）で実行されるため
+--      これを集計することでアクティビティの重複なく集計できる。
+--      日付境界は JST ベース（Asia/Tokyo）で評価する。
+-- =========================================================================
+
+create or replace function public.get_dau_last_30_days()
+returns table (
+  activity_date date,
+  active_users  integer
+)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+begin
+  if not public.is_admin() then
+    raise exception 'Forbidden';
+  end if;
+
+  return query
+  with day_series as (
+    select (generate_series(
+      (current_date at time zone 'Asia/Tokyo')::date - 29,
+      (current_date at time zone 'Asia/Tokyo')::date,
+      interval '1 day'
+    ))::date as d
+  ),
+  per_day as (
+    select
+      (ph.created_at at time zone 'Asia/Tokyo')::date as d,
+      count(distinct ph.user_id) as n
+    from public.point_history ph
+    where ph.created_at >= ((current_date at time zone 'Asia/Tokyo')::date - 29)
+    group by 1
+  )
+  select
+    ds.d as activity_date,
+    coalesce(pd.n, 0)::integer as active_users
+  from day_series ds
+  left join per_day pd on pd.d = ds.d
+  order by ds.d asc;
+end;
+$$;
+
+grant execute on function public.get_dau_last_30_days() to authenticated;
+
+-- =========================================================================
+-- 2-2. get_step_completion_rates
+--      step_progress を集計して step_id ごとの完了率を返す。
+--      total_users = 少なくとも 1 つでも進捗レコードを持つユーザー数
+--      （未着手ユーザーを分母に含めないため、進捗を始めたユーザー中の完了率になる）
+--      completion は step_progress.completed_at が NULL でない = 4 モード全完了。
+-- =========================================================================
+
+create or replace function public.get_step_completion_rates()
+returns table (
+  step_id          text,
+  total_users      integer,
+  completed_users  integer,
+  completion_rate  numeric
+)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+begin
+  if not public.is_admin() then
+    raise exception 'Forbidden';
+  end if;
+
+  return query
+  select
+    sp.step_id,
+    count(distinct sp.user_id)::integer as total_users,
+    count(distinct sp.user_id) filter (where sp.completed_at is not null)::integer as completed_users,
+    case
+      when count(distinct sp.user_id) = 0 then 0::numeric
+      else round(
+        (count(distinct sp.user_id) filter (where sp.completed_at is not null))::numeric
+          / count(distinct sp.user_id)::numeric,
+        4
+      )
+    end as completion_rate
+  from public.step_progress sp
+  group by sp.step_id
+  order by completion_rate asc, sp.step_id asc;
+end;
+$$;
+
+grant execute on function public.get_step_completion_rates() to authenticated;
+
+-- =========================================================================
+-- 2-3. get_top_missed_questions
+--      challenge_submissions を集計して、失敗率が高い step_id TOP N を返す。
+--      失敗率 = 不正解回数 / 試行回数
+--      試行回数が少なすぎる step は除外（min_attempts 未満）。
+--      JSON に列名を持たせるため named return table を使う。
+-- =========================================================================
+
+create or replace function public.get_top_missed_questions(
+  p_limit integer default 10,
+  p_min_attempts integer default 3
+)
+returns table (
+  step_id        text,
+  attempt_count  integer,
+  failure_count  integer,
+  failure_rate   numeric
+)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+declare
+  v_limit integer;
+  v_min   integer;
+begin
+  if not public.is_admin() then
+    raise exception 'Forbidden';
+  end if;
+
+  -- clamp inputs
+  v_limit := greatest(1, least(coalesce(p_limit, 10), 100));
+  v_min   := greatest(1, coalesce(p_min_attempts, 3));
+
+  return query
+  select
+    cs.step_id,
+    count(*)::integer as attempt_count,
+    count(*) filter (where cs.is_passed = false)::integer as failure_count,
+    round(
+      (count(*) filter (where cs.is_passed = false))::numeric
+        / count(*)::numeric,
+      4
+    ) as failure_rate
+  from public.challenge_submissions cs
+  group by cs.step_id
+  having count(*) >= v_min
+  order by failure_rate desc, attempt_count desc
+  limit v_limit;
+end;
+$$;
+
+grant execute on function public.get_top_missed_questions(integer, integer) to authenticated;
+
+-- =========================================================================
+-- 3. admin_list_users
+--    ユーザー一覧（email を含む）を返す。
+--    auth.users は authenticated ロールから直接 SELECT できないため、
+--    SECURITY DEFINER で join して返す。badge_count も同時集計。
+-- =========================================================================
+
+create or replace function public.admin_list_users()
+returns table (
+  user_id         uuid,
+  email           text,
+  display_name    text,
+  is_admin        boolean,
+  total_points    integer,
+  current_streak  integer,
+  max_streak      integer,
+  last_study_date date,
+  badge_count     integer,
+  created_at      timestamptz
+)
+language plpgsql
+stable
+security definer
+set search_path = public
+as $$
+begin
+  if not public.is_admin() then
+    raise exception 'Forbidden';
+  end if;
+
+  return query
+  select
+    p.id as user_id,
+    au.email::text as email,
+    p.display_name,
+    p.is_admin,
+    coalesce(ls.total_points, 0)::integer as total_points,
+    coalesce(ls.current_streak, 0)::integer as current_streak,
+    coalesce(ls.max_streak, 0)::integer as max_streak,
+    ls.last_study_date,
+    coalesce(bc.cnt, 0)::integer as badge_count,
+    p.created_at
+  from public.profiles p
+  left join auth.users au on au.id = p.id
+  left join public.learning_stats ls on ls.user_id = p.id
+  left join (
+    select a.user_id, count(*)::integer as cnt
+    from public.achievements a
+    group by a.user_id
+  ) bc on bc.user_id = p.id
+  order by ls.total_points desc nulls last, p.created_at desc;
+end;
+$$;
+
+grant execute on function public.admin_list_users() to authenticated;

--- a/apps/web/supabase/sql/015_admin_ops_rpc.sql
+++ b/apps/web/supabase/sql/015_admin_ops_rpc.sql
@@ -1,0 +1,167 @@
+-- v4roadmap02 M3: 管理者運用 RPC（手動ポイント付与 / 手動バッジ付与）
+-- Run this in Supabase SQL Editor (または supabase db push)
+--
+-- 構成:
+--   1. admin_grant_points  -- 任意のユーザーに運用ポイントを付与し、履歴+監査ログを残す
+--   2. admin_grant_badge   -- 任意のユーザーにバッジを手動付与し、監査ログを残す
+--
+-- セキュリティ:
+--   - SECURITY DEFINER + set search_path = public
+--   - 冒頭で public.is_admin() を確認し、非 admin 呼び出しを拒否
+--   - 対象ユーザーの存在確認（profiles.id の存在）
+--   - amount は正整数のみ許可、reason / badge_id は空文字・長大を拒否
+--   - admin_audit_log への INSERT は監査のため fail-loud（例外時はトランザクション全体ロールバック）
+
+-- =========================================================================
+-- 1. admin_grant_points
+--    learning_stats.total_points を加算し、point_history に履歴を残す。
+--    同時に admin_audit_log に監査レコードを残す。
+--    減算（マイナス付与）は現段階では対象外とし、正整数のみ受け付ける。
+-- =========================================================================
+
+create or replace function public.admin_grant_points(
+  p_target_user_id uuid,
+  p_amount         integer,
+  p_reason         text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_admin_id uuid := auth.uid();
+  v_exists   boolean;
+begin
+  -- 権限チェック
+  if v_admin_id is null then
+    raise exception 'Not authenticated';
+  end if;
+  if not public.is_admin() then
+    raise exception 'Forbidden';
+  end if;
+
+  -- 入力バリデーション
+  if p_target_user_id is null then
+    raise exception 'target_user_id is required';
+  end if;
+  if p_amount is null or p_amount <= 0 then
+    raise exception 'amount must be a positive integer';
+  end if;
+  if p_amount > 10000 then
+    raise exception 'amount exceeds max (10000)';
+  end if;
+  if p_reason is null or char_length(btrim(p_reason)) = 0 then
+    raise exception 'reason is required';
+  end if;
+  if char_length(p_reason) > 200 then
+    raise exception 'reason is too long (max 200)';
+  end if;
+
+  -- 対象ユーザーの存在確認
+  select exists(select 1 from public.profiles where id = p_target_user_id)
+    into v_exists;
+  if not v_exists then
+    raise exception 'target user not found';
+  end if;
+
+  -- ポイント加算（行が無ければ INSERT）
+  insert into public.learning_stats (user_id, total_points, updated_at)
+  values (p_target_user_id, p_amount, now())
+  on conflict (user_id) do update
+    set total_points = public.learning_stats.total_points + excluded.total_points,
+        updated_at   = now();
+
+  -- ポイント履歴
+  insert into public.point_history (user_id, amount, reason)
+  values (p_target_user_id, p_amount, p_reason);
+
+  -- 監査ログ
+  insert into public.admin_audit_log (admin_id, action, target_type, target_id, payload)
+  values (
+    v_admin_id,
+    'admin.grant_points',
+    'user',
+    p_target_user_id::text,
+    jsonb_build_object(
+      'amount', p_amount,
+      'reason', p_reason
+    )
+  );
+end;
+$$;
+
+grant execute on function public.admin_grant_points(uuid, integer, text) to authenticated;
+
+-- =========================================================================
+-- 2. admin_grant_badge
+--    achievements に (user_id, badge_id) を INSERT する。
+--    既に保有している場合は do nothing（同じバッジを重複付与しても 1 件）。
+--    監査ログには was_new（新規付与かどうか）を記録する。
+-- =========================================================================
+
+create or replace function public.admin_grant_badge(
+  p_target_user_id uuid,
+  p_badge_id       text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_admin_id uuid := auth.uid();
+  v_exists   boolean;
+  v_inserted integer;
+begin
+  -- 権限チェック
+  if v_admin_id is null then
+    raise exception 'Not authenticated';
+  end if;
+  if not public.is_admin() then
+    raise exception 'Forbidden';
+  end if;
+
+  -- 入力バリデーション
+  if p_target_user_id is null then
+    raise exception 'target_user_id is required';
+  end if;
+  if p_badge_id is null or char_length(btrim(p_badge_id)) = 0 then
+    raise exception 'badge_id is required';
+  end if;
+  if char_length(p_badge_id) > 100 then
+    raise exception 'badge_id is too long (max 100)';
+  end if;
+
+  -- 対象ユーザー存在確認
+  select exists(select 1 from public.profiles where id = p_target_user_id)
+    into v_exists;
+  if not v_exists then
+    raise exception 'target user not found';
+  end if;
+
+  -- バッジ INSERT（既保持なら do nothing）
+  with ins as (
+    insert into public.achievements (user_id, badge_id)
+    values (p_target_user_id, p_badge_id)
+    on conflict (user_id, badge_id) do nothing
+    returning 1
+  )
+  select count(*)::int into v_inserted from ins;
+
+  -- 監査ログ
+  insert into public.admin_audit_log (admin_id, action, target_type, target_id, payload)
+  values (
+    v_admin_id,
+    'admin.grant_badge',
+    'user',
+    p_target_user_id::text,
+    jsonb_build_object(
+      'badge_id', p_badge_id,
+      'was_new',  v_inserted > 0
+    )
+  );
+end;
+$$;
+
+grant execute on function public.admin_grant_badge(uuid, text) to authenticated;


### PR DESCRIPTION
## Summary

v4roadmap02 M3 の実装。管理画面の本体機能として、ユーザーデータ閲覧・統計・運用操作を実装しました。

- **SQL**: `014_admin_stats_rpc.sql`（集計 RPC 4 本 + 11 テーブルへの admin SELECT policies）、`015_admin_ops_rpc.sql`（ポイント/バッジ手動付与 RPC、SECURITY DEFINER + `is_admin()` ガード + `admin_audit_log` 自動記録）
- **Services**: `adminStatsService` / `adminUsersService` / `adminOpsService` 新設（定数 MAX_GRANT_POINTS_AMOUNT=10000、MAX_GRANT_POINTS_REASON_LENGTH=200）
- **Pages**: `AdminUsersPage`（検索フィルタ付き一覧）/ `AdminUserDetailPage`（プロフィール + 6 セクション）/ `AdminStatsPage`（DAU 棒グラフ + 完了率バー + 失敗率表）/ `AdminOpsPage`（ポイント・バッジ手動付与フォーム）
- **ルーティング**: `/admin/users`, `/admin/users/:id`, `/admin/stats`, `/admin/ops` を React.lazy + Suspense + AdminGuard で追加
- **Dashboard**: `AdminDashboardPage` の 4 セクションを `getGlobalStatsSummary()` の実データで表示
- **テスト**: サービス単体テスト +31 件（全 776 件 PASS）

### 設計ポイント

- **RLS × SECURITY DEFINER ハイブリッド**: 集計・運用は SECURITY DEFINER RPC + `is_admin()` ガードで集中化、多表参照の閲覧は admin SELECT policies でクライアント並列 fetch。柔軟性と保守性のバランスを取った。
- **DAU の定義**: `point_history.created_at` を JST 日付で丸めたユニークユーザー数。ポイント獲得 = 意味ある学習行動の代表値。`generate_series` で 0 人の日も欠落させない。
- **`exactOptionalPropertyTypes` 対策**: 条件付きスプレッド `{...(cond ? { accent: '...' } : {})}` で optional prop を扱うパターンを継承。

## Test plan

- [x] typecheck
- [x] lint
- [x] test (776 件 PASS, +31)
- [x] build（新規 admin ページは個別 chunk に分割）
- [ ] 手動: Supabase に `014` / `015` を適用し、admin / 非 admin で `/admin/*` の挙動確認（RPC 権限テスト含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)