### PR TITLE
feat: スクリーンショット添付機能（M2）

### DIFF
--- a/apps/web/src/features/feedback/FeedbackDialog.tsx
+++ b/apps/web/src/features/feedback/FeedbackDialog.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { AlertCircle, Loader2, X } from 'lucide-react'
+import { AlertCircle, ImagePlus, Loader2, Trash2, X } from 'lucide-react'
 import { useAuth } from '../../contexts/AuthContext'
 import {
   captureClientMeta,
   FEEDBACK_CATEGORY_LABELS,
   MAX_FEEDBACK_MESSAGE_LENGTH,
+  MAX_IMAGE_COUNT,
   submitFeedback,
+  validateImageFiles,
   type FeedbackCategory,
 } from '../../services/feedbackService'
 
@@ -23,8 +25,10 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [isSubmitted, setIsSubmitted] = useState(false)
+  const [files, setFiles] = useState<File[]>([])
   const dialogRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   // ダイアログを閉じたらフォーム状態をリセット
   const reset = useCallback(() => {
@@ -33,6 +37,7 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
     setError(null)
     setIsSubmitted(false)
     setIsSubmitting(false)
+    setFiles([])
   }, [])
 
   const handleClose = useCallback(() => {
@@ -96,6 +101,7 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
         message: trimmed,
         pageUrl: meta.pageUrl,
         userAgent: meta.userAgent,
+        ...(files.length > 0 ? { files } : {}),
       })
       setIsSubmitted(true)
     } catch (err) {
@@ -204,6 +210,85 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
               </div>
             </div>
 
+            {/* 画像添付セクション */}
+            <div>
+              <div className="flex items-center justify-between">
+                <span className="block text-xs font-semibold text-slate-700">
+                  スクリーンショット（任意）
+                </span>
+                <span className="text-xs text-slate-400">{files.length}/{MAX_IMAGE_COUNT}</span>
+              </div>
+
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                className="hidden"
+                disabled={isSubmitting || files.length >= MAX_IMAGE_COUNT}
+                onChange={(e) => {
+                  const selected = Array.from(e.target.files ?? [])
+                  if (selected.length === 0) return
+                  const merged = [...files, ...selected].slice(0, MAX_IMAGE_COUNT)
+                  try {
+                    validateImageFiles(merged)
+                    setFiles(merged)
+                    setError(null)
+                  } catch (err) {
+                    setError(err instanceof Error ? err.message : 'ファイルの追加に失敗しました')
+                  }
+                  // 同じファイルを再選択できるようリセット
+                  e.target.value = ''
+                }}
+              />
+
+              {files.length > 0 ? (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {files.map((file, idx) => (
+                    <div
+                      key={`${file.name}-${file.size}-${idx}`}
+                      className="group relative flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-2 py-1.5"
+                    >
+                      <img
+                        src={URL.createObjectURL(file)}
+                        alt={file.name}
+                        className="h-10 w-10 rounded object-cover"
+                      />
+                      <div className="min-w-0">
+                        <p className="max-w-[120px] truncate text-xs font-medium text-slate-700">{file.name}</p>
+                        <p className="text-[10px] text-slate-400">{formatFileSize(file.size)}</p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => setFiles((prev) => prev.filter((_, i) => i !== idx))}
+                        disabled={isSubmitting}
+                        className="ml-1 rounded p-0.5 text-slate-400 transition hover:bg-slate-200 hover:text-rose-600"
+                        aria-label={`${file.name} を削除`}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+
+              {files.length < MAX_IMAGE_COUNT ? (
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={isSubmitting}
+                  className="mt-2 flex items-center gap-1.5 rounded-lg border border-dashed border-slate-300 px-3 py-2 text-xs font-medium text-slate-500 transition hover:border-primary-mint hover:text-primary-mint"
+                >
+                  <ImagePlus className="h-4 w-4" aria-hidden="true" />
+                  画像を追加
+                </button>
+              ) : null}
+
+              <p className="mt-1 text-[10px] text-slate-400">
+                PNG / JPG / GIF など、各 5MB 以下
+              </p>
+            </div>
+
             {error ? (
               <div className="flex items-start gap-2 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700">
                 <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
@@ -234,4 +319,10 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
       </div>
     </div>
   )
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }

--- a/apps/web/src/features/feedback/__tests__/FeedbackDialog.test.tsx
+++ b/apps/web/src/features/feedback/__tests__/FeedbackDialog.test.tsx
@@ -107,4 +107,41 @@ describe('FeedbackDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: '閉じる' }))
     expect(onClose).toHaveBeenCalled()
   })
+
+  it('画像追加ボタンが表示される', () => {
+    render(<FeedbackDialog open={true} onClose={() => undefined} />)
+    expect(screen.getByRole('button', { name: '画像を追加' })).toBeTruthy()
+    expect(screen.getByText(/0\/3/)).toBeTruthy()
+  })
+
+  it('不正なファイルを追加するとエラーが表示される', async () => {
+    render(<FeedbackDialog open={true} onClose={() => undefined} />)
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement
+
+    const pdf = new File(['dummy'], 'doc.pdf', { type: 'application/pdf' })
+    fireEvent.change(fileInput, { target: { files: [pdf] } })
+
+    await waitFor(() => {
+      expect(screen.getByText(/画像ファイルではありません/)).toBeTruthy()
+    })
+  })
+
+  it('画像を追加するとプレビューが表示され削除ボタンで除去できる', async () => {
+    render(<FeedbackDialog open={true} onClose={() => undefined} />)
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement
+
+    const img = new File(['x'], 'shot.png', { type: 'image/png' })
+    fireEvent.change(fileInput, { target: { files: [img] } })
+
+    await waitFor(() => {
+      expect(screen.getByText('shot.png')).toBeTruthy()
+      expect(screen.getByText(/1\/3/)).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'shot.png を削除' }))
+    await waitFor(() => {
+      expect(screen.queryByText('shot.png')).toBeNull()
+      expect(screen.getByText(/0\/3/)).toBeTruthy()
+    })
+  })
 })

--- a/apps/web/src/services/__tests__/feedbackService.test.ts
+++ b/apps/web/src/services/__tests__/feedbackService.test.ts
@@ -7,6 +7,8 @@ import {
   submitFeedback,
   updateFeedbackNote,
   updateFeedbackStatus,
+  uploadFeedbackImages,
+  validateImageFiles,
 } from '../feedbackService'
 
 // Supabase chain mocks. 単一テーブルごとにビルダーを返す `from` を作成する。
@@ -106,6 +108,21 @@ function createAuditLogBuilder() {
   }
 }
 
+const storageState = {
+  uploadCalls: [] as Array<{ path: string; file: File; options: Record<string, unknown> }>,
+  uploadResult: { error: null as unknown },
+}
+
+const storageUpload = vi.fn((path: string, file: File, options: Record<string, unknown>) => {
+  storageState.uploadCalls.push({ path, file, options })
+  return Promise.resolve({ data: { path }, error: storageState.uploadResult.error })
+})
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const storageFrom = vi.fn((_bucket: string) => ({
+  upload: storageUpload,
+}))
+
 const from = vi.fn((table: string) => {
   if (table === 'user_feedback') return createUserFeedbackBuilder()
   if (table === 'admin_audit_log') return createAuditLogBuilder()
@@ -115,6 +132,9 @@ const from = vi.fn((table: string) => {
 vi.mock('../../lib/supabaseClient', () => ({
   supabase: {
     from: (...args: unknown[]) => from(...(args as [string])),
+    storage: {
+      from: (...args: unknown[]) => storageFrom(...(args as [string])),
+    },
   },
 }))
 
@@ -137,6 +157,8 @@ function resetState() {
   userFeedbackState.limitCalls = []
   auditLogState.lastInsertPayload = null
   auditLogState.insertResult = { error: null }
+  storageState.uploadCalls = []
+  storageState.uploadResult = { error: null }
 }
 
 describe('FEEDBACK_CATEGORIES / FEEDBACK_STATUSES', () => {
@@ -434,5 +456,129 @@ describe('updateFeedbackNote', () => {
       userMessage: 'フィードバックのメモ更新に失敗しました',
     })
     expect(auditLogState.lastInsertPayload).toBeNull()
+  })
+})
+
+// ─── 画像バリデーション・アップロード ─────────────────────
+
+function createTestFile(name: string, size: number, type = 'image/png'): File {
+  const buf = new ArrayBuffer(size)
+  return new File([buf], name, { type })
+}
+
+describe('validateImageFiles', () => {
+  it('空配列は正常に通過する', () => {
+    expect(() => validateImageFiles([])).not.toThrow()
+  })
+
+  it('3枚以下の画像は正常に通過する', () => {
+    const files = [
+      createTestFile('a.png', 1024),
+      createTestFile('b.jpg', 2048),
+      createTestFile('c.gif', 512),
+    ]
+    expect(() => validateImageFiles(files)).not.toThrow()
+  })
+
+  it('4枚以上で例外を投げる', () => {
+    const files = Array.from({ length: 4 }, (_, i) => createTestFile(`${i}.png`, 100))
+    expect(() => validateImageFiles(files)).toThrow('画像は最大 3 枚まで添付できます')
+  })
+
+  it('5MB超過のファイルで例外を投げる', () => {
+    const big = createTestFile('huge.png', 6 * 1024 * 1024)
+    expect(() => validateImageFiles([big])).toThrow('huge.png のサイズが上限（5MB）を超えています')
+  })
+
+  it('image/* 以外の MIME タイプで例外を投げる', () => {
+    const pdf = createTestFile('doc.pdf', 1024, 'application/pdf')
+    expect(() => validateImageFiles([pdf])).toThrow('doc.pdf は画像ファイルではありません')
+  })
+})
+
+describe('uploadFeedbackImages', () => {
+  beforeEach(resetState)
+
+  it('Storage にアップロードしパスの配列を返す', async () => {
+    const files = [createTestFile('a.png', 100), createTestFile('b.jpg', 200, 'image/jpeg')]
+    const paths = await uploadFeedbackImages(VALID_USER_ID, VALID_FEEDBACK_ID, files)
+
+    expect(storageFrom).toHaveBeenCalledWith('feedback-images')
+    expect(storageState.uploadCalls).toHaveLength(2)
+    expect(storageState.uploadCalls[0]!.path).toMatch(
+      new RegExp(`^${VALID_USER_ID}/${VALID_FEEDBACK_ID}/\\d+_a\\.png$`),
+    )
+    expect(storageState.uploadCalls[1]!.options).toEqual({ contentType: 'image/jpeg' })
+    expect(paths).toHaveLength(2)
+    expect(paths[0]).toContain(VALID_USER_ID)
+  })
+
+  it('ファイル名の特殊文字をアンダースコアに置換する', async () => {
+    const files = [createTestFile('スクショ (1).png', 100)]
+    await uploadFeedbackImages(VALID_USER_ID, VALID_FEEDBACK_ID, files)
+    const uploaded = storageState.uploadCalls[0]!.path
+    expect(uploaded).not.toMatch(/[^a-zA-Z0-9._\-/]/)
+  })
+
+  it('Storage エラー時にアプリ共通エラーを投げる', async () => {
+    storageState.uploadResult = { error: { message: 'bucket not found' } }
+    const files = [createTestFile('fail.png', 100)]
+    await expect(
+      uploadFeedbackImages(VALID_USER_ID, VALID_FEEDBACK_ID, files),
+    ).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: '画像「fail.png」のアップロードに失敗しました',
+    })
+  })
+})
+
+describe('submitFeedback with files', () => {
+  beforeEach(resetState)
+
+  it('画像付き送信で INSERT → Storage アップロード → UPDATE の順に実行する', async () => {
+    const feedbackRow = {
+      id: VALID_FEEDBACK_ID,
+      user_id: VALID_USER_ID,
+      category: 'bug',
+      message: 'hello',
+      status: 'new',
+      image_paths: [],
+    }
+    userFeedbackState.insertResult = { data: feedbackRow, error: null }
+    userFeedbackState.updateResult = {
+      data: { ...feedbackRow, image_paths: ['path/a.png'] },
+      error: null,
+    }
+
+    const files = [createTestFile('screenshot.png', 1024)]
+    const result = await submitFeedback({
+      userId: VALID_USER_ID,
+      category: 'bug',
+      message: 'hello',
+      files,
+    })
+
+    // INSERT が呼ばれている
+    expect(userFeedbackState.insertPayload).not.toBeNull()
+    // Storage アップロードが呼ばれている
+    expect(storageState.uploadCalls).toHaveLength(1)
+    // UPDATE で image_paths が設定されている
+    expect(userFeedbackState.updatePayload).toHaveProperty('image_paths')
+    expect(result.image_paths).toEqual(['path/a.png'])
+  })
+
+  it('画像なし送信では Storage アップロードも UPDATE も呼ばない', async () => {
+    userFeedbackState.insertResult = {
+      data: { id: VALID_FEEDBACK_ID, image_paths: [] },
+      error: null,
+    }
+    await submitFeedback({
+      userId: VALID_USER_ID,
+      category: 'bug',
+      message: 'hello',
+    })
+
+    expect(storageState.uploadCalls).toHaveLength(0)
+    expect(userFeedbackState.updatePayload).toBeNull()
   })
 })

--- a/apps/web/src/services/feedbackService.ts
+++ b/apps/web/src/services/feedbackService.ts
@@ -44,6 +44,13 @@ export const FEEDBACK_STATUS_LABELS: Record<FeedbackStatus, string> = {
   archived: 'アーカイブ',
 }
 
+/** 添付画像の最大枚数 */
+export const MAX_IMAGE_COUNT = 3
+/** 添付画像の最大サイズ（5 MB） */
+export const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024
+/** Storage バケット名 */
+export const FEEDBACK_IMAGES_BUCKET = 'feedback-images'
+
 /** 本文の最大文字数（DB 側制約 4000 と一致させる） */
 export const MAX_FEEDBACK_MESSAGE_LENGTH = 4000
 /** page_url の最大文字数（長大な URL で DB を肥大化させないため短めに丸める） */
@@ -92,6 +99,8 @@ export interface SubmitFeedbackInput {
   message: string
   pageUrl?: string | null
   userAgent?: string | null
+  /** 添付する画像ファイル（最大3枚、各5MB以下） */
+  files?: File[]
 }
 
 /**
@@ -109,9 +118,14 @@ export async function submitFeedback(input: SubmitFeedbackInput): Promise<UserFe
   }
   assertMaxLength(trimmedMessage, MAX_FEEDBACK_MESSAGE_LENGTH, 'message')
 
+  // 画像バリデーション
+  const files = input.files ?? []
+  validateImageFiles(files)
+
   const normalizedPageUrl = normalizeOptionalText(input.pageUrl, MAX_PAGE_URL_LENGTH)
   const normalizedUserAgent = normalizeOptionalText(input.userAgent, MAX_USER_AGENT_LENGTH)
 
+  // 1. feedback レコードを INSERT
   const { data, error } = await supabase
     .from('user_feedback')
     .insert({
@@ -128,7 +142,75 @@ export async function submitFeedback(input: SubmitFeedbackInput): Promise<UserFe
     throw fromSupabaseError(error, 'フィードバックの送信に失敗しました')
   }
 
+  // 2. 画像があれば Storage にアップロードし image_paths を UPDATE
+  if (files.length > 0) {
+    const paths = await uploadFeedbackImages(input.userId, data.id, files)
+    const { data: updated, error: updateError } = await supabase
+      .from('user_feedback')
+      .update({ image_paths: paths as Json[] })
+      .eq('id', data.id)
+      .select()
+      .single()
+
+    if (updateError) {
+      throw fromSupabaseError(updateError, '画像パスの保存に失敗しました')
+    }
+    return updated
+  }
+
   return data
+}
+
+/**
+ * 画像ファイルのバリデーション。
+ * - 枚数: MAX_IMAGE_COUNT 以下
+ * - 各ファイルサイズ: MAX_IMAGE_SIZE_BYTES 以下
+ * - MIME タイプ: image/* のみ
+ */
+export function validateImageFiles(files: File[]): void {
+  if (files.length > MAX_IMAGE_COUNT) {
+    throw new Error(`画像は最大 ${MAX_IMAGE_COUNT} 枚まで添付できます`)
+  }
+  for (const file of files) {
+    if (file.size > MAX_IMAGE_SIZE_BYTES) {
+      throw new Error(`${file.name} のサイズが上限（5MB）を超えています`)
+    }
+    if (!file.type.startsWith('image/')) {
+      throw new Error(`${file.name} は画像ファイルではありません`)
+    }
+  }
+}
+
+/**
+ * Storage にフィードバック画像をアップロードし、保存パスの配列を返す。
+ * パス構造: {userId}/{feedbackId}/{filename}
+ */
+export async function uploadFeedbackImages(
+  userId: string,
+  feedbackId: string,
+  files: File[],
+): Promise<string[]> {
+  const paths: string[] = []
+
+  for (const file of files) {
+    // ファイル名の衝突を避けるため timestamp を付与
+    const safeName = `${Date.now()}_${file.name.replace(/[^a-zA-Z0-9._-]/g, '_')}`
+    const path = `${userId}/${feedbackId}/${safeName}`
+
+    const { error } = await supabase.storage
+      .from(FEEDBACK_IMAGES_BUCKET)
+      .upload(path, file, { contentType: file.type })
+
+    if (error) {
+      throw fromSupabaseError(
+        { code: 'STORAGE_ERROR', message: error.message },
+        `画像「${file.name}」のアップロードに失敗しました`,
+      )
+    }
+    paths.push(path)
+  }
+
+  return paths
 }
 
 function normalizeOptionalText(value: string | null | undefined, maxLength: number): string | null {

--- a/apps/web/src/shared/types/database.types.ts
+++ b/apps/web/src/shared/types/database.types.ts
@@ -173,6 +173,7 @@ export type Database = {
           category: string
           created_at: string
           id: string
+          image_paths: Json
           message: string
           page_url: string | null
           status: string
@@ -185,6 +186,7 @@ export type Database = {
           category: string
           created_at?: string
           id?: string
+          image_paths?: Json
           message: string
           page_url?: string | null
           status?: string
@@ -197,6 +199,7 @@ export type Database = {
           category?: string
           created_at?: string
           id?: string
+          image_paths?: Json
           message?: string
           page_url?: string | null
           status?: string

--- a/apps/web/supabase/sql/019_feedback_images.sql
+++ b/apps/web/supabase/sql/019_feedback_images.sql
@@ -1,0 +1,66 @@
+-- 019_feedback_images.sql
+-- user_feedback にスクリーンショット添付機能を追加する。
+-- 1) image_paths jsonb 列を追加
+-- 2) feedback-images Storage バケットを作成
+-- 3) Storage RLS ポリシーを設定
+
+-- ─── 1. user_feedback.image_paths 列追加 ───────────────────────────
+ALTER TABLE public.user_feedback
+  ADD COLUMN IF NOT EXISTS image_paths jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN public.user_feedback.image_paths
+  IS '添付画像のパス配列（最大3枚）。形式: ["user_id/feedback_id/filename", ...]';
+
+-- ─── 2. Storage バケット作成 ────────────────────────────────────────
+-- private バケット（signed URL 経由でのみアクセス可能）
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('feedback-images', 'feedback-images', false)
+ON CONFLICT (id) DO NOTHING;
+
+-- ─── 3. Storage RLS ポリシー ───────────────────────────────────────
+
+-- 3a. INSERT: 認証済みユーザーが自分のディレクトリにのみアップロード可能
+--     パス構造: {user_id}/{feedback_id}/{filename}
+--     → path の先頭セグメントが auth.uid() と一致することを検証
+CREATE POLICY "feedback_images_insert_own"
+  ON storage.objects
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'feedback-images'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- 3b. SELECT: 自分のファイルのみ閲覧可能（一般ユーザー）
+CREATE POLICY "feedback_images_select_own"
+  ON storage.objects
+  FOR SELECT
+  TO authenticated
+  USING (
+    bucket_id = 'feedback-images'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- 3c. SELECT: admin は全ファイル閲覧可能
+CREATE POLICY "feedback_images_select_admin"
+  ON storage.objects
+  FOR SELECT
+  TO authenticated
+  USING (
+    bucket_id = 'feedback-images'
+    AND EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE profiles.id = auth.uid()
+        AND profiles.is_admin = true
+    )
+  );
+
+-- 3d. DELETE: 自分のファイルのみ削除可能（アップロード取り消し用）
+CREATE POLICY "feedback_images_delete_own"
+  ON storage.objects
+  FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'feedback-images'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );


### PR DESCRIPTION
## Summary
- `019_feedback_images.sql`: `user_feedback.image_paths` jsonb 列追加 + `feedback-images` Storage バケット作成 + RLS ポリシー（INSERT/SELECT/DELETE own + SELECT admin）
- `feedbackService.ts`: `validateImageFiles()` / `uploadFeedbackImages()` 追加、`submitFeedback()` に画像アップロードフロー統合
- `FeedbackDialog.tsx`: 画像プレビュー・個別削除・バリデーションエラー表示 UI
- テスト +13件（validateImageFiles 5件 / uploadFeedbackImages 3件 / submitFeedback with files 2件 / Dialog UI 3件）

## Test plan
- [x] typecheck pass
- [x] lint pass
- [x] test pass (795 → 808件)
- [x] build pass
- [ ] 手動: Supabase に SQL 適用後、実機で画像添付→送信→管理画面で閲覧を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)