### PR TITLE
feat: FAB 導線追加 + FeedbackContext リファクタ (v4roadmap03 M1)

### DIFF
--- a/apps/web/src/components/FeedbackFab.tsx
+++ b/apps/web/src/components/FeedbackFab.tsx
@@ -1,0 +1,22 @@
+import { MessageSquarePlus } from 'lucide-react'
+import { useAuth } from '../contexts/AuthContext'
+import { useFeedbackContext } from '../contexts/FeedbackContext'
+
+export function FeedbackFab() {
+  const { user } = useAuth()
+  const { openFeedback } = useFeedbackContext()
+
+  if (!user) return null
+
+  return (
+    <button
+      type="button"
+      onClick={openFeedback}
+      aria-label="フィードバックを送る"
+      title="フィードバックを送る"
+      className="fixed bottom-5 right-5 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-primary-mint text-white shadow-lg transition hover:bg-primary-dark hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary-mint focus:ring-offset-2 sm:h-14 sm:w-14"
+    >
+      <MessageSquarePlus className="h-5 w-5 sm:h-6 sm:w-6" aria-hidden="true" />
+    </button>
+  )
+}

--- a/apps/web/src/components/__tests__/FeedbackFab.test.tsx
+++ b/apps/web/src/components/__tests__/FeedbackFab.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { FeedbackFab } from '../FeedbackFab'
+
+const mockAuth = vi.hoisted(() => ({
+  value: { user: { id: 'u1' } as { id: string } | null },
+}))
+
+const mockFeedback = vi.hoisted(() => ({
+  openFeedback: vi.fn(),
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockAuth.value,
+}))
+
+vi.mock('@/contexts/FeedbackContext', () => ({
+  useFeedbackContext: () => mockFeedback,
+}))
+
+afterEach(() => {
+  cleanup()
+  mockAuth.value = { user: { id: 'u1' } }
+  mockFeedback.openFeedback.mockReset()
+})
+
+describe('FeedbackFab', () => {
+  it('ログイン済みユーザーに FAB が表示される', () => {
+    render(<FeedbackFab />)
+    expect(screen.getByRole('button', { name: 'フィードバックを送る' })).toBeTruthy()
+  })
+
+  it('未ログイン時は FAB が表示されない', () => {
+    mockAuth.value = { user: null }
+    const { container } = render(<FeedbackFab />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('FAB クリックで openFeedback が呼ばれる', () => {
+    render(<FeedbackFab />)
+    screen.getByRole('button', { name: 'フィードバックを送る' }).click()
+    expect(mockFeedback.openFeedback).toHaveBeenCalledOnce()
+  })
+
+  it('FAB が画面右下に固定されている', () => {
+    render(<FeedbackFab />)
+    const btn = screen.getByRole('button', { name: 'フィードバックを送る' })
+    expect(btn.className).toContain('fixed')
+    expect(btn.className).toContain('bottom-5')
+    expect(btn.className).toContain('right-5')
+  })
+})

--- a/apps/web/src/contexts/FeedbackContext.tsx
+++ b/apps/web/src/contexts/FeedbackContext.tsx
@@ -1,0 +1,33 @@
+import { createContext, useCallback, useContext, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+
+interface FeedbackContextValue {
+  isOpen: boolean
+  openFeedback: () => void
+  closeFeedback: () => void
+}
+
+const FeedbackContext = createContext<FeedbackContextValue | undefined>(undefined)
+
+export function FeedbackProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const openFeedback = useCallback(() => setIsOpen(true), [])
+  const closeFeedback = useCallback(() => setIsOpen(false), [])
+
+  const value = useMemo<FeedbackContextValue>(
+    () => ({ isOpen, openFeedback, closeFeedback }),
+    [isOpen, openFeedback, closeFeedback],
+  )
+
+  return <FeedbackContext.Provider value={value}>{children}</FeedbackContext.Provider>
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useFeedbackContext() {
+  const context = useContext(FeedbackContext)
+  if (!context) {
+    throw new Error('useFeedbackContext must be used inside FeedbackProvider')
+  }
+  return context
+}

--- a/apps/web/src/contexts/__tests__/FeedbackContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/FeedbackContext.test.tsx
@@ -1,0 +1,64 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { FeedbackProvider, useFeedbackContext } from '../FeedbackContext'
+
+afterEach(() => {
+  cleanup()
+})
+
+function TestConsumer() {
+  const { isOpen, openFeedback, closeFeedback } = useFeedbackContext()
+  return (
+    <div>
+      <span data-testid="status">{isOpen ? 'open' : 'closed'}</span>
+      <button type="button" onClick={openFeedback}>open</button>
+      <button type="button" onClick={closeFeedback}>close</button>
+    </div>
+  )
+}
+
+describe('FeedbackContext', () => {
+  it('初期状態で isOpen が false', () => {
+    render(
+      <FeedbackProvider>
+        <TestConsumer />
+      </FeedbackProvider>,
+    )
+    expect(screen.getByTestId('status').textContent).toBe('closed')
+  })
+
+  it('openFeedback で isOpen が true になる', () => {
+    render(
+      <FeedbackProvider>
+        <TestConsumer />
+      </FeedbackProvider>,
+    )
+    act(() => {
+      screen.getByRole('button', { name: 'open' }).click()
+    })
+    expect(screen.getByTestId('status').textContent).toBe('open')
+  })
+
+  it('closeFeedback で isOpen が false に戻る', () => {
+    render(
+      <FeedbackProvider>
+        <TestConsumer />
+      </FeedbackProvider>,
+    )
+    act(() => {
+      screen.getByRole('button', { name: 'open' }).click()
+    })
+    expect(screen.getByTestId('status').textContent).toBe('open')
+
+    act(() => {
+      screen.getByRole('button', { name: 'close' }).click()
+    })
+    expect(screen.getByTestId('status').textContent).toBe('closed')
+  })
+
+  it('Provider 外で useFeedbackContext を呼ぶとエラーになる', () => {
+    expect(() => render(<TestConsumer />)).toThrow(
+      'useFeedbackContext must be used inside FeedbackProvider',
+    )
+  })
+})

--- a/apps/web/src/features/dashboard/components/AppHeader.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeader.tsx
@@ -3,8 +3,8 @@ import { Link, useLocation } from 'react-router-dom'
 import { ChevronDown, Flame, Gem, MessageSquarePlus, Menu, Shield, X } from 'lucide-react'
 import { CATEGORIES } from '@/content/courseData'
 import { useAuth } from '@/contexts/AuthContext'
+import { useFeedbackContext } from '@/contexts/FeedbackContext'
 import { useLearningContext } from '@/contexts/LearningContext'
-import { FeedbackDialog } from '@/features/feedback/FeedbackDialog'
 
 interface AppHeaderProps {
   displayName: string
@@ -26,10 +26,10 @@ const TOP_NAV_LINKS = [
 export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
   const { stats } = useLearningContext()
   const { isAdmin } = useAuth()
+  const { openFeedback } = useFeedbackContext()
   const location = useLocation()
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
-  const [isFeedbackOpen, setIsFeedbackOpen] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
   const drawerRef = useRef<HTMLElement>(null)
   const menuButtonRef = useRef<HTMLButtonElement>(null)
@@ -190,7 +190,7 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
                     role="menuitem"
                     onClick={() => {
                       setIsDropdownOpen(false)
-                      setIsFeedbackOpen(true)
+                      openFeedback()
                     }}
                     className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50"
                   >
@@ -371,7 +371,7 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
               type="button"
               onClick={() => {
                 closeDrawer()
-                setIsFeedbackOpen(true)
+                openFeedback()
               }}
               className={`${drawerLinkClass(false)} w-full`}
             >
@@ -409,7 +409,6 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
       </nav>
     ) : null}
 
-    <FeedbackDialog open={isFeedbackOpen} onClose={() => setIsFeedbackOpen(false)} />
     </>
   )
 }

--- a/apps/web/src/features/dashboard/components/__tests__/AppHeaderAdminLink.test.tsx
+++ b/apps/web/src/features/dashboard/components/__tests__/AppHeaderAdminLink.test.tsx
@@ -17,6 +17,10 @@ vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => mockAuth.value,
 }))
 
+vi.mock('@/contexts/FeedbackContext', () => ({
+  useFeedbackContext: () => ({ openFeedback: vi.fn() }),
+}))
+
 function renderHeader() {
   return render(
     <MemoryRouter>

--- a/apps/web/src/features/dashboard/components/__tests__/AppHeaderMobile.test.tsx
+++ b/apps/web/src/features/dashboard/components/__tests__/AppHeaderMobile.test.tsx
@@ -19,6 +19,10 @@ vi.mock('@/contexts/AuthContext', () => ({
   }),
 }))
 
+vi.mock('@/contexts/FeedbackContext', () => ({
+  useFeedbackContext: () => ({ openFeedback: vi.fn() }),
+}))
+
 afterEach(() => {
   cleanup()
 })

--- a/apps/web/src/features/dashboard/components/__tests__/DashboardNavigation.test.tsx
+++ b/apps/web/src/features/dashboard/components/__tests__/DashboardNavigation.test.tsx
@@ -20,6 +20,10 @@ vi.mock('@/contexts/AuthContext', () => ({
   }),
 }))
 
+vi.mock('@/contexts/FeedbackContext', () => ({
+  useFeedbackContext: () => ({ openFeedback: vi.fn() }),
+}))
+
 vi.mock('@/services/statsService', () => ({
   calculatePointGoalProgress: () => ({
     current: 120,

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,11 +2,14 @@ import React, { lazy, Suspense } from 'react'
 import ReactDOM from 'react-dom/client'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { AdminGuard } from './components/AdminGuard'
+import { FeedbackFab } from './components/FeedbackFab'
 import { ProtectedRoute, GuestRoute } from './components/ProtectedRoute'
 import { AuthProvider } from './contexts/AuthContext'
+import { FeedbackProvider, useFeedbackContext } from './contexts/FeedbackContext'
 import { LearningProvider } from './contexts/LearningContext'
 import { AchievementProvider } from './contexts/AchievementContext'
 import { AchievementToast } from './components/AchievementToast'
+import { FeedbackDialog } from './features/feedback/FeedbackDialog'
 import { ConfigErrorView } from './components/ConfigErrorView'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { PageSpinner } from './components/Spinner'
@@ -57,6 +60,12 @@ const AdminStatsPage = lazy(() =>
 const AdminOpsPage = lazy(() =>
   import('./pages/admin/AdminOpsPage').then((m) => ({ default: m.AdminOpsPage })),
 )
+
+// FeedbackContext → FeedbackDialog をつなぐ薄いラッパー
+function ConnectedFeedbackDialog() {
+  const { isOpen, closeFeedback } = useFeedbackContext()
+  return <FeedbackDialog open={isOpen} onClose={closeFeedback} />
+}
 
 // ページ遷移中のフォールバック UI
 function PageLoading() {
@@ -314,8 +323,12 @@ async function startApp() {
           <AuthProvider>
             <LearningProvider>
               <AchievementProvider>
-                <AchievementToast />
-                <RouterProvider router={router} />
+                <FeedbackProvider>
+                  <AchievementToast />
+                  <FeedbackFab />
+                  <ConnectedFeedbackDialog />
+                  <RouterProvider router={router} />
+                </FeedbackProvider>
               </AchievementProvider>
             </LearningProvider>
           </AuthProvider>


### PR DESCRIPTION
## Summary
- FeedbackContext 新設（isOpen / openFeedback / closeFeedback）でダイアログの開閉状態をグローバル管理
- FeedbackFab コンポーネント新設：画面右下固定のフローティングボタン（ログイン済みのみ表示）
- AppHeader リファクタ：ローカル isFeedbackOpen state → FeedbackContext に移行、Dialog インスタンスを削除
- main.tsx に FeedbackProvider + ConnectedFeedbackDialog + FeedbackFab を配置
- テスト追加：FeedbackContext 4件、FeedbackFab 4件、既存テスト修正3件

## Test plan
- [x] typecheck pass
- [x] lint pass  
- [x] test pass (795件)
- [x] build pass
- [ ] 手動: FAB が全ページ（ダッシュボード・学習・プロフィール等）で表示されること
- [ ] 手動: FAB クリック → FeedbackDialog が開くこと
- [ ] 手動: AppHeader ドロップダウンからも引き続き Dialog が開くこと
- [ ] 手動: モバイル幅で FAB のサイズ・位置が適切か確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)