### PR TITLE
feat: 管理画面にフィードバック添付画像の表示機能を追加

### DIFF
--- a/apps/web/src/features/admin/components/ImageLightbox.tsx
+++ b/apps/web/src/features/admin/components/ImageLightbox.tsx
@@ -1,0 +1,113 @@
+import { useCallback, useEffect } from 'react'
+import { ChevronLeft, ChevronRight, X } from 'lucide-react'
+import type { FeedbackImageUrl } from '../../../services/feedbackService'
+
+interface ImageLightboxProps {
+  images: FeedbackImageUrl[]
+  currentIndex: number
+  onClose: () => void
+  onChangeIndex: (index: number) => void
+}
+
+export function ImageLightbox({ images, currentIndex, onClose, onChangeIndex }: ImageLightboxProps) {
+  const hasPrev = currentIndex > 0
+  const hasNext = currentIndex < images.length - 1
+
+  const goPrev = useCallback(() => {
+    if (hasPrev) onChangeIndex(currentIndex - 1)
+  }, [hasPrev, currentIndex, onChangeIndex])
+
+  const goNext = useCallback(() => {
+    if (hasNext) onChangeIndex(currentIndex + 1)
+  }, [hasNext, currentIndex, onChangeIndex])
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      switch (e.key) {
+        case 'Escape':
+          onClose()
+          break
+        case 'ArrowLeft':
+          goPrev()
+          break
+        case 'ArrowRight':
+          goNext()
+          break
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose, goPrev, goNext])
+
+  const current = images[currentIndex]
+  if (!current) return null
+
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- keyboard handled via document keydown listener, dialog overlay click-to-close is standard UX
+    <div
+      role="dialog"
+      aria-label="画像プレビュー"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
+      onClick={onClose}
+    >
+      {/* Close button */}
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation()
+          onClose()
+        }}
+        className="absolute right-4 top-4 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20"
+        aria-label="閉じる"
+      >
+        <X className="h-6 w-6" />
+      </button>
+
+      {/* Counter */}
+      <span className="absolute left-4 top-4 rounded-full bg-white/10 px-3 py-1 text-sm text-white">
+        {currentIndex + 1} / {images.length}
+      </span>
+
+      {/* Prev button */}
+      {hasPrev && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            goPrev()
+          }}
+          className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20"
+          aria-label="前の画像"
+        >
+          <ChevronLeft className="h-6 w-6" />
+        </button>
+      )}
+
+      {/* Image — wrapper div prevents click-to-close when clicking on the image */}
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+      <div onClick={(e) => e.stopPropagation()}>
+        <img
+          src={current.url}
+          alt={`添付画像 ${currentIndex + 1}`}
+          className="max-h-[85vh] max-w-[90vw] rounded-lg object-contain"
+        />
+      </div>
+
+      {/* Next button */}
+      {hasNext && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            goNext()
+          }}
+          className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20"
+          aria-label="次の画像"
+        >
+          <ChevronRight className="h-6 w-6" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/features/admin/components/__tests__/ImageLightbox.test.tsx
+++ b/apps/web/src/features/admin/components/__tests__/ImageLightbox.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ImageLightbox } from '../ImageLightbox'
+import type { FeedbackImageUrl } from '../../../../services/feedbackService'
+
+const images: FeedbackImageUrl[] = [
+  { path: 'uid/fid/a.png', url: 'https://example.com/a.png' },
+  { path: 'uid/fid/b.jpg', url: 'https://example.com/b.jpg' },
+  { path: 'uid/fid/c.gif', url: 'https://example.com/c.gif' },
+]
+
+afterEach(cleanup)
+
+describe('ImageLightbox', () => {
+  it('dialog ロールで表示される', () => {
+    render(
+      <ImageLightbox images={images} currentIndex={0} onClose={vi.fn()} onChangeIndex={vi.fn()} />,
+    )
+    expect(screen.getByRole('dialog', { name: '画像プレビュー' })).toBeTruthy()
+  })
+
+  it('現在の画像が表示される', () => {
+    render(
+      <ImageLightbox images={images} currentIndex={1} onClose={vi.fn()} onChangeIndex={vi.fn()} />,
+    )
+    const img = screen.getByAltText('添付画像 2')
+    expect(img.getAttribute('src')).toBe('https://example.com/b.jpg')
+  })
+
+  it('カウンタ���が表示される', () => {
+    render(
+      <ImageLightbox images={images} currentIndex={0} onClose={vi.fn()} onChangeIndex={vi.fn()} />,
+    )
+    expect(screen.getByText('1 / 3')).toBeTruthy()
+  })
+
+  it('ESC キーで onClose が呼ばれる', () => {
+    const onClose = vi.fn()
+    render(
+      <ImageLightbox images={images} currentIndex={0} onClose={onClose} onChangeIndex={vi.fn()} />,
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('閉じるボタンで onClose が呼ばれる', () => {
+    const onClose = vi.fn()
+    render(
+      <ImageLightbox images={images} currentIndex={0} onClose={onClose} onChangeIndex={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: '閉じる' }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('ArrowRight キーで次の画像に切り替わる', () => {
+    const onChangeIndex = vi.fn()
+    render(
+      <ImageLightbox images={images} currentIndex={0} onClose={vi.fn()} onChangeIndex={onChangeIndex} />,
+    )
+    fireEvent.keyDown(document, { key: 'ArrowRight' })
+    expect(onChangeIndex).toHaveBeenCalledWith(1)
+  })
+
+  it('ArrowLeft キーで前の画像に切り替わる', () => {
+    const onChangeIndex = vi.fn()
+    render(
+      <ImageLightbox images={images} currentIndex={2} onClose={vi.fn()} onChangeIndex={onChangeIndex} />,
+    )
+    fireEvent.keyDown(document, { key: 'ArrowLeft' })
+    expect(onChangeIndex).toHaveBeenCalledWith(1)
+  })
+
+  it('最初の画像で ArrowLeft を押しても onChangeIndex は呼ばれない', () => {
+    const onChangeIndex = vi.fn()
+    render(
+      <ImageLightbox images={images} currentIndex={0} onClose={vi.fn()} onChangeIndex={onChangeIndex} />,
+    )
+    fireEvent.keyDown(document, { key: 'ArrowLeft' })
+    expect(onChangeIndex).not.toHaveBeenCalled()
+  })
+
+  it('最後の画像で ArrowRight を押しても onChangeIndex は呼ばれない', () => {
+    const onChangeIndex = vi.fn()
+    render(
+      <ImageLightbox images={images} currentIndex={2} onClose={vi.fn()} onChangeIndex={onChangeIndex} />,
+    )
+    fireEvent.keyDown(document, { key: 'ArrowRight' })
+    expect(onChangeIndex).not.toHaveBeenCalled()
+  })
+
+  it('前へ・次へボタンのクリックで onChangeIndex が呼ばれる', () => {
+    const onChangeIndex = vi.fn()
+    render(
+      <ImageLightbox images={images} currentIndex={1} onClose={vi.fn()} onChangeIndex={onChangeIndex} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: '前の画像' }))
+    expect(onChangeIndex).toHaveBeenCalledWith(0)
+    fireEvent.click(screen.getByRole('button', { name: '次の画像' }))
+    expect(onChangeIndex).toHaveBeenCalledWith(2)
+  })
+})

--- a/apps/web/src/pages/admin/AdminFeedbackDetailPage.tsx
+++ b/apps/web/src/pages/admin/AdminFeedbackDetailPage.tsx
@@ -1,21 +1,23 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
-import { AlertCircle, ArrowLeft, Loader2 } from 'lucide-react'
+import { AlertCircle, ArrowLeft, ImageIcon, Loader2 } from 'lucide-react'
 import { useAuth } from '../../contexts/AuthContext'
 import { AdminLayout } from '../../features/admin/components/AdminLayout'
 import { FeedbackNoteForm } from '../../features/admin/components/FeedbackNoteForm'
 import { FeedbackStatusForm } from '../../features/admin/components/FeedbackStatusForm'
 import { FeedbackUserInfo } from '../../features/admin/components/FeedbackUserInfo'
+import { ImageLightbox } from '../../features/admin/components/ImageLightbox'
 import { formatJstDateTime } from '../../lib/dateFormat'
 import { useDocumentTitle } from '../../hooks/useDocumentTitle'
 import {
   FEEDBACK_CATEGORY_LABELS,
   FEEDBACK_STATUS_LABELS,
   getFeedback,
+  getFeedbackImageUrls,
   isFeedbackCategory,
   isFeedbackStatus,
 } from '../../services/feedbackService'
-import type { UserFeedback } from '../../services/feedbackService'
+import type { FeedbackImageUrl, UserFeedback } from '../../services/feedbackService'
 import { CATEGORY_BADGE_CLASSES, STATUS_BADGE_CLASSES } from '../../features/feedback/feedbackBadge'
 
 // ─── Badge helpers ──────────────────────────────────────────────────────────
@@ -67,6 +69,11 @@ export function AdminFeedbackDetailPage() {
   const [notFound, setNotFound] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
 
+  const [imageUrls, setImageUrls] = useState<FeedbackImageUrl[]>([])
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null)
+
+  const closeLightbox = useCallback(() => setLightboxIndex(null), [])
+
   useEffect(() => {
     if (!id) {
       setNotFound(true)
@@ -86,6 +93,17 @@ export function AdminFeedbackDetailPage() {
           return
         }
         setFeedback(data)
+
+        // image_paths がある場合は signed URL を取得
+        const paths = Array.isArray(data.image_paths) ? (data.image_paths as string[]) : []
+        if (paths.length > 0) {
+          try {
+            const urls = await getFeedbackImageUrls(paths)
+            if (isMounted) setImageUrls(urls)
+          } catch {
+            // 画像 URL 取得失敗はフィードバック表示をブロックしない
+          }
+        }
       } catch (e) {
         if (!isMounted) return
         setLoadError(e instanceof Error ? e.message : 'フィードバックの取得に失敗しました')
@@ -153,6 +171,33 @@ export function AdminFeedbackDetailPage() {
             </pre>
           </section>
 
+          {/* Images */}
+          {imageUrls.length > 0 && (
+            <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+              <h2 className="mb-3 flex items-center gap-1.5 text-sm font-semibold text-slate-700">
+                <ImageIcon className="h-4 w-4" aria-hidden="true" />
+                添付画像（{imageUrls.length}枚）
+              </h2>
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                {imageUrls.map((img, i) => (
+                  <button
+                    key={img.path}
+                    type="button"
+                    onClick={() => setLightboxIndex(i)}
+                    className="group relative aspect-video overflow-hidden rounded-lg border border-slate-200 bg-slate-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    aria-label={`添付画像 ${i + 1} を拡大`}
+                  >
+                    <img
+                      src={img.url}
+                      alt={`添付画像 ${i + 1}`}
+                      className="h-full w-full object-cover transition-transform group-hover:scale-105"
+                    />
+                  </button>
+                ))}
+              </div>
+            </section>
+          )}
+
           <FeedbackUserInfo userId={feedback.user_id} />
 
           {/* Meta info */}
@@ -191,6 +236,16 @@ export function AdminFeedbackDetailPage() {
           )}
         </div>
       </div>
+
+      {/* Lightbox */}
+      {lightboxIndex !== null && (
+        <ImageLightbox
+          images={imageUrls}
+          currentIndex={lightboxIndex}
+          onClose={closeLightbox}
+          onChangeIndex={setLightboxIndex}
+        />
+      )}
     </AdminLayout>
   )
 }

--- a/apps/web/src/pages/admin/__tests__/AdminFeedbackDetailPage.test.tsx
+++ b/apps/web/src/pages/admin/__tests__/AdminFeedbackDetailPage.test.tsx
@@ -1,0 +1,184 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ─── Mocks ──────────────────────────────────────────────────────
+
+const mockAuth = vi.hoisted(() => ({
+  value: {
+    user: { id: 'admin-1' } as { id: string } | null,
+    isLoadingAuth: false,
+    isAdmin: true,
+  },
+}))
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => mockAuth.value,
+}))
+
+vi.mock('../../../hooks/useDocumentTitle', () => ({
+  useDocumentTitle: () => undefined,
+}))
+
+vi.mock('../../../features/admin/components/AdminLayout', () => ({
+  AdminLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="admin-layout">{children}</div>
+  ),
+}))
+
+vi.mock('../../../features/admin/components/FeedbackUserInfo', () => ({
+  FeedbackUserInfo: ({ userId }: { userId: string }) => (
+    <div data-testid="user-info">{userId}</div>
+  ),
+}))
+
+vi.mock('../../../features/admin/components/FeedbackStatusForm', () => ({
+  FeedbackStatusForm: () => <div data-testid="status-form" />,
+}))
+
+vi.mock('../../../features/admin/components/FeedbackNoteForm', () => ({
+  FeedbackNoteForm: () => <div data-testid="note-form" />,
+}))
+
+const getFeedbackMock = vi.hoisted(() => vi.fn())
+const getFeedbackImageUrlsMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../services/feedbackService', async () => {
+  const actual = await vi.importActual<typeof import('../../../services/feedbackService')>(
+    '../../../services/feedbackService',
+  )
+  return {
+    ...actual,
+    getFeedback: (...args: unknown[]) => getFeedbackMock(...args),
+    getFeedbackImageUrls: (...args: unknown[]) => getFeedbackImageUrlsMock(...args),
+  }
+})
+
+import { AdminFeedbackDetailPage } from '../AdminFeedbackDetailPage'
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+const FEEDBACK_ID = '33333333-3333-3333-3333-333333333333'
+
+const baseFeedback = {
+  id: FEEDBACK_ID,
+  user_id: '11111111-1111-1111-1111-111111111111',
+  category: 'bug',
+  status: 'new',
+  message: 'テストメッセージ',
+  page_url: '/dashboard',
+  user_agent: 'Mozilla/5.0',
+  admin_note: null,
+  image_paths: [],
+  created_at: '2026-04-20T12:00:00Z',
+  updated_at: '2026-04-20T12:00:00Z',
+}
+
+function renderPage(feedbackId = FEEDBACK_ID) {
+  return render(
+    <MemoryRouter initialEntries={[`/admin/feedback/${feedbackId}`]}>
+      <Routes>
+        <Route path="/admin/feedback/:id" element={<AdminFeedbackDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+// ─── Tests ──────────────────────────────────────────────────────
+
+afterEach(() => {
+  cleanup()
+  mockAuth.value = { user: { id: 'admin-1' }, isLoadingAuth: false, isAdmin: true }
+})
+
+beforeEach(() => {
+  getFeedbackMock.mockReset()
+  getFeedbackImageUrlsMock.mockReset()
+})
+
+describe('AdminFeedbackDetailPage', () => {
+  it('読み込み中はスピナーを表示する', () => {
+    getFeedbackMock.mockReturnValue(new Promise(() => {})) // never resolves
+    renderPage()
+    expect(screen.getByLabelText('読み込み中')).toBeTruthy()
+  })
+
+  it('フィードバック詳細を表示する', async () => {
+    getFeedbackMock.mockResolvedValue(baseFeedback)
+    renderPage()
+
+    expect(await screen.findByText('テストメッセージ')).toBeTruthy()
+    expect(screen.getByText('フィードバック詳細')).toBeTruthy()
+  })
+
+  it('画像がない場合は画像セクションを表示しない', async () => {
+    getFeedbackMock.mockResolvedValue({ ...baseFeedback, image_paths: [] })
+    renderPage()
+
+    await screen.findByText('テストメッセージ')
+    expect(screen.queryByText(/添付画像/)).toBeNull()
+  })
+
+  it('画像がある場合はサムネイルを表示する', async () => {
+    getFeedbackMock.mockResolvedValue({
+      ...baseFeedback,
+      image_paths: ['uid/fid/a.png', 'uid/fid/b.jpg'],
+    })
+    getFeedbackImageUrlsMock.mockResolvedValue([
+      { path: 'uid/fid/a.png', url: 'https://example.com/a.png' },
+      { path: 'uid/fid/b.jpg', url: 'https://example.com/b.jpg' },
+    ])
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/添付画像（2枚）/)).toBeTruthy()
+    })
+    expect(screen.getByAltText('添付画像 1').getAttribute('src')).toBe('https://example.com/a.png')
+    expect(screen.getByAltText('添付画像 2').getAttribute('src')).toBe('https://example.com/b.jpg')
+  })
+
+  it('サムネイルクリックで Lightbox が開く', async () => {
+    getFeedbackMock.mockResolvedValue({
+      ...baseFeedback,
+      image_paths: ['uid/fid/a.png'],
+    })
+    getFeedbackImageUrlsMock.mockResolvedValue([
+      { path: 'uid/fid/a.png', url: 'https://example.com/a.png' },
+    ])
+    renderPage()
+
+    const thumb = await screen.findByRole('button', { name: '添付画像 1 を拡大' })
+    fireEvent.click(thumb)
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: '画像プレビュー' })).toBeTruthy()
+    })
+  })
+
+  it('画像 URL 取得失敗でもフィードバック詳細は表示される', async () => {
+    getFeedbackMock.mockResolvedValue({
+      ...baseFeedback,
+      image_paths: ['uid/fid/a.png'],
+    })
+    getFeedbackImageUrlsMock.mockRejectedValue(new Error('access denied'))
+    renderPage()
+
+    expect(await screen.findByText('テストメッセージ')).toBeTruthy()
+    expect(screen.queryByText(/添付画像/)).toBeNull()
+  })
+
+  it('フィードバックが見つからない場合はメッセージを表示する', async () => {
+    getFeedbackMock.mockResolvedValue(null)
+    renderPage()
+
+    expect(await screen.findByText('フィードバックが見つかりません')).toBeTruthy()
+  })
+
+  it('取得エラーはアラートを表示する', async () => {
+    getFeedbackMock.mockRejectedValue(new Error('rls violation'))
+    renderPage()
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('rls violation')
+  })
+})

--- a/apps/web/src/services/__tests__/feedbackService.test.ts
+++ b/apps/web/src/services/__tests__/feedbackService.test.ts
@@ -3,6 +3,7 @@ import {
   FEEDBACK_CATEGORIES,
   FEEDBACK_STATUSES,
   getFeedback,
+  getFeedbackImageUrls,
   listFeedback,
   submitFeedback,
   updateFeedbackNote,
@@ -111,6 +112,10 @@ function createAuditLogBuilder() {
 const storageState = {
   uploadCalls: [] as Array<{ path: string; file: File; options: Record<string, unknown> }>,
   uploadResult: { error: null as unknown },
+  signedUrlsResult: {
+    data: null as Array<{ path: string; signedUrl: string }> | null,
+    error: null as unknown,
+  },
 }
 
 const storageUpload = vi.fn((path: string, file: File, options: Record<string, unknown>) => {
@@ -118,9 +123,14 @@ const storageUpload = vi.fn((path: string, file: File, options: Record<string, u
   return Promise.resolve({ data: { path }, error: storageState.uploadResult.error })
 })
 
+const storageCreateSignedUrls = vi.fn(() => {
+  return Promise.resolve(storageState.signedUrlsResult)
+})
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const storageFrom = vi.fn((_bucket: string) => ({
   upload: storageUpload,
+  createSignedUrls: storageCreateSignedUrls,
 }))
 
 const from = vi.fn((table: string) => {
@@ -159,6 +169,7 @@ function resetState() {
   auditLogState.insertResult = { error: null }
   storageState.uploadCalls = []
   storageState.uploadResult = { error: null }
+  storageState.signedUrlsResult = { data: null, error: null }
 }
 
 describe('FEEDBACK_CATEGORIES / FEEDBACK_STATUSES', () => {
@@ -580,5 +591,51 @@ describe('submitFeedback with files', () => {
 
     expect(storageState.uploadCalls).toHaveLength(0)
     expect(userFeedbackState.updatePayload).toBeNull()
+  })
+})
+
+// ─── getFeedbackImageUrls ──────────────────────────────────
+
+describe('getFeedbackImageUrls', () => {
+  beforeEach(resetState)
+
+  it('空配列を渡すと空配列を返す（API を呼ばない）', async () => {
+    const result = await getFeedbackImageUrls([])
+    expect(result).toEqual([])
+    expect(storageCreateSignedUrls).not.toHaveBeenCalled()
+  })
+
+  it('paths に対する signed URL の配列を返す', async () => {
+    storageState.signedUrlsResult = {
+      data: [
+        { path: 'uid/fid/a.png', signedUrl: 'https://example.com/signed/a' },
+        { path: 'uid/fid/b.jpg', signedUrl: 'https://example.com/signed/b' },
+      ],
+      error: null,
+    }
+    const result = await getFeedbackImageUrls(['uid/fid/a.png', 'uid/fid/b.jpg'])
+
+    expect(storageFrom).toHaveBeenCalledWith('feedback-images')
+    expect(storageCreateSignedUrls).toHaveBeenCalledWith(
+      ['uid/fid/a.png', 'uid/fid/b.jpg'],
+      3600,
+    )
+    expect(result).toEqual([
+      { path: 'uid/fid/a.png', url: 'https://example.com/signed/a' },
+      { path: 'uid/fid/b.jpg', url: 'https://example.com/signed/b' },
+    ])
+  })
+
+  it('Storage エラー時にアプリ共通エラーを投げる', async () => {
+    storageState.signedUrlsResult = {
+      data: null,
+      error: { message: 'access denied' },
+    }
+    await expect(
+      getFeedbackImageUrls(['uid/fid/a.png']),
+    ).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: '画像 URL の生成に失敗しました',
+    })
   })
 })

--- a/apps/web/src/services/feedbackService.ts
+++ b/apps/web/src/services/feedbackService.ts
@@ -339,6 +339,41 @@ export async function updateFeedbackNote(
   return data
 }
 
+// ─── 画像 URL ────────────────────────────────────────────
+
+/** signed URL の有効期限（秒）: 1 時間 */
+const SIGNED_URL_EXPIRES_IN = 3600
+
+export interface FeedbackImageUrl {
+  path: string
+  url: string
+}
+
+/**
+ * image_paths から signed URL を一括生成する（admin 向け）。
+ * Storage RLS `feedback_images_select_admin` により admin のみ全画像を閲覧可能。
+ */
+export async function getFeedbackImageUrls(
+  paths: string[],
+): Promise<FeedbackImageUrl[]> {
+  if (paths.length === 0) return []
+
+  const { data, error } = await supabase.storage
+    .from(FEEDBACK_IMAGES_BUCKET)
+    .createSignedUrls(paths, SIGNED_URL_EXPIRES_IN)
+
+  if (error) {
+    throw fromSupabaseError(
+      { code: 'STORAGE_ERROR', message: error.message },
+      '画像 URL の生成に失敗しました',
+    )
+  }
+
+  return (data ?? [])
+    .filter((item) => item.signedUrl)
+    .map((item) => ({ path: item.path ?? '', url: item.signedUrl }))
+}
+
 // ─── ユーティリティ ──────────────────────────────────────
 
 /** 現在のページ情報から送信元メタデータを取得する（クライアント専用） */


### PR DESCRIPTION
## Summary
- `feedbackService.ts` に `getFeedbackImageUrls()` を追加（Supabase Storage signed URL 一括生成）
- `AdminFeedbackDetailPage` にサムネイルグリッドの画像セクションを追加（image_paths がある場合のみ表示）
- `ImageLightbox` コンポーネント新設（クリックで拡大モーダル、左右矢印/ESCキーボード操作、カウンター表示）

## Test plan
- [x] `getFeedbackImageUrls`: 空配列・正常応答・エラー時の3テスト
- [x] `ImageLightbox`: dialog表示・画像表示・カウンター・ESC閉じ・閉じるボタン・矢印キー操作・境界値・ボタンクリックの10テスト
- [x] `AdminFeedbackDetailPage`: スピナー・詳細表示・画像なし・画像あり・Lightbox表示・URL取得失敗・404・エラーの8テスト
- [x] CI全通過: typecheck / lint / test (829件) / build

🤖 Generated with [Claude Code](https://claude.com/claude-code)