### PR TITLE
feat: フィードバック詳細にユーザー基本情報セクションを追加

### DIFF
--- a/apps/web/src/pages/admin/AdminFeedbackDetailPage.tsx
+++ b/apps/web/src/pages/admin/AdminFeedbackDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
-import { AlertCircle, ArrowLeft, Loader2, Save } from 'lucide-react'
+import { AlertCircle, ArrowLeft, Loader2, Save, Shield } from 'lucide-react'
 import { useAuth } from '../../contexts/AuthContext'
 import { AdminLayout } from '../../features/admin/components/AdminLayout'
 import { useDocumentTitle } from '../../hooks/useDocumentTitle'
@@ -15,6 +15,8 @@ import {
   updateFeedbackStatus,
 } from '../../services/feedbackService'
 import type { FeedbackCategory, FeedbackStatus, UserFeedback } from '../../services/feedbackService'
+import { getUserBasicInfo } from '../../services/adminUsersService'
+import type { AdminUserBasic } from '../../services/adminUsersService'
 
 // ─── Badge helpers ──────────────────────────────────────────────────────────
 
@@ -90,6 +92,11 @@ export function AdminFeedbackDetailPage() {
   const [notFound, setNotFound] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
 
+  // User basic info (送信者プロフィール) state
+  const [userBasic, setUserBasic] = useState<AdminUserBasic | null>(null)
+  const [isLoadingUser, setIsLoadingUser] = useState(false)
+  const [userInfoError, setUserInfoError] = useState<string | null>(null)
+
   // Status update state
   const [isUpdatingStatus, setIsUpdatingStatus] = useState(false)
   const [statusError, setStatusError] = useState<string | null>(null)
@@ -117,12 +124,29 @@ export function AdminFeedbackDetailPage() {
         if (!isMounted) return
         if (data === null) {
           setNotFound(true)
-        } else {
-          setFeedback(data)
-          const initialNote = data.admin_note ?? ''
-          setNoteText(initialNote)
-          setSavedNote(initialNote)
+          return
         }
+        setFeedback(data)
+        const initialNote = data.admin_note ?? ''
+        setNoteText(initialNote)
+        setSavedNote(initialNote)
+
+        // 送信者プロフィールは feedback 本体とは独立して並行ロードする。
+        // 失敗してもフィードバック本体の表示は継続する（UI側でセクション内にエラー表示）。
+        setIsLoadingUser(true)
+        getUserBasicInfo(data.user_id)
+          .then((basic) => {
+            if (isMounted) setUserBasic(basic)
+          })
+          .catch((e: unknown) => {
+            if (!isMounted) return
+            setUserInfoError(
+              e instanceof Error ? e.message : 'ユーザー情報の取得に失敗しました',
+            )
+          })
+          .finally(() => {
+            if (isMounted) setIsLoadingUser(false)
+          })
       } catch (e) {
         if (!isMounted) return
         setLoadError(e instanceof Error ? e.message : 'フィードバックの取得に失敗しました')
@@ -261,6 +285,66 @@ export function AdminFeedbackDetailPage() {
             <pre className="whitespace-pre-wrap rounded-lg bg-slate-50 p-4 text-sm leading-relaxed text-slate-800">
               {feedback.message}
             </pre>
+          </section>
+
+          {/* User info (送信者プロフィール) */}
+          <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+            <div className="mb-4 flex items-center justify-between gap-3">
+              <h2 className="text-sm font-semibold text-slate-700">ユーザー情報</h2>
+              <Link
+                to={`/admin/users/${feedback.user_id}`}
+                className="text-xs font-medium text-primary-mint hover:text-primary-mint/80"
+              >
+                ユーザー詳細へ →
+              </Link>
+            </div>
+
+            {isLoadingUser ? (
+              <div className="flex justify-center py-4">
+                <Loader2
+                  className="h-5 w-5 animate-spin text-slate-400"
+                  aria-label="ユーザー情報を読み込み中"
+                />
+              </div>
+            ) : userInfoError ? (
+              <div
+                role="status"
+                aria-live="polite"
+                className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs text-amber-700"
+              >
+                <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                <p>{userInfoError}</p>
+              </div>
+            ) : userBasic ? (
+              <dl className="space-y-3 text-sm">
+                <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+                  <dt className="w-32 shrink-0 font-medium text-slate-500">表示名</dt>
+                  <dd className="flex flex-wrap items-center gap-2 text-slate-800">
+                    <span>{userBasic.displayName ?? '—'}</span>
+                    {userBasic.isAdmin && (
+                      <span className="inline-flex items-center gap-0.5 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-700">
+                        <Shield className="h-3 w-3" aria-hidden="true" />
+                        ADMIN
+                      </span>
+                    )}
+                  </dd>
+                </div>
+                <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+                  <dt className="w-32 shrink-0 font-medium text-slate-500">メールアドレス</dt>
+                  <dd className="break-all text-slate-800">{userBasic.email ?? '—'}</dd>
+                </div>
+                <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+                  <dt className="w-32 shrink-0 font-medium text-slate-500">管理者</dt>
+                  <dd className="text-slate-800">{userBasic.isAdmin ? 'はい' : 'いいえ'}</dd>
+                </div>
+                <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
+                  <dt className="w-32 shrink-0 font-medium text-slate-500">登録日</dt>
+                  <dd className="text-slate-800">{formatJst(userBasic.createdAt)}</dd>
+                </div>
+              </dl>
+            ) : (
+              <p className="text-xs text-slate-500">ユーザー情報を取得できませんでした</p>
+            )}
           </section>
 
           {/* Meta info */}

--- a/apps/web/src/services/__tests__/adminUsersService.test.ts
+++ b/apps/web/src/services/__tests__/adminUsersService.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { getUserDetail, listUsers } from '../adminUsersService'
+import { getUserBasicInfo, getUserDetail, listUsers } from '../adminUsersService'
 
 const rpc = vi.fn()
 
@@ -216,6 +216,53 @@ describe('getUserDetail', () => {
   it('profile エラーは専用メッセージで AppError を投げる', async () => {
     state.profiles = { data: null, error: { code: 'DB_ERROR', message: 'rls denied' } }
     await expect(getUserDetail(VALID)).rejects.toMatchObject({
+      userMessage: 'ユーザー情報の取得に失敗しました',
+    })
+  })
+})
+
+describe('getUserBasicInfo', () => {
+  beforeEach(resetState)
+
+  it('admin_get_user_basic RPC を引数付きで呼び AdminUserBasic に変換する', async () => {
+    rpc.mockResolvedValue({
+      data: [
+        {
+          user_id: VALID,
+          email: 'a@example.com',
+          display_name: 'Alice',
+          is_admin: true,
+          created_at: '2026-03-01T00:00:00Z',
+        },
+      ],
+      error: null,
+    })
+
+    const result = await getUserBasicInfo(VALID)
+    expect(rpc).toHaveBeenCalledWith('admin_get_user_basic', { p_user_id: VALID })
+    expect(result).toEqual({
+      userId: VALID,
+      email: 'a@example.com',
+      displayName: 'Alice',
+      isAdmin: true,
+      createdAt: '2026-03-01T00:00:00Z',
+    })
+  })
+
+  it('data が空配列のときは null を返す', async () => {
+    rpc.mockResolvedValue({ data: [], error: null })
+    expect(await getUserBasicInfo(VALID)).toBeNull()
+  })
+
+  it('不正な UUID は例外を投げ RPC は呼ばれない', async () => {
+    await expect(getUserBasicInfo('not-uuid')).rejects.toThrow('userId must be a valid UUID')
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('RPC エラーを AppError に変換する', async () => {
+    rpc.mockResolvedValue({ data: null, error: { code: 'DB_ERROR', message: 'forbidden' } })
+    await expect(getUserBasicInfo(VALID)).rejects.toMatchObject({
+      name: 'AppError',
       userMessage: 'ユーザー情報の取得に失敗しました',
     })
   })

--- a/apps/web/src/services/adminUsersService.ts
+++ b/apps/web/src/services/adminUsersService.ts
@@ -26,6 +26,14 @@ export interface AdminUserSummary {
   createdAt: string
 }
 
+export interface AdminUserBasic {
+  userId: string
+  email: string | null
+  displayName: string | null
+  isAdmin: boolean
+  createdAt: string
+}
+
 export interface AdminUserDetail {
   profile: {
     userId: string
@@ -49,6 +57,33 @@ export interface AdminUserDetail {
   codeReading: Tables<'code_reading_progress'>[]
   baseNook: Tables<'base_nook_progress'>[]
   pointHistory: Tables<'point_history'>[]
+}
+
+/**
+ * 管理者向けユーザー基本情報（単一ユーザー）を取得する。
+ * フィードバック詳細などの「送信者が誰か」を軽量に把握する用途。
+ * admin_get_user_basic RPC は SECURITY DEFINER + is_admin() ガードで非 admin をブロックする。
+ * 対象ユーザーが存在しない場合は null を返す。
+ */
+export async function getUserBasicInfo(
+  userId: string,
+): Promise<AdminUserBasic | null> {
+  assertUuid(userId, 'userId')
+  const { data, error } = await supabase.rpc('admin_get_user_basic', {
+    p_user_id: userId,
+  })
+  if (error) {
+    throw fromSupabaseError(error, 'ユーザー情報の取得に失敗しました')
+  }
+  const row = (data ?? [])[0]
+  if (!row) return null
+  return {
+    userId: row.user_id,
+    email: row.email,
+    displayName: row.display_name,
+    isAdmin: row.is_admin,
+    createdAt: row.created_at,
+  }
 }
 
 /** 管理者向けユーザー一覧を取得（admin_list_users RPC） */

--- a/apps/web/src/shared/types/database.types.ts
+++ b/apps/web/src/shared/types/database.types.ts
@@ -410,6 +410,18 @@ export type Database = {
           created_at: string
         }[]
       }
+      admin_get_user_basic: {
+        Args: {
+          p_user_id: string
+        }
+        Returns: {
+          user_id: string
+          email: string | null
+          display_name: string | null
+          is_admin: boolean
+          created_at: string
+        }[]
+      }
       admin_grant_points: {
         Args: {
           p_target_user_id: string

--- a/apps/web/supabase/sql/016_admin_user_basic_rpc.sql
+++ b/apps/web/supabase/sql/016_admin_user_basic_rpc.sql
@@ -1,0 +1,46 @@
+-- v4roadmap02: 管理者向けユーザー基本情報 RPC
+-- Run this in Supabase SQL Editor (または supabase db push)
+--
+-- 構成:
+--   1. admin_get_user_basic RPC
+--      単一ユーザーの基本情報（表示名・メール・管理者フラグ・登録日）を返す。
+--      フィードバック詳細ページから呼び出してトリアージを高速化する用途。
+--
+-- セキュリティ:
+--   - SECURITY DEFINER + set search_path = public
+--   - 本体で public.is_admin() ガードを効かせ、非 admin からの呼び出しを封じる
+--   - auth.users.email を authenticated ロールから直接参照できないため、
+--     014 の admin_list_users と同じパターンで join して返す
+
+-- =========================================================================
+-- 1. admin_get_user_basic
+--    対象ユーザーが存在しない / 非 admin からの呼び出しは 0 行を返す。
+-- =========================================================================
+
+create or replace function public.admin_get_user_basic(p_user_id uuid)
+returns table (
+  user_id      uuid,
+  email        text,
+  display_name text,
+  is_admin     boolean,
+  created_at   timestamptz
+)
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select
+    p.id as user_id,
+    au.email::text as email,
+    p.display_name,
+    coalesce(p.is_admin, false) as is_admin,
+    p.created_at
+  from public.profiles p
+  left join auth.users au on au.id = p.id
+  where p.id = p_user_id
+    and public.is_admin()
+  limit 1;
+$$;
+
+grant execute on function public.admin_get_user_basic(uuid) to authenticated;


### PR DESCRIPTION
## 概要

`/admin/feedback/:id` の詳細ページで、送信者の UUID だけでなく基本プロフィール（表示名・メール・管理者フラグ・登録日）と `/admin/users/:id` への導線を表示し、フィードバックのトリアージを高速化する。

## 変更内容

- `apps/web/supabase/sql/016_admin_user_basic_rpc.sql` (新規)
  - `admin_get_user_basic(p_user_id uuid)` RPC を追加
  - `SECURITY DEFINER` + `is_admin()` ガードで非 admin の呼び出しを封じる（014/015 と同パターン）
  - `auth.users.email` を直接読めないため `profiles` に `left join` して返却
- `apps/web/src/shared/types/database.types.ts`
  - `Functions.admin_get_user_basic` の Args / Returns を追加
- `apps/web/src/services/adminUsersService.ts`
  - 軽量型 `AdminUserBasic` と `getUserBasicInfo(userId)` を追加
  - 既存 `getUserDetail` とは別経路（feedback 詳細専用）
- `apps/web/src/pages/admin/AdminFeedbackDetailPage.tsx`
  - 左カラムに「ユーザー情報」セクションを「詳細情報」の上に新設
  - ADMIN バッジ（`Shield` アイコン + amber 背景）と「ユーザー詳細へ →」リンクを表示
  - フィードバック本体とは独立して非同期ロードし、失敗時はセクション内のみでエラー表示（本体の描画は継続）
- `apps/web/src/services/__tests__/adminUsersService.test.ts`
  - `getUserBasicInfo` の 4 ケース（RPC引数検証 / null返却 / 不正UUID例外 / AppError変換）

## 検証

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test` ✅ (776 → 780, +4)
- `npm run build` ✅

## スコープ外（次段以降）

- 学習統計（total_points / streak 等）の表示
- 同一ユーザーの過去フィードバック数
- 本番 Supabase への `016_admin_user_basic_rpc.sql` 適用（手動）

## Issue要否

Issue 不要。v4roadmap02 M2（フィードバック基盤）延長の小機能追加であり、既存の M2 スコープ内で完結する。