### PR TITLE
fix: v4roadmap03 design-audit FAIL 7件を修正

### DIFF
--- a/apps/web/src/features/admin/components/ImageLightbox.tsx
+++ b/apps/web/src/features/admin/components/ImageLightbox.tsx
@@ -61,7 +61,7 @@ export function ImageLightbox({ images, currentIndex, onClose, onChangeIndex }: 
         className="absolute right-4 top-4 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20"
         aria-label="閉じる"
       >
-        <X className="h-6 w-6" />
+        <X className="h-6 w-6" aria-hidden="true" />
       </button>
 
       {/* Counter */}
@@ -80,7 +80,7 @@ export function ImageLightbox({ images, currentIndex, onClose, onChangeIndex }: 
           className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20"
           aria-label="前の画像"
         >
-          <ChevronLeft className="h-6 w-6" />
+          <ChevronLeft className="h-6 w-6" aria-hidden="true" />
         </button>
       )}
 
@@ -105,7 +105,7 @@ export function ImageLightbox({ images, currentIndex, onClose, onChangeIndex }: 
           className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20"
           aria-label="次の画像"
         >
-          <ChevronRight className="h-6 w-6" />
+          <ChevronRight className="h-6 w-6" aria-hidden="true" />
         </button>
       )}
     </div>

--- a/apps/web/src/features/dashboard/components/AppHeader.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeader.tsx
@@ -1,27 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
-import { ChevronDown, Flame, Gem, MessageSquarePlus, Menu, Shield, X } from 'lucide-react'
-import { CATEGORIES } from '@/content/courseData'
+import { Flame, Gem, Menu } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useFeedbackContext } from '@/contexts/FeedbackContext'
 import { useLearningContext } from '@/contexts/LearningContext'
+import { AppHeaderDesktopNav } from './AppHeaderDesktopNav'
+import { AppHeaderMobileDrawer } from './AppHeaderMobileDrawer'
 
 interface AppHeaderProps {
   displayName: string
   onSignOut: () => void
 }
-
-const PRACTICE_LINKS = [
-  { to: '/daily', label: 'デイリーチャレンジ' },
-  { to: '/practice/code-doctor', label: 'コードドクター' },
-  { to: '/practice/mini-projects', label: 'ミニプロジェクト' },
-  { to: '/practice/code-reading', label: 'コードリーディング' },
-] as const
-
-const TOP_NAV_LINKS = [
-  { to: '/base-nook', label: 'ベースヌック', pathPrefix: '/base-nook' },
-  { to: '/profile', label: 'プロフィール', pathPrefix: '/profile' },
-] as const
 
 export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
   const { stats } = useLearningContext()
@@ -29,9 +18,6 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
   const { openFeedback } = useFeedbackContext()
   const location = useLocation()
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
-  const dropdownRef = useRef<HTMLDivElement>(null)
-  const drawerRef = useRef<HTMLElement>(null)
   const menuButtonRef = useRef<HTMLButtonElement>(null)
 
   const closeDrawer = useCallback(() => {
@@ -39,76 +25,10 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
     menuButtonRef.current?.focus()
   }, [])
 
-  const isCurriculumActive =
-    location.pathname === '/curriculum' ||
-    location.pathname.startsWith('/step') ||
-    location.pathname.startsWith('/daily') ||
-    location.pathname.startsWith('/practice')
-
-  // ページ遷移時にドロワー・ドロップダウンを閉じる
+  // ページ遷移時にドロワーを閉じる
   useEffect(() => {
     closeDrawer()
-    setIsDropdownOpen(false)
   }, [location.pathname, closeDrawer])
