### PR TITLE
fix: サインアップ時に profiles 自動作成トリガーを追加 (#254)

### DIFF
--- a/apps/web/supabase/sql/018_auto_create_profile_trigger.sql
+++ b/apps/web/supabase/sql/018_auto_create_profile_trigger.sql
@@ -1,0 +1,55 @@
+-- Issue #254: サインアップ時に profiles レコードを自動作成するトリガー + 既存ユーザー補完
+--
+-- 構成:
+--   1. handle_new_user() トリガー関数（SECURITY DEFINER で RLS をバイパス）
+--   2. auth.users AFTER INSERT トリガー
+--   3. 既存ユーザーの profiles 一括補完
+
+-- =========================================================================
+-- 1. トリガー関数
+--    auth.users に新規行が挿入されたときに profiles を自動作成する。
+--    SECURITY DEFINER にすることで RLS の INSERT ポリシーをバイパスする。
+-- =========================================================================
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (id, display_name, is_admin, created_at)
+  values (
+    new.id,
+    coalesce(new.raw_user_meta_data ->> 'display_name', null),
+    false,
+    now()
+  )
+  on conflict (id) do nothing;
+  return new;
+end;
+$$;
+
+-- =========================================================================
+-- 2. トリガー定義
+-- =========================================================================
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();
+
+-- =========================================================================
+-- 3. 既存ユーザーの profiles 一括補完
+--    auth.users に存在するが profiles に行がないユーザーを補完する。
+-- =========================================================================
+
+insert into public.profiles (id, display_name, is_admin, created_at)
+select
+  au.id,
+  null,
+  false,
+  au.created_at
+from auth.users au
+left join public.profiles p on p.id = au.id
+where p.id is null;


### PR DESCRIPTION
## Summary
- `auth.users` INSERT 時に `profiles` レコードを自動作成する DB トリガー (`handle_new_user`) を追加
- 既存の `profiles` レコードがないユーザーを一括補完する INSERT クエリを同一マイグレーション内に含む
- 管理画面のユーザー一覧で全ユーザーが表示されるようになる

## 対応内容
- `018_auto_create_profile_trigger.sql` を新規追加
  - `handle_new_user()` SECURITY DEFINER 関数: `display_name` は `raw_user_meta_data` から取得（なければ NULL）、`is_admin = false` 固定
  - `on_auth_user_created` トリガー: `AFTER INSERT ON auth.users`
  - 既存ユーザー補完: `auth.users` に存在し `profiles` にないユーザーを一括 INSERT

## Supabase SQL エディタでの実行が必要
このマイグレーションはアプリコードの変更を含まないため、Supabase SQL エディタで手動実行してください。

## Test plan
- [ ] Supabase SQL エディタで `018_auto_create_profile_trigger.sql` を実行
- [ ] 管理画面ユーザー一覧で 9 ユーザー全員が表示されることを確認
- [ ] 新規サインアップ後、管理画面に即座に表示されることを確認

Closes #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)