### PR TITLE
fix: セキュリティ監査 4件の修正

### DIFF
--- a/apps/web/src/features/learning/ChallengePuzzle/MultiBlankCodeContext.tsx
+++ b/apps/web/src/features/learning/ChallengePuzzle/MultiBlankCodeContext.tsx
@@ -3,6 +3,7 @@ import 'prismjs/components/prism-markup'
 import 'prismjs/components/prism-jsx'
 import 'prismjs/components/prism-typescript'
 import 'prismjs/components/prism-tsx'
+import { renderTokenStream } from '../utils/renderPrismTokens'
 
 interface BlankInfo {
   label: string
@@ -18,7 +19,6 @@ interface MultiBlankCodeContextProps {
 
 export function MultiBlankCodeContext({ code, blanks, activeIndex, onBlankTap }: MultiBlankCodeContextProps) {
   const lang = Prism.languages['tsx'] ?? Prism.languages['javascript']
-  const langName = Prism.languages['tsx'] ? 'tsx' : 'javascript'
 
   // Split by ____0, ____1, ____2, etc.
   const parts = code.split(/____(\d+)/)
@@ -29,12 +29,11 @@ export function MultiBlankCodeContext({ code, blanks, activeIndex, onBlankTap }:
         // Even indices are code, odd indices are blank numbers
         if (i % 2 === 0) {
           return (
-            <span
-              key={i}
-              dangerouslySetInnerHTML={{
-                __html: lang ? Prism.highlight(part, lang, langName) : part,
-              }}
-            />
+            <span key={i}>
+              {lang
+                ? renderTokenStream(Prism.tokenize(part, lang), `mpart-${String(i)}`)
+                : part}
+            </span>
           )
         }
         const blankIndex = Number(part)

--- a/apps/web/src/features/learning/CodePuzzle/CodeContext.tsx
+++ b/apps/web/src/features/learning/CodePuzzle/CodeContext.tsx
@@ -3,6 +3,7 @@ import 'prismjs/components/prism-markup'
 import 'prismjs/components/prism-jsx'
 import 'prismjs/components/prism-typescript'
 import 'prismjs/components/prism-tsx'
+import { renderTokenStream } from '../utils/renderPrismTokens'
 
 interface CodeContextProps {
   code: string
@@ -12,17 +13,16 @@ interface CodeContextProps {
 export function CodeContext({ code, blankLabel = '▼ ここを組み立て' }: CodeContextProps) {
   const parts = code.split('____')
   const lang = Prism.languages['tsx'] ?? Prism.languages['javascript']
-  const langName = Prism.languages['tsx'] ? 'tsx' : 'javascript'
 
   return (
     <pre className="overflow-x-auto font-mono text-sm bg-slate-900 rounded-lg p-3">
       {parts.map((part, index) => (
         <span key={index}>
-          <span
-            dangerouslySetInnerHTML={{
-              __html: lang ? Prism.highlight(part, lang, langName) : part,
-            }}
-          />
+          <span>
+            {lang
+              ? renderTokenStream(Prism.tokenize(part, lang), `part-${String(index)}`)
+              : part}
+          </span>
           {index < parts.length - 1 && (
             <span className="inline-block bg-amber-500/20 text-amber-400 px-2 py-0.5 rounded text-sm font-medium">
               {blankLabel}

--- a/apps/web/src/features/learning/CodePuzzle/__tests__/CodeContext.test.tsx
+++ b/apps/web/src/features/learning/CodePuzzle/__tests__/CodeContext.test.tsx
@@ -4,7 +4,7 @@ import { CodeContext } from '../CodeContext'
 
 vi.mock('prismjs', () => ({
   default: {
-    highlight: (code: string) => code,
+    tokenize: (code: string) => [code],
     languages: { tsx: {}, javascript: {} },
   },
 }))

--- a/apps/web/src/features/learning/CodePuzzle/__tests__/CodePuzzle.test.tsx
+++ b/apps/web/src/features/learning/CodePuzzle/__tests__/CodePuzzle.test.tsx
@@ -6,7 +6,7 @@ import { CodePuzzle } from '../CodePuzzle'
 
 vi.mock('prismjs', () => ({
   default: {
-    highlight: (_code: string) => _code,
+    tokenize: (_code: string) => [_code],
     languages: { tsx: {}, javascript: {} },
   },
 }))

--- a/apps/web/src/features/learning/utils/__tests__/renderPrismTokens.test.tsx
+++ b/apps/web/src/features/learning/utils/__tests__/renderPrismTokens.test.tsx
@@ -1,0 +1,74 @@
+import { render } from '@testing-library/react'
+import type { Token } from 'prismjs'
+import { describe, expect, it } from 'vitest'
+import { renderTokenStream } from '../renderPrismTokens'
+
+function makeToken(type: string, content: string | Token | Array<string | Token>, alias: string | string[] = ''): Token {
+  return { type, content, alias, length: 0, greedy: false } as Token
+}
+
+describe('renderTokenStream', () => {
+  it('文字列トークンをそのまま <span> に描画する', () => {
+    const { container } = render(<>{renderTokenStream(['hello'], 'k')}</>)
+    expect(container.textContent).toBe('hello')
+  })
+
+  it('Token オブジェクトに token + type クラスを付与する', () => {
+    const token = makeToken('keyword', 'const')
+    const { container } = render(<>{renderTokenStream([token], 'k')}</>)
+
+    const span = container.querySelector('span.token.keyword')
+    expect(span).toBeTruthy()
+    expect(span?.textContent).toBe('const')
+  })
+
+  it('alias が文字列の場合にクラスに含める', () => {
+    const token = makeToken('function', 'useState', 'builtin')
+    const { container } = render(<>{renderTokenStream([token], 'k')}</>)
+
+    const span = container.querySelector('span.token.function.builtin')
+    expect(span).toBeTruthy()
+  })
+
+  it('alias が配列の場合にすべてクラスに含める', () => {
+    const token = makeToken('tag', 'div', ['important', 'bold'])
+    const { container } = render(<>{renderTokenStream([token], 'k')}</>)
+
+    const span = container.querySelector('span.token.tag.important.bold')
+    expect(span).toBeTruthy()
+  })
+
+  it('ネストした Token を再帰的に描画する', () => {
+    const inner = makeToken('attr-name', 'onClick')
+    const outer = makeToken('tag', [inner])
+    const { container } = render(<>{renderTokenStream([outer], 'k')}</>)
+
+    const outerSpan = container.querySelector('span.token.tag')
+    expect(outerSpan).toBeTruthy()
+    const innerSpan = outerSpan?.querySelector('span.token.attr-name')
+    expect(innerSpan).toBeTruthy()
+    expect(innerSpan?.textContent).toBe('onClick')
+  })
+
+  it('空の alias はクラスに含めない', () => {
+    const token = makeToken('number', '42', '')
+    const { container } = render(<>{renderTokenStream([token], 'k')}</>)
+
+    const span = container.querySelector('span.token.number')
+    expect(span).toBeTruthy()
+    expect(span?.className).toBe('token number')
+  })
+
+  it('混在するトークンストリームを正しく描画する', () => {
+    const tokens: Array<string | Token> = [
+      makeToken('keyword', 'const'),
+      ' x = ',
+      makeToken('number', '42'),
+    ]
+    const { container } = render(<>{renderTokenStream(tokens, 'k')}</>)
+
+    expect(container.textContent).toBe('const x = 42')
+    expect(container.querySelector('span.token.keyword')).toBeTruthy()
+    expect(container.querySelector('span.token.number')).toBeTruthy()
+  })
+})

--- a/apps/web/src/features/learning/utils/renderPrismTokens.tsx
+++ b/apps/web/src/features/learning/utils/renderPrismTokens.tsx
@@ -1,0 +1,54 @@
+import type { Token } from 'prismjs'
+import type { ReactNode } from 'react'
+
+/**
+ * Prism.tokenize() が返すトークン配列を React 要素に変換する。
+ * dangerouslySetInnerHTML を使わずにシンタックスハイライトを実現する。
+ */
+export function renderTokenStream(
+  tokens: Array<string | Token>,
+  keyPrefix: string,
+): ReactNode[] {
+  return tokens.map((token, i) => {
+    const key = `${keyPrefix}-${String(i)}`
+
+    if (typeof token === 'string') {
+      return <span key={key}>{token}</span>
+    }
+
+    const classes = buildClassList(token.type, token.alias)
+    const children = renderContent(token.content, key)
+
+    return (
+      <span key={key} className={classes}>
+        {children}
+      </span>
+    )
+  })
+}
+
+function buildClassList(type: string, alias: string | string[]): string {
+  const parts = ['token', type]
+  if (typeof alias === 'string') {
+    if (alias) parts.push(alias)
+  } else if (Array.isArray(alias)) {
+    parts.push(...alias)
+  }
+  return parts.join(' ')
+}
+
+function renderContent(
+  content: string | Token | Array<string | Token>,
+  keyPrefix: string,
+): ReactNode {
+  if (typeof content === 'string') {
+    return content
+  }
+  if (Array.isArray(content)) {
+    return renderTokenStream(content, keyPrefix)
+  }
+  // Single nested Token
+  const classes = buildClassList(content.type, content.alias)
+  const children = renderContent(content.content, `${keyPrefix}-nested`)
+  return <span className={classes}>{children}</span>
+}

--- a/apps/web/supabase/sql/017_fix_profile_rls.sql
+++ b/apps/web/supabase/sql/017_fix_profile_rls.sql
@@ -1,0 +1,46 @@
+-- C-1: profiles テーブル is_admin RLS 修正
+-- Issue: #249
+--
+-- 脆弱性: own_profile ポリシーが for all で設定されており、
+-- ユーザーが DevTools から is_admin = true に書き換えて管理者権限を取得可能。
+--
+-- 修正: own_profile を操作別に分割し、is_admin の変更を構造的に防止する。
+
+-- =========================================================================
+-- 1. 既存の for all ポリシーを削除
+-- =========================================================================
+
+drop policy if exists own_profile on public.profiles;
+
+-- =========================================================================
+-- 2. SELECT: 自分のプロフィールを読取可能
+-- =========================================================================
+
+create policy own_profile_select on public.profiles
+  for select using (auth.uid() = id);
+
+-- =========================================================================
+-- 3. INSERT: 自分のプロフィールを作成可能（is_admin は false 固定）
+-- =========================================================================
+
+create policy own_profile_insert on public.profiles
+  for insert with check (auth.uid() = id and is_admin = false);
+
+-- =========================================================================
+-- 4. UPDATE: 自分のプロフィールを更新可能（is_admin の変更は不可）
+--    with check で is_admin の新しい値が現在の値と一致することを強制する。
+--    public.is_admin() は SECURITY DEFINER + set search_path = public なので
+--    RLS 再帰は発生しない。
+-- =========================================================================
+
+create policy own_profile_update on public.profiles
+  for update using (auth.uid() = id)
+  with check (
+    auth.uid() = id
+    and is_admin is not distinct from public.is_admin()
+  );
+
+-- =========================================================================
+-- 5. DELETE: ポリシーなし = 全拒否（削除は Supabase Auth cascade に任せる）
+-- =========================================================================
+-- 意図的にポリシーを定義しない

--- a/package-lock.json
+++ b/package-lock.json
@@ -4485,37 +4485,24 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -4741,9 +4728,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5003,9 +4990,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7915,9 +7902,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7964,9 +7951,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -8499,9 +8486,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9747,9 +9734,9 @@
       }
     },
     "node_modules/tailwindcss/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10108,9 +10095,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10176,9 +10163,9 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/vercel.json
+++ b/vercel.json
@@ -4,5 +4,24 @@
   "installCommand": "npm install",
   "rewrites": [
     { "source": "/(.*)", "destination": "/index.html" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self' https://*.supabase.co; worker-src 'self'; frame-ancestors 'none'"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary

セキュリティ監査で検出された 4 件の Issue を修正。

- **#249** profiles テーブル is_admin RLS を操作別ポリシーに分割
- **#250** npm audit 脆弱性 5件を修正
- **#252** dangerouslySetInnerHTML を除去し Prism.tokenize + React rendering に移行
- **#251** Content-Security-Policy + X-Frame-Options + X-Content-Type-Options を vercel.json に追加

## Test plan

- [x] `npm run typecheck` 通過
- [x] `npm run lint` 通過
- [x] `npm run test` 787件 全 PASS
- [x] `npm run build` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)