-
-  // ESCキーでドロワーを閉じる
-  useEffect(() => {
-    if (!isDrawerOpen) return
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') closeDrawer()
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [isDrawerOpen, closeDrawer])
-
-  // フォーカストラップ: ドロワー内にフォーカスを閉じ込める
-  useEffect(() => {
-    if (!isDrawerOpen) return
-    const nav = drawerRef.current
-    if (!nav) return
-    const focusable = Array.from(nav.querySelectorAll<HTMLElement>(
-      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
-    ))
-    const first = focusable[0]
-    const last = focusable[focusable.length - 1]
-    if (!first || !last) return
-    // クロージャ内で型ナローイングを維持するためにローカル変数に再代入
-    const firstEl: HTMLElement = first
-    const lastEl: HTMLElement = last
-    firstEl.focus()
-    function handleTab(e: KeyboardEvent) {
-      if (e.key !== 'Tab') return
-      if (e.shiftKey) {
-        if (document.activeElement === firstEl) { e.preventDefault(); lastEl.focus() }
-      } else {
-        if (document.activeElement === lastEl) { e.preventDefault(); firstEl.focus() }
-      }
-    }
-    nav.addEventListener('keydown', handleTab)
-    return () => nav.removeEventListener('keydown', handleTab)
-  }, [isDrawerOpen])
-
-  // ドロワー開放中はbodyスクロールを無効化
-  useEffect(() => {
-    if (isDrawerOpen) {
-      document.body.style.overflow = 'hidden'
-    } else {
-      document.body.style.overflow = ''
-    }
-    return () => { document.body.style.overflow = '' }
-  }, [isDrawerOpen])
-
-  // ドロップダウン外クリックで閉じる
-  useEffect(() => {
-    if (!isDropdownOpen) return
-    function handleClickOutside(e: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setIsDropdownOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [isDropdownOpen])
 
   const navLinkClass = (active: boolean) =>
     `pb-1 ${active ? 'border-b-2 border-primary-mint text-slate-900' : 'text-slate-500 hover:text-slate-700'}`
@@ -126,112 +46,12 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
             <span className="font-display text-2xl font-bold tracking-tight text-primary-mint">Coden</span>
           </Link>
 
-          <nav className="hidden items-center gap-5 text-sm font-medium md:flex" aria-label="メインナビゲーション">
-            <Link
-              to="/"
-              className={navLinkClass(location.pathname === '/')}
-              aria-current={location.pathname === '/' ? 'page' : undefined}
-            >
-              ダッシュボード
-            </Link>
-
-            {/* カリキュラム ドロップダウン */}
-            <div className="relative" ref={dropdownRef}>
-              <button
-                type="button"
-                className={`flex items-center gap-1 ${navLinkClass(isCurriculumActive)}`}
-                onClick={() => setIsDropdownOpen((prev) => !prev)}
-                aria-expanded={isDropdownOpen}
-                aria-haspopup="true"
-                aria-controls="curriculum-menu"
-              >
-                カリキュラム
-                <ChevronDown className={`h-3.5 w-3.5 transition-transform ${isDropdownOpen ? 'rotate-180' : ''}`} aria-hidden="true" />
-              </button>
-
-              {isDropdownOpen && (
-                <div id="curriculum-menu" role="menu" className="absolute left-0 top-full mt-2 w-56 rounded-lg border border-slate-200 bg-white py-2 shadow-lg">
-                  <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
-                    学習コース
-                  </div>
-                  {CATEGORIES.map((cat) => (
-                    <Link
-                      key={cat.id}
-                      to={`/curriculum#${cat.id}`}
-                      role="menuitem"
-                      className="block px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50"
-                    >
-                      {cat.title}
-                    </Link>
-                  ))}
-
-                  <div className="my-1.5 border-t border-slate-100" />
-
-                  <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
-                    練習モード
-                  </div>
-                  {PRACTICE_LINKS.map((link) => (
-                    <Link
-                      key={link.to}
-                      to={link.to}
-                      role="menuitem"
-                      className="block px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50"
-                    >
-                      {link.label}
-                    </Link>
-                  ))}
-
-                  <div className="my-1.5 border-t border-slate-100" />
-                  <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
-                    サポート
-                  </div>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    onClick={() => {
-                      setIsDropdownOpen(false)
-                      openFeedback()
-                    }}
-                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50"
-                  >
-                    <MessageSquarePlus className="h-3.5 w-3.5" aria-hidden="true" />
-                    フィードバックを送る
-                  </button>
-
-                  {isAdmin ? (
-                    <>
-                      <div className="my-1.5 border-t border-slate-100" />
-                      <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
-                        管理
-                      </div>
-                      <Link
-                        to="/admin"
-                        role="menuitem"
-                        className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50"
-                      >
-                        <Shield className="h-3.5 w-3.5" aria-hidden="true" />
-                        管理画面
-                      </Link>
-                    </>
-                  ) : null}
-                </div>
-              )}
-            </div>
-
-            {TOP_NAV_LINKS.map((link) => {
-              const isActive = location.pathname.startsWith(link.pathPrefix)
-              return (
-                <Link
-                  key={link.to}
-                  to={link.to}
-                  className={navLinkClass(isActive)}
-                  aria-current={isActive ? 'page' : undefined}
-                >
-                  {link.label}
-                </Link>
-              )
-            })}
-          </nav>
+          <AppHeaderDesktopNav
+            pathname={location.pathname}
+            isAdmin={isAdmin}
+            openFeedback={openFeedback}
+            navLinkClass={navLinkClass}
+          />
         </div>
 
         <div className="flex items-center gap-3">
@@ -264,149 +84,17 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
       </div>
     </header>
 
-    {/* モバイルドロワー — フルスクリーン */}
     {isDrawerOpen ? (
-      <nav
-        ref={drawerRef}
-        role="dialog"
-        aria-modal="true"
-        className="fixed inset-0 z-50 flex flex-col bg-white md:hidden"
-        aria-label="モバイルナビゲーション"
-      >
-        {/* ヘッダー */}
-        <div className="flex h-16 items-center justify-between border-b border-slate-200 px-4">
-          <span className="text-sm font-semibold text-slate-900">メニュー</span>
-          <button
-            className="rounded-lg p-2 text-slate-500 transition hover:bg-slate-100"
-            type="button"
-            onClick={closeDrawer}
-            aria-label="メニューを閉じる"
-          >
-            <X className="h-5 w-5" />
-          </button>
-        </div>
-
-        {/* ユーザー情報 */}
-        <div className="border-b border-slate-100 px-4 py-4">
-          <p className="font-semibold text-slate-900">{displayName}</p>
-          <div className="mt-1 flex items-center gap-3 text-sm text-slate-500">
-            <span><Gem className="inline-block h-3.5 w-3.5 text-amber-600" aria-hidden="true" /> {stats?.total_points ?? 0} Pt</span>
-            <span aria-hidden="true">·</span>
-            <span><Flame className="inline-block h-3.5 w-3.5 text-primary-mint" aria-hidden="true" /> {stats?.current_streak ?? 0}日連続</span>
-          </div>
-        </div>
-
-        {/* ナビゲーションリンク */}
-        <div className="flex-1 overflow-y-auto">
-          {/* メイン */}
-          <div className="border-b border-slate-100 px-4 py-3">
-            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">メイン</p>
-            <Link
-              to="/"
-              className={drawerLinkClass(location.pathname === '/')}
-              aria-current={location.pathname === '/' ? 'page' : undefined}
-            >
-              ダッシュボード
-            </Link>
-            <Link
-              to="/curriculum"
-              className={drawerLinkClass(isCurriculumActive)}
-              aria-current={location.pathname === '/curriculum' ? 'page' : undefined}
-            >
-              カリキュラム
-            </Link>
-          </div>
-
-          {/* 学習コース */}
-          <div className="border-b border-slate-100 px-4 py-3">
-            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">学習コース</p>
-            {CATEGORIES.map((cat) => (
-              <Link
-                key={cat.id}
-                to={`/curriculum#${cat.id}`}
-                className={drawerLinkClass(false)}
-              >
-                {cat.title}
-              </Link>
-            ))}
-          </div>
-
-          {/* 練習モード */}
-          <div className="border-b border-slate-100 px-4 py-3">
-            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">練習モード</p>
-            {PRACTICE_LINKS.map((link) => (
-              <Link
-                key={link.to}
-                to={link.to}
-                className={drawerLinkClass(location.pathname.startsWith(link.to))}
-                aria-current={location.pathname.startsWith(link.to) ? 'page' : undefined}
-              >
-                {link.label}
-              </Link>
-            ))}
-          </div>
-
-          {/* その他 */}
-          <div className="border-b border-slate-100 px-4 py-3">
-            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">その他</p>
-            {TOP_NAV_LINKS.map((link) => {
-              const isActive = location.pathname.startsWith(link.pathPrefix)
-              return (
-                <Link
-                  key={link.to}
-                  to={link.to}
-                  className={drawerLinkClass(isActive)}
-                  aria-current={isActive ? 'page' : undefined}
-                >
-                  {link.label}
-                </Link>
-              )
-            })}
-          </div>
-
-          {/* サポート（全ユーザー） */}
-          <div className="border-b border-slate-100 px-4 py-3">
-            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">サポート</p>
-            <button
-              type="button"
-              onClick={() => {
-                closeDrawer()
-                openFeedback()
-              }}
-              className={`${drawerLinkClass(false)} w-full`}
-            >
-              <MessageSquarePlus className="mr-2 h-4 w-4" aria-hidden="true" />
-              フィードバックを送る
-            </button>
-          </div>
-
-          {/* 管理（admin のみ） */}
-          {isAdmin ? (
-            <div className="border-b border-slate-100 px-4 py-3">
-              <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">管理</p>
-              <Link
-                to="/admin"
-                className={drawerLinkClass(location.pathname.startsWith('/admin'))}
-                aria-current={location.pathname.startsWith('/admin') ? 'page' : undefined}
-              >
-                <Shield className="mr-2 h-4 w-4" aria-hidden="true" />
-                管理画面
-              </Link>
-            </div>
-          ) : null}
-        </div>
-
-        {/* ログアウトボタン */}
-        <div className="border-t border-slate-200 px-4 py-3">
-          <button
-            className="flex min-h-[44px] w-full items-center justify-center rounded-lg border border-slate-300 bg-white text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
-            type="button"
-            onClick={() => { closeDrawer(); onSignOut() }}
-          >
-            ログアウト
-          </button>
-        </div>
-      </nav>
+      <AppHeaderMobileDrawer
+        displayName={displayName}
+        pathname={location.pathname}
+        stats={stats}
+        isAdmin={isAdmin}
+        openFeedback={openFeedback}
+        onClose={closeDrawer}
+        onSignOut={onSignOut}
+        drawerLinkClass={drawerLinkClass}
+      />
     ) : null}
 
     </>

--- a/apps/web/src/features/dashboard/components/AppHeaderDesktopNav.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeaderDesktopNav.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { ChevronDown, MessageSquarePlus, Shield } from 'lucide-react'
+import { CATEGORIES } from '@/content/courseData'
+import { PRACTICE_LINKS, TOP_NAV_LINKS } from './appHeaderLinks'
+
+interface AppHeaderDesktopNavProps {
+  pathname: string
+  isAdmin: boolean
+  openFeedback: () => void
+  navLinkClass: (active: boolean) => string
+}
+
+export function AppHeaderDesktopNav({ pathname, isAdmin, openFeedback, navLinkClass }: AppHeaderDesktopNavProps) {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  const isCurriculumActive =
+    pathname === '/curriculum' ||
+    pathname.startsWith('/step') ||
+    pathname.startsWith('/daily') ||
+    pathname.startsWith('/practice')
+
+  // ページ遷移時にドロップダウンを閉じる
+  useEffect(() => {
+    setIsDropdownOpen(false)
+  }, [pathname])
+
+  // ドロップダウン外クリックで閉じる
+  useEffect(() => {
+    if (!isDropdownOpen) return
+    function handleClickOutside(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setIsDropdownOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isDropdownOpen])
+
+  return (
+    <nav className="hidden items-center gap-5 text-sm font-medium md:flex" aria-label="メインナビゲーション">
+      <Link
+        to="/"
+        className={navLinkClass(pathname === '/')}
+        aria-current={pathname === '/' ? 'page' : undefined}
+      >
+        ダッシュボード
+      </Link>
+
+      {/* カリキュラム ドロップダウン */}
+      <div className="relative" ref={dropdownRef}>
+        <button
+          type="button"
+          className={`flex items-center gap-1 ${navLinkClass(isCurriculumActive)}`}
+          onClick={() => setIsDropdownOpen((prev) => !prev)}
+          aria-expanded={isDropdownOpen}
+          aria-haspopup="true"
+          aria-controls="curriculum-menu"
+        >
+          カリキュラム
+          <ChevronDown className={`h-3.5 w-3.5 transition-transform ${isDropdownOpen ? 'rotate-180' : ''}`} aria-hidden="true" />
+        </button>
+
+        {isDropdownOpen && (
+          <div id="curriculum-menu" role="menu" className="absolute left-0 top-full mt-2 w-56 rounded-lg border border-slate-200 bg-white py-2 shadow-lg">
+            <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
+              学習コース
+            </div>
+            {CATEGORIES.map((cat) => (
+              <Link
+                key={cat.id}
+                to={`/curriculum#${cat.id}`}
+                role="menuitem"
+                className="block px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50"
+              >
+                {cat.title}
+              </Link>
+            ))}
+
+            <div className="my-1.5 border-t border-slate-100" />
+
+            <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
+              練習モード
+            </div>
+            {PRACTICE_LINKS.map((link) => (
+              <Link
+                key={link.to}
+                to={link.to}
+                role="menuitem"
+                className="block px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50"
+              >
+                {link.label}
+              </Link>
+            ))}
+
+            <div className="my-1.5 border-t border-slate-100" />
+            <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
+              サポート
+            </div>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setIsDropdownOpen(false)
+                openFeedback()
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50"
+            >
+              <MessageSquarePlus className="h-3.5 w-3.5" aria-hidden="true" />
+              フィードバックを送る
+            </button>
+
+            {isAdmin ? (
+              <>
+                <div className="my-1.5 border-t border-slate-100" />
+                <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
+                  管理
+                </div>
+                <Link
+                  to="/admin"
+                  role="menuitem"
+                  className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50"
+                >
+                  <Shield className="h-3.5 w-3.5" aria-hidden="true" />
+                  管理画面
+                </Link>
+              </>
+            ) : null}
+          </div>
+        )}
+      </div>
+
+      {TOP_NAV_LINKS.map((link) => {
+        const isActive = pathname.startsWith(link.pathPrefix)
+        return (
+          <Link
+            key={link.to}
+            to={link.to}
+            className={navLinkClass(isActive)}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            {link.label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/apps/web/src/features/dashboard/components/AppHeaderMobileDrawer.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeaderMobileDrawer.tsx
@@ -1,0 +1,224 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { Flame, Gem, MessageSquarePlus, Shield, X } from 'lucide-react'
+import { CATEGORIES } from '@/content/courseData'
+import type { LearningStats } from '@/services/statsService'
+import { PRACTICE_LINKS, TOP_NAV_LINKS } from './appHeaderLinks'
+
+interface AppHeaderMobileDrawerProps {
+  displayName: string
+  pathname: string
+  stats: LearningStats | null
+  isAdmin: boolean
+  openFeedback: () => void
+  onClose: () => void
+  onSignOut: () => void
+  drawerLinkClass: (active: boolean) => string
+}
+
+export function AppHeaderMobileDrawer({
+  displayName,
+  pathname,
+  stats,
+  isAdmin,
+  openFeedback,
+  onClose,
+  onSignOut,
+  drawerLinkClass,
+}: AppHeaderMobileDrawerProps) {
+  const drawerRef = useRef<HTMLElement>(null)
+
+  const isCurriculumActive =
+    pathname === '/curriculum' ||
+    pathname.startsWith('/step') ||
+    pathname.startsWith('/daily') ||
+    pathname.startsWith('/practice')
+
+  const handleClose = useCallback(() => {
+    onClose()
+  }, [onClose])
+
+  // ESCキーでドロワーを閉じる
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') handleClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [handleClose])
+
+  // フォーカストラップ: ドロワー内にフォーカスを閉じ込める
+  useEffect(() => {
+    const nav = drawerRef.current
+    if (!nav) return
+    const focusable = Array.from(nav.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ))
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (!first || !last) return
+    const firstEl: HTMLElement = first
+    const lastEl: HTMLElement = last
+    firstEl.focus()
+    function handleTab(e: KeyboardEvent) {
+      if (e.key !== 'Tab') return
+      if (e.shiftKey) {
+        if (document.activeElement === firstEl) { e.preventDefault(); lastEl.focus() }
+      } else {
+        if (document.activeElement === lastEl) { e.preventDefault(); firstEl.focus() }
+      }
+    }
+    nav.addEventListener('keydown', handleTab)
+    return () => nav.removeEventListener('keydown', handleTab)
+  }, [])
+
+  // body スクロール無効化
+  useEffect(() => {
+    document.body.style.overflow = 'hidden'
+    return () => { document.body.style.overflow = '' }
+  }, [])
+
+  return (
+    <nav
+      ref={drawerRef}
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex flex-col bg-white md:hidden"
+      aria-label="モバイルナビゲーション"
+    >
+      {/* ヘッダー */}
+      <div className="flex h-16 items-center justify-between border-b border-slate-200 px-4">
+        <span className="text-sm font-semibold text-slate-900">メニュー</span>
+        <button
+          className="rounded-lg p-2 text-slate-500 transition hover:bg-slate-100"
+          type="button"
+          onClick={handleClose}
+          aria-label="メニューを閉じる"
+        >
+          <X className="h-5 w-5" aria-hidden="true" />
+        </button>
+      </div>
+
+      {/* ユーザー情報 */}
+      <div className="border-b border-slate-100 px-4 py-4">
+        <p className="font-semibold text-slate-900">{displayName}</p>
+        <div className="mt-1 flex items-center gap-3 text-sm text-slate-500">
+          <span><Gem className="inline-block h-3.5 w-3.5 text-amber-600" aria-hidden="true" /> {stats?.total_points ?? 0} Pt</span>
+          <span aria-hidden="true">·</span>
+          <span><Flame className="inline-block h-3.5 w-3.5 text-primary-mint" aria-hidden="true" /> {stats?.current_streak ?? 0}日連続</span>
+        </div>
+      </div>
+
+      {/* ナビゲーションリンク */}
+      <div className="flex-1 overflow-y-auto">
+        {/* メイン */}
+        <div className="border-b border-slate-100 px-4 py-3">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">メイン</p>
+          <Link
+            to="/"
+            className={drawerLinkClass(pathname === '/')}
+            aria-current={pathname === '/' ? 'page' : undefined}
+          >
+            ダッシュボード
+          </Link>
+          <Link
+            to="/curriculum"
+            className={drawerLinkClass(isCurriculumActive)}
+            aria-current={pathname === '/curriculum' ? 'page' : undefined}
+          >
+            カリキュラム
+          </Link>
+        </div>
+
+        {/* 学習コース */}
+        <div className="border-b border-slate-100 px-4 py-3">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">学習コース</p>
+          {CATEGORIES.map((cat) => (
+            <Link
+              key={cat.id}
+              to={`/curriculum#${cat.id}`}
+              className={drawerLinkClass(false)}
+            >
+              {cat.title}
+            </Link>
+          ))}
+        </div>
+
+        {/* 練習モード */}
+        <div className="border-b border-slate-100 px-4 py-3">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">練習モード</p>
+          {PRACTICE_LINKS.map((link) => (
+            <Link
+              key={link.to}
+              to={link.to}
+              className={drawerLinkClass(pathname.startsWith(link.to))}
+              aria-current={pathname.startsWith(link.to) ? 'page' : undefined}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+
+        {/* その他 */}
+        <div className="border-b border-slate-100 px-4 py-3">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">その他</p>
+          {TOP_NAV_LINKS.map((link) => {
+            const isActive = pathname.startsWith(link.pathPrefix)
+            return (
+              <Link
+                key={link.to}
+                to={link.to}
+                className={drawerLinkClass(isActive)}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                {link.label}
+              </Link>
+            )
+          })}
+        </div>
+
+        {/* サポート（全ユーザー） */}
+        <div className="border-b border-slate-100 px-4 py-3">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">サポート</p>
+          <button
+            type="button"
+            onClick={() => {
+              handleClose()
+              openFeedback()
+            }}
+            className={`${drawerLinkClass(false)} w-full`}
+          >
+            <MessageSquarePlus className="mr-2 h-4 w-4" aria-hidden="true" />
+            フィードバックを送る
+          </button>
+        </div>
+
+        {/* 管理（admin のみ） */}
+        {isAdmin ? (
+          <div className="border-b border-slate-100 px-4 py-3">
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">管理</p>
+            <Link
+              to="/admin"
+              className={drawerLinkClass(pathname.startsWith('/admin'))}
+              aria-current={pathname.startsWith('/admin') ? 'page' : undefined}
+            >
+              <Shield className="mr-2 h-4 w-4" aria-hidden="true" />
+              管理画面
+            </Link>
+          </div>
+        ) : null}
+      </div>
+
+      {/* ログアウトボタン */}
+      <div className="border-t border-slate-200 px-4 py-3">
+        <button
+          className="flex min-h-[44px] w-full items-center justify-center rounded-lg border border-slate-300 bg-white text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+          type="button"
+          onClick={() => { handleClose(); onSignOut() }}
+        >
+          ログアウト
+        </button>
+      </div>
+    </nav>
+  )
+}

--- a/apps/web/src/features/dashboard/components/appHeaderLinks.ts
+++ b/apps/web/src/features/dashboard/components/appHeaderLinks.ts
@@ -1,0 +1,11 @@
+export const PRACTICE_LINKS = [
+  { to: '/daily', label: 'デイリーチャレンジ' },
+  { to: '/practice/code-doctor', label: 'コードドクター' },
+  { to: '/practice/mini-projects', label: 'ミニプロジェクト' },
+  { to: '/practice/code-reading', label: 'コードリーディング' },
+] as const
+
+export const TOP_NAV_LINKS = [
+  { to: '/base-nook', label: 'ベースヌック', pathPrefix: '/base-nook' },
+  { to: '/profile', label: 'プロフィール', pathPrefix: '/profile' },
+] as const

--- a/apps/web/src/features/feedback/FeedbackDialog.tsx
+++ b/apps/web/src/features/feedback/FeedbackDialog.tsx
@@ -154,7 +154,7 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
         </div>
 
         {isSubmitted ? (
-          <div className="py-6 text-center">
+          <div role="status" aria-live="polite" className="py-6 text-center">
             <p className="text-sm font-semibold text-slate-900">送信しました。ありがとうございます！</p>
             <p className="mt-1 text-xs text-slate-500">いただいた内容は運営が確認いたします。</p>
             <button
@@ -290,7 +290,7 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
             </div>
 
             {error ? (
-              <div className="flex items-start gap-2 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700">
+              <div role="alert" className="flex items-start gap-2 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700">
                 <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
                 <span>{error}</span>
               </div>

--- a/apps/web/src/features/feedback/FeedbackDialog.tsx
+++ b/apps/web/src/features/feedback/FeedbackDialog.tsx
@@ -1,15 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { AlertCircle, ImagePlus, Loader2, Trash2, X } from 'lucide-react'
+import { AlertCircle, Loader2, X } from 'lucide-react'
 import { useAuth } from '../../contexts/AuthContext'
 import {
   captureClientMeta,
   FEEDBACK_CATEGORY_LABELS,
   MAX_FEEDBACK_MESSAGE_LENGTH,
-  MAX_IMAGE_COUNT,
   submitFeedback,
-  validateImageFiles,
   type FeedbackCategory,
 } from '../../services/feedbackService'
+import { FeedbackImagePicker } from './FeedbackImagePicker'
 
 interface FeedbackDialogProps {
   open: boolean
@@ -28,7 +27,6 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
   const [files, setFiles] = useState<File[]>([])
   const dialogRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const fileInputRef = useRef<HTMLInputElement>(null)
 
   // ダイアログを閉じたらフォーム状態をリセット
   const reset = useCallback(() => {
@@ -210,84 +208,12 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
               </div>
             </div>
 
-            {/* 画像添付セクション */}
-            <div>
-              <div className="flex items-center justify-between">
-                <span className="block text-xs font-semibold text-slate-700">
-                  スクリーンショット（任意）
-                </span>
-                <span className="text-xs text-slate-400">{files.length}/{MAX_IMAGE_COUNT}</span>
-              </div>
-
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="image/*"
-                multiple
-                className="hidden"
-                disabled={isSubmitting || files.length >= MAX_IMAGE_COUNT}
-                onChange={(e) => {
-                  const selected = Array.from(e.target.files ?? [])
-                  if (selected.length === 0) return
-                  const merged = [...files, ...selected].slice(0, MAX_IMAGE_COUNT)
-                  try {
-                    validateImageFiles(merged)
-                    setFiles(merged)
-                    setError(null)
-                  } catch (err) {
-                    setError(err instanceof Error ? err.message : 'ファイルの追加に失敗しました')
-                  }
-                  // 同じファイルを再選択できるようリセット
-                  e.target.value = ''
-                }}
-              />
-
-              {files.length > 0 ? (
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {files.map((file, idx) => (
-                    <div
-                      key={`${file.name}-${file.size}-${idx}`}
-                      className="group relative flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-2 py-1.5"
-                    >
-                      <img
-                        src={URL.createObjectURL(file)}
-                        alt={file.name}
-                        className="h-10 w-10 rounded object-cover"
-                      />
-                      <div className="min-w-0">
-                        <p className="max-w-[120px] truncate text-xs font-medium text-slate-700">{file.name}</p>
-                        <p className="text-[10px] text-slate-400">{formatFileSize(file.size)}</p>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => setFiles((prev) => prev.filter((_, i) => i !== idx))}
-                        disabled={isSubmitting}
-                        className="ml-1 rounded p-0.5 text-slate-400 transition hover:bg-slate-200 hover:text-rose-600"
-                        aria-label={`${file.name} を削除`}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              ) : null}
-
-              {files.length < MAX_IMAGE_COUNT ? (
-                <button
-                  type="button"
-                  onClick={() => fileInputRef.current?.click()}
-                  disabled={isSubmitting}
-                  className="mt-2 flex items-center gap-1.5 rounded-lg border border-dashed border-slate-300 px-3 py-2 text-xs font-medium text-slate-500 transition hover:border-primary-mint hover:text-primary-mint"
-                >
-                  <ImagePlus className="h-4 w-4" aria-hidden="true" />
-                  画像を追加
-                </button>
-              ) : null}
-
-              <p className="mt-1 text-[10px] text-slate-400">
-                PNG / JPG / GIF など、各 5MB 以下
-              </p>
-            </div>
+            <FeedbackImagePicker
+              files={files}
+              onFilesChange={(next) => { setFiles(next); setError(null) }}
+              disabled={isSubmitting}
+              onError={setError}
+            />
 
             {error ? (
               <div role="alert" className="flex items-start gap-2 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700">
@@ -319,10 +245,4 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
       </div>
     </div>
   )
-}
-
-function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }

--- a/apps/web/src/features/feedback/FeedbackImagePicker.tsx
+++ b/apps/web/src/features/feedback/FeedbackImagePicker.tsx
@@ -1,0 +1,98 @@
+import { useRef } from 'react'
+import { ImagePlus, Trash2 } from 'lucide-react'
+import { MAX_IMAGE_COUNT, validateImageFiles } from '../../services/feedbackService'
+
+interface FeedbackImagePickerProps {
+  files: File[]
+  onFilesChange: (files: File[]) => void
+  disabled: boolean
+  onError: (message: string) => void
+}
+
+export function FeedbackImagePicker({ files, onFilesChange, disabled, onError }: FeedbackImagePickerProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <span className="block text-xs font-semibold text-slate-700">
+          スクリーンショット（任意）
+        </span>
+        <span className="text-xs text-slate-400">{files.length}/{MAX_IMAGE_COUNT}</span>
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        className="hidden"
+        disabled={disabled || files.length >= MAX_IMAGE_COUNT}
+        onChange={(e) => {
+          const selected = Array.from(e.target.files ?? [])
+          if (selected.length === 0) return
+          const merged = [...files, ...selected].slice(0, MAX_IMAGE_COUNT)
+          try {
+            validateImageFiles(merged)
+            onFilesChange(merged)
+          } catch (err) {
+            onError(err instanceof Error ? err.message : 'ファイルの追加に失敗しました')
+          }
+          e.target.value = ''
+        }}
+      />
+
+      {files.length > 0 ? (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {files.map((file, idx) => (
+            <div
+              key={`${file.name}-${file.size}-${idx}`}
+              className="group relative flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-2 py-1.5"
+            >
+              <img
+                src={URL.createObjectURL(file)}
+                alt={file.name}
+                className="h-10 w-10 rounded object-cover"
+              />
+              <div className="min-w-0">
+                <p className="max-w-[120px] truncate text-xs font-medium text-slate-700">{file.name}</p>
+                <p className="text-[10px] text-slate-400">{formatFileSize(file.size)}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => onFilesChange(files.filter((_, i) => i !== idx))}
+                disabled={disabled}
+                className="ml-1 rounded p-0.5 text-slate-400 transition hover:bg-slate-200 hover:text-rose-600"
+                aria-label={`${file.name} を削除`}
+              >
+                <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {files.length < MAX_IMAGE_COUNT ? (
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={disabled}
+          className="mt-2 flex items-center gap-1.5 rounded-lg border border-dashed border-slate-300 px-3 py-2 text-xs font-medium text-slate-500 transition hover:border-primary-mint hover:text-primary-mint"
+        >
+          <ImagePlus className="h-4 w-4" aria-hidden="true" />
+          画像を追加
+        </button>
+      ) : null}
+
+      <p className="mt-1 text-[10px] text-slate-400">
+        PNG / JPG / GIF など、各 5MB 以下
+      </p>
+    </div>
+  )
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}

--- a/apps/web/src/pages/admin/AdminFeedbackDetailPage.tsx
+++ b/apps/web/src/pages/admin/AdminFeedbackDetailPage.tsx
@@ -95,7 +95,8 @@ export function AdminFeedbackDetailPage() {
         setFeedback(data)
 
         // image_paths がある場合は signed URL を取得
-        const paths = Array.isArray(data.image_paths) ? (data.image_paths as string[]) : []
+        const raw = Array.isArray(data.image_paths) ? data.image_paths : []
+        const paths = raw.filter((p): p is string => typeof p === 'string')
         if (paths.length > 0) {
           try {
             const urls = await getFeedbackImageUrls(paths)

--- a/apps/web/src/services/__tests__/feedbackService.test.ts
+++ b/apps/web/src/services/__tests__/feedbackService.test.ts
@@ -517,7 +517,7 @@ describe('uploadFeedbackImages', () => {
     expect(storageFrom).toHaveBeenCalledWith('feedback-images')
     expect(storageState.uploadCalls).toHaveLength(2)
     expect(storageState.uploadCalls[0]!.path).toMatch(
-      new RegExp(`^${VALID_USER_ID}/${VALID_FEEDBACK_ID}/\\d+_a\\.png$`),
+      new RegExp(`^${VALID_USER_ID}/${VALID_FEEDBACK_ID}/\\d+_0_a\\.png$`),
     )
     expect(storageState.uploadCalls[1]!.options).toEqual({ contentType: 'image/jpeg' })
     expect(paths).toHaveLength(2)

--- a/apps/web/src/services/feedbackService.ts
+++ b/apps/web/src/services/feedbackService.ts
@@ -190,25 +190,26 @@ export async function uploadFeedbackImages(
   feedbackId: string,
   files: File[],
 ): Promise<string[]> {
-  const paths: string[] = []
+  const now = Date.now()
 
-  for (const file of files) {
-    // ファイル名の衝突を避けるため timestamp を付与
-    const safeName = `${Date.now()}_${file.name.replace(/[^a-zA-Z0-9._-]/g, '_')}`
-    const path = `${userId}/${feedbackId}/${safeName}`
+  const paths = await Promise.all(
+    files.map(async (file, index) => {
+      const safeName = `${now}_${index}_${file.name.replace(/[^a-zA-Z0-9._-]/g, '_')}`
+      const path = `${userId}/${feedbackId}/${safeName}`
 
-    const { error } = await supabase.storage
-      .from(FEEDBACK_IMAGES_BUCKET)
-      .upload(path, file, { contentType: file.type })
+      const { error } = await supabase.storage
+        .from(FEEDBACK_IMAGES_BUCKET)
+        .upload(path, file, { contentType: file.type })
 
-    if (error) {
-      throw fromSupabaseError(
-        { code: 'STORAGE_ERROR', message: error.message },
-        `画像「${file.name}」のアップロードに失敗しました`,
-      )
-    }
-    paths.push(path)
-  }
+      if (error) {
+        throw fromSupabaseError(
+          { code: 'STORAGE_ERROR', message: error.message },
+          `画像「${file.name}」のアップロードに失敗しました`,
+        )
+      }
+      return path
+    }),
+  )
 
   return paths
 }


### PR DESCRIPTION
## Summary
- **#260**: `image_paths` の `as` キャストを型ガード (`filter + type predicate`) に置換
- **#261 / #262**: FeedbackDialog のエラーに `role="alert"`、送信完了に `role="status" aria-live="polite"` を追加
- **#263**: ImageLightbox の装飾アイコン (`X`, `ChevronLeft`, `ChevronRight`) に `aria-hidden="true"` を追加
- **#264**: `uploadFeedbackImages` を `Promise.all` で並列化し、`Date.now()` + index でファイル名衝突を回避
- **#266**: FeedbackDialog から画像添付セクションを `FeedbackImagePicker` コンポーネントとして分離
- **#265**: AppHeader を `AppHeaderDesktopNav` / `AppHeaderMobileDrawer` / `appHeaderLinks.ts` に3分割（react-refresh warning も解消）

## Test plan
- [x] `npm run typecheck` pass
- [x] `npm run lint` pass（warning 0）
- [x] `npm run test` — 829 tests pass
- [x] `npm run build` pass

Closes #260, #261, #262, #263, #264, #265, #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)