### PR TITLE
v4.1: フィードバック UX 改善 + design-audit FAIL 修正

### DIFF
--- a/apps/web/src/components/FeedbackFab.tsx
+++ b/apps/web/src/components/FeedbackFab.tsx
@@ -1,0 +1,22 @@
+import { MessageSquarePlus } from 'lucide-react'
+import { useAuth } from '../contexts/AuthContext'
+import { useFeedbackContext } from '../contexts/FeedbackContext'
+
+export function FeedbackFab() {
+  const { user } = useAuth()
+  const { openFeedback } = useFeedbackContext()
+
+  if (!user) return null
+
+  return (
+    <button
+      type="button"
+      onClick={openFeedback}
+      aria-label="フィードバックを送る"
+      title="フィードバックを送る"
+      className="fixed bottom-5 right-5 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-primary-mint text-white shadow-lg transition hover:bg-primary-dark hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-primary-mint focus:ring-offset-2 sm:h-14 sm:w-14"
+    >
+      <MessageSquarePlus className="h-5 w-5 sm:h-6 sm:w-6" aria-hidden="true" />
+    </button>
+  )
+}

--- a/apps/web/src/components/__tests__/FeedbackFab.test.tsx
+++ b/apps/web/src/components/__tests__/FeedbackFab.test.tsx
@@ -1,0 +1,52 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { FeedbackFab } from '../FeedbackFab'
+
+const mockAuth = vi.hoisted(() => ({
+  value: { user: { id: 'u1' } as { id: string } | null },
+}))
+
+const mockFeedback = vi.hoisted(() => ({
+  openFeedback: vi.fn(),
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => mockAuth.value,
+}))
+
+vi.mock('@/contexts/FeedbackContext', () => ({
+  useFeedbackContext: () => mockFeedback,
+}))
+
+afterEach(() => {
+  cleanup()
+  mockAuth.value = { user: { id: 'u1' } }
+  mockFeedback.openFeedback.mockReset()
+})
+
+describe('FeedbackFab', () => {
+  it('ログイン済みユーザーに FAB が表示される', () => {
+    render(<FeedbackFab />)
+    expect(screen.getByRole('button', { name: 'フィードバックを送る' })).toBeTruthy()
+  })
+
+  it('未ログイン時は FAB が表示されない', () => {
+    mockAuth.value = { user: null }
+    const { container } = render(<FeedbackFab />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('FAB クリックで openFeedback が呼ばれる', () => {
+    render(<FeedbackFab />)
+    screen.getByRole('button', { name: 'フィードバックを送る' }).click()
+    expect(mockFeedback.openFeedback).toHaveBeenCalledOnce()
+  })
+
+  it('FAB が画面右下に固定されている', () => {
+    render(<FeedbackFab />)
+    const btn = screen.getByRole('button', { name: 'フィードバックを送る' })
+    expect(btn.className).toContain('fixed')
+    expect(btn.className).toContain('bottom-5')
+    expect(btn.className).toContain('right-5')
+  })
+})

--- a/apps/web/src/contexts/FeedbackContext.tsx
+++ b/apps/web/src/contexts/FeedbackContext.tsx
@@ -1,0 +1,33 @@
+import { createContext, useCallback, useContext, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+
+interface FeedbackContextValue {
+  isOpen: boolean
+  openFeedback: () => void
+  closeFeedback: () => void
+}
+
+const FeedbackContext = createContext<FeedbackContextValue | undefined>(undefined)
+
+export function FeedbackProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const openFeedback = useCallback(() => setIsOpen(true), [])
+  const closeFeedback = useCallback(() => setIsOpen(false), [])
+
+  const value = useMemo<FeedbackContextValue>(
+    () => ({ isOpen, openFeedback, closeFeedback }),
+    [isOpen, openFeedback, closeFeedback],
+  )
+
+  return <FeedbackContext.Provider value={value}>{children}</FeedbackContext.Provider>
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export function useFeedbackContext() {
+  const context = useContext(FeedbackContext)
+  if (!context) {
+    throw new Error('useFeedbackContext must be used inside FeedbackProvider')
+  }
+  return context
+}

--- a/apps/web/src/contexts/__tests__/FeedbackContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/FeedbackContext.test.tsx
@@ -1,0 +1,64 @@
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { FeedbackProvider, useFeedbackContext } from '../FeedbackContext'
+
+afterEach(() => {
+  cleanup()
+})
+
+function TestConsumer() {
+  const { isOpen, openFeedback, closeFeedback } = useFeedbackContext()
+  return (
+    <div>
+      <span data-testid="status">{isOpen ? 'open' : 'closed'}</span>
+      <button type="button" onClick={openFeedback}>open</button>
+      <button type="button" onClick={closeFeedback}>close</button>
+    </div>
+  )
+}
+
+describe('FeedbackContext', () => {
+  it('初期状態で isOpen が false', () => {
+    render(
+      <FeedbackProvider>
+        <TestConsumer />
+      </FeedbackProvider>,
+    )
+    expect(screen.getByTestId('status').textContent).toBe('closed')
+  })
+
+  it('openFeedback で isOpen が true になる', () => {
+    render(
+      <FeedbackProvider>
+        <TestConsumer />
+      </FeedbackProvider>,
+    )
+    act(() => {
+      screen.getByRole('button', { name: 'open' }).click()
+    })
+    expect(screen.getByTestId('status').textContent).toBe('open')
+  })
+
+  it('closeFeedback で isOpen が false に戻る', () => {
+    render(
+      <FeedbackProvider>
+        <TestConsumer />
+      </FeedbackProvider>,
+    )
+    act(() => {
+      screen.getByRole('button', { name: 'open' }).click()
+    })
+    expect(screen.getByTestId('status').textContent).toBe('open')
+
+    act(() => {
+      screen.getByRole('button', { name: 'close' }).click()
+    })
+    expect(screen.getByTestId('status').textContent).toBe('closed')
+  })
+
+  it('Provider 外で useFeedbackContext を呼ぶとエラーになる', () => {
+    expect(() => render(<TestConsumer />)).toThrow(
+      'useFeedbackContext must be used inside FeedbackProvider',
+    )
+  })
+})

--- a/apps/web/src/features/admin/components/ImageLightbox.tsx
+++ b/apps/web/src/features/admin/components/ImageLightbox.tsx
@@ -61,7 +61,7 @@ export function ImageLightbox({ images, currentIndex, onClose, onChangeIndex }: 
         className="absolute right-4 top-4 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20"
         aria-label="閉じる"
       >
-        <X className="h-6 w-6" />
+        <X className="h-6 w-6" aria-hidden="true" />
       </button>
 
       {/* Counter */}
@@ -80,7 +80,7 @@ export function ImageLightbox({ images, currentIndex, onClose, onChangeIndex }: 
           className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20"
           aria-label="前の画像"
         >
-          <ChevronLeft className="h-6 w-6" />
+          <ChevronLeft className="h-6 w-6" aria-hidden="true" />
         </button>
       )}
 
@@ -105,7 +105,7 @@ export function ImageLightbox({ images, currentIndex, onClose, onChangeIndex }: 
           className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20"
           aria-label="次の画像"
         >
-          <ChevronRight className="h-6 w-6" />
+          <ChevronRight className="h-6 w-6" aria-hidden="true" />
         </button>
       )}
     </div>

--- a/apps/web/src/features/admin/components/ImageLightbox.tsx
+++ b/apps/web/src/features/admin/components/ImageLightbox.tsx
@@ -1,0 +1,113 @@
+import { useCallback, useEffect } from 'react'
+import { ChevronLeft, ChevronRight, X } from 'lucide-react'
+import type { FeedbackImageUrl } from '../../../services/feedbackService'
+
+interface ImageLightboxProps {
+  images: FeedbackImageUrl[]
+  currentIndex: number
+  onClose: () => void
+  onChangeIndex: (index: number) => void
+}
+
+export function ImageLightbox({ images, currentIndex, onClose, onChangeIndex }: ImageLightboxProps) {
+  const hasPrev = currentIndex > 0
+  const hasNext = currentIndex < images.length - 1
+
+  const goPrev = useCallback(() => {
+    if (hasPrev) onChangeIndex(currentIndex - 1)
+  }, [hasPrev, currentIndex, onChangeIndex])
+
+  const goNext = useCallback(() => {
+    if (hasNext) onChangeIndex(currentIndex + 1)
+  }, [hasNext, currentIndex, onChangeIndex])
+
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      switch (e.key) {
+        case 'Escape':
+          onClose()
+          break
+        case 'ArrowLeft':
+          goPrev()
+          break
+        case 'ArrowRight':
+          goNext()
+          break
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose, goPrev, goNext])
+
+  const current = images[currentIndex]
+  if (!current) return null
+
+  return (
+    // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- keyboard handled via document keydown listener, dialog overlay click-to-close is standard UX
+    <div
+      role="dialog"
+      aria-label="画像プレビュー"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
+      onClick={onClose}
+    >
+      {/* Close button */}
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation()
+          onClose()
+        }}
+        className="absolute right-4 top-4 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20"
+        aria-label="閉じる"
+      >
+        <X className="h-6 w-6" />
+      </button>
+
+      {/* Counter */}
+      <span className="absolute left-4 top-4 rounded-full bg-white/10 px-3 py-1 text-sm text-white">
+        {currentIndex + 1} / {images.length}
+      </span>
+
+      {/* Prev button */}
+      {hasPrev && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            goPrev()
+          }}
+          className="absolute left-4 top-1/2 -translate-y-1/2 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20"
+          aria-label="前の画像"
+        >
+          <ChevronLeft className="h-6 w-6" />
+        </button>
+      )}
+
+      {/* Image — wrapper div prevents click-to-close when clicking on the image */}
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+      <div onClick={(e) => e.stopPropagation()}>
+        <img
+          src={current.url}
+          alt={`添付画像 ${currentIndex + 1}`}
+          className="max-h-[85vh] max-w-[90vw] rounded-lg object-contain"
+        />
+      </div>
+
+      {/* Next button */}
+      {hasNext && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            goNext()
+          }}
+          className="absolute right-4 top-1/2 -translate-y-1/2 rounded-full bg-white/10 p-2 text-white transition-colors hover:bg-white/20"
+          aria-label="次の画像"
+        >
+          <ChevronRight className="h-6 w-6" />
+        </button>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/features/admin/components/__tests__/ImageLightbox.test.tsx
+++ b/apps/web/src/features/admin/components/__tests__/ImageLightbox.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ImageLightbox } from '../ImageLightbox'
+import type { FeedbackImageUrl } from '../../../../services/feedbackService'
+
+const images: FeedbackImageUrl[] = [
+  { path: 'uid/fid/a.png', url: 'https://example.com/a.png' },
+  { path: 'uid/fid/b.jpg', url: 'https://example.com/b.jpg' },
+  { path: 'uid/fid/c.gif', url: 'https://example.com/c.gif' },
+]
+
+afterEach(cleanup)
+
+describe('ImageLightbox', () => {
+  it('dialog ロールで表示される', () => {
+    render(
+      <ImageLightbox images={images} currentIndex={0} onClose={vi.fn()} onChangeIndex={vi.fn()} />,
+    )
+    expect(screen.getByRole('dialog', { name: '画像プレビュー' })).toBeTruthy()
+  })
+
+  it('現在の画像が表示される', () => {
+    render(
+      <ImageLightbox images={images} currentIndex={1} onClose={vi.fn()} onChangeIndex={vi.fn()} />,
+    )
+    const img = screen.getByAltText('添付画像 2')
+    expect(img.getAttribute('src')).toBe('https://example.com/b.jpg')
+  })
+
+  it('カウンタ���が表示される', () => {
+    render(
+      <ImageLightbox images={images} currentIndex={0} onClose={vi.fn()} onChangeIndex={vi.fn()} />,
+    )
+    expect(screen.getByText('1 / 3')).toBeTruthy()
+  })
+
+  it('ESC キーで onClose が呼ばれる', () => {
+    const onClose = vi.fn()
+    render(
+      <ImageLightbox images={images} currentIndex={0} onClose={onClose} onChangeIndex={vi.fn()} />,
+    )
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('閉じるボタンで onClose が呼ばれる', () => {
+    const onClose = vi.fn()
+    render(
+      <ImageLightbox images={images} currentIndex={0} onClose={onClose} onChangeIndex={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: '閉じる' }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('ArrowRight キーで次の画像に切り替わる', () => {
+    const onChangeIndex = vi.fn()
+    render(
+      <ImageLightbox images={images} currentIndex={0} onClose={vi.fn()} onChangeIndex={onChangeIndex} />,
+    )
+    fireEvent.keyDown(document, { key: 'ArrowRight' })
+    expect(onChangeIndex).toHaveBeenCalledWith(1)
+  })
+
+  it('ArrowLeft キーで前の画像に切り替わる', () => {
+    const onChangeIndex = vi.fn()
+    render(
+      <ImageLightbox images={images} currentIndex={2} onClose={vi.fn()} onChangeIndex={onChangeIndex} />,
+    )
+    fireEvent.keyDown(document, { key: 'ArrowLeft' })
+    expect(onChangeIndex).toHaveBeenCalledWith(1)
+  })
+
+  it('最初の画像で ArrowLeft を押しても onChangeIndex は呼ばれない', () => {
+    const onChangeIndex = vi.fn()
+    render(
+      <ImageLightbox images={images} currentIndex={0} onClose={vi.fn()} onChangeIndex={onChangeIndex} />,
+    )
+    fireEvent.keyDown(document, { key: 'ArrowLeft' })
+    expect(onChangeIndex).not.toHaveBeenCalled()
+  })
+
+  it('最後の画像で ArrowRight を押しても onChangeIndex は呼ばれない', () => {
+    const onChangeIndex = vi.fn()
+    render(
+      <ImageLightbox images={images} currentIndex={2} onClose={vi.fn()} onChangeIndex={onChangeIndex} />,
+    )
+    fireEvent.keyDown(document, { key: 'ArrowRight' })
+    expect(onChangeIndex).not.toHaveBeenCalled()
+  })
+
+  it('前へ・次へボタンのクリックで onChangeIndex が呼ばれる', () => {
+    const onChangeIndex = vi.fn()
+    render(
+      <ImageLightbox images={images} currentIndex={1} onClose={vi.fn()} onChangeIndex={onChangeIndex} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: '前の画像' }))
+    expect(onChangeIndex).toHaveBeenCalledWith(0)
+    fireEvent.click(screen.getByRole('button', { name: '次の画像' }))
+    expect(onChangeIndex).toHaveBeenCalledWith(2)
+  })
+})

--- a/apps/web/src/features/dashboard/components/AppHeader.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeader.tsx
@@ -1,27 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
-import { ChevronDown, Flame, Gem, MessageSquarePlus, Menu, Shield, X } from 'lucide-react'
-import { CATEGORIES } from '@/content/courseData'
+import { Flame, Gem, Menu } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useFeedbackContext } from '@/contexts/FeedbackContext'
 import { useLearningContext } from '@/contexts/LearningContext'
+import { AppHeaderDesktopNav } from './AppHeaderDesktopNav'
+import { AppHeaderMobileDrawer } from './AppHeaderMobileDrawer'
 
 interface AppHeaderProps {
   displayName: string
   onSignOut: () => void
 }
-
-const PRACTICE_LINKS = [
-  { to: '/daily', label: 'デイリーチャレンジ' },
-  { to: '/practice/code-doctor', label: 'コードドクター' },
-  { to: '/practice/mini-projects', label: 'ミニプロジェクト' },
-  { to: '/practice/code-reading', label: 'コードリーディング' },
-] as const
-
-const TOP_NAV_LINKS = [
-  { to: '/base-nook', label: 'ベースヌック', pathPrefix: '/base-nook' },
-  { to: '/profile', label: 'プロフィール', pathPrefix: '/profile' },
-] as const
 
 export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
   const { stats } = useLearningContext()
@@ -29,9 +18,6 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
   const { openFeedback } = useFeedbackContext()
   const location = useLocation()
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
-  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
-  const dropdownRef = useRef<HTMLDivElement>(null)
-  const drawerRef = useRef<HTMLElement>(null)
   const menuButtonRef = useRef<HTMLButtonElement>(null)
 
   const closeDrawer = useCallback(() => {
@@ -39,76 +25,10 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
     menuButtonRef.current?.focus()
   }, [])
 
-  const isCurriculumActive =
-    location.pathname === '/curriculum' ||
-    location.pathname.startsWith('/step') ||
-    location.pathname.startsWith('/daily') ||
-    location.pathname.startsWith('/practice')
-
-  // ページ遷移時にドロワー・ドロップダウンを閉じる
+  // ページ遷移時にドロワーを閉じる
   useEffect(() => {
     closeDrawer()
-    setIsDropdownOpen(false)
   }, [location.pathname, closeDrawer])
-
-  // ESCキーでドロワーを閉じる
-  useEffect(() => {
-    if (!isDrawerOpen) return
-    function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') closeDrawer()
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [isDrawerOpen, closeDrawer])
-
-  // フォーカストラップ: ドロワー内にフォーカスを閉じ込める
-  useEffect(() => {
-    if (!isDrawerOpen) return
-    const nav = drawerRef.current
-    if (!nav) return
-    const focusable = Array.from(nav.querySelectorAll<HTMLElement>(
-      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
-    ))
-    const first = focusable[0]
-    const last = focusable[focusable.length - 1]
-    if (!first || !last) return
-    // クロージャ内で型ナローイングを維持するためにローカル変数に再代入
-    const firstEl: HTMLElement = first
-    const lastEl: HTMLElement = last
-    firstEl.focus()
-    function handleTab(e: KeyboardEvent) {
-      if (e.key !== 'Tab') return
-      if (e.shiftKey) {
-        if (document.activeElement === firstEl) { e.preventDefault(); lastEl.focus() }
-      } else {
-        if (document.activeElement === lastEl) { e.preventDefault(); firstEl.focus() }
-      }
-    }
-    nav.addEventListener('keydown', handleTab)
-    return () => nav.removeEventListener('keydown', handleTab)
-  }, [isDrawerOpen])
-
-  // ドロワー開放中はbodyスクロールを無効化
-  useEffect(() => {
-    if (isDrawerOpen) {
-      document.body.style.overflow = 'hidden'
-    } else {
-      document.body.style.overflow = ''
-    }
-    return () => { document.body.style.overflow = '' }
-  }, [isDrawerOpen])
-
-  // ドロップダウン外クリックで閉じる
-  useEffect(() => {
-    if (!isDropdownOpen) return
-    function handleClickOutside(e: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setIsDropdownOpen(false)
-      }
-    }
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => document.removeEventListener('mousedown', handleClickOutside)
-  }, [isDropdownOpen])
 
   const navLinkClass = (active: boolean) =>
     `pb-1 ${active ? 'border-b-2 border-primary-mint text-slate-900' : 'text-slate-500 hover:text-slate-700'}`
@@ -126,112 +46,12 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
             <span className="font-display text-2xl font-bold tracking-tight text-primary-mint">Coden</span>
           </Link>
 
-          <nav className="hidden items-center gap-5 text-sm font-medium md:flex" aria-label="メインナビゲーション">
-            <Link
-              to="/"
-              className={navLinkClass(location.pathname === '/')}
-              aria-current={location.pathname === '/' ? 'page' : undefined}
-            >
-              ダッシュボード
-            </Link>
-
-            {/* カリキュラム ドロップダウン */}
-            <div className="relative" ref={dropdownRef}>
-              <button
-                type="button"
-                className={`flex items-center gap-1 ${navLinkClass(isCurriculumActive)}`}
-                onClick={() => setIsDropdownOpen((prev) => !prev)}
-                aria-expanded={isDropdownOpen}
-                aria-haspopup="true"
-                aria-controls="curriculum-menu"
-              >
-                カリキュラム
-                <ChevronDown className={`h-3.5 w-3.5 transition-transform ${isDropdownOpen ? 'rotate-180' : ''}`} aria-hidden="true" />
-              </button>
-
-              {isDropdownOpen && (
-                <div id="curriculum-menu" role="menu" className="absolute left-0 top-full mt-2 w-56 rounded-lg border border-slate-200 bg-white py-2 shadow-lg">
-                  <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
-                    学習コース
-                  </div>
-                  {CATEGORIES.map((cat) => (
-                    <Link
-                      key={cat.id}
-                      to={`/curriculum#${cat.id}`}
-                      role="menuitem"
-                      className="block px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50"
-                    >
-                      {cat.title}
-                    </Link>
-                  ))}
-
-                  <div className="my-1.5 border-t border-slate-100" />
-
-                  <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
-                    練習モード
-                  </div>
-                  {PRACTICE_LINKS.map((link) => (
-                    <Link
-                      key={link.to}
-                      to={link.to}
-                      role="menuitem"
-                      className="block px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50"
-                    >
-                      {link.label}
-                    </Link>
-                  ))}
-
-                  <div className="my-1.5 border-t border-slate-100" />
-                  <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
-                    サポート
-                  </div>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    onClick={() => {
-                      setIsDropdownOpen(false)
-                      openFeedback()
-                    }}
-                    className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50"
-                  >
-                    <MessageSquarePlus className="h-3.5 w-3.5" aria-hidden="true" />
-                    フィードバックを送る
-                  </button>
-
-                  {isAdmin ? (
-                    <>
-                      <div className="my-1.5 border-t border-slate-100" />
-                      <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
-                        管理
-                      </div>
-                      <Link
-                        to="/admin"
-                        role="menuitem"
-                        className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50"
-                      >
-                        <Shield className="h-3.5 w-3.5" aria-hidden="true" />
-                        管理画面
-                      </Link>
-                    </>
-                  ) : null}
-                </div>
-              )}
-            </div>
-
-            {TOP_NAV_LINKS.map((link) => {
-              const isActive = location.pathname.startsWith(link.pathPrefix)
-              return (
-                <Link
-                  key={link.to}
-                  to={link.to}
-                  className={navLinkClass(isActive)}
-                  aria-current={isActive ? 'page' : undefined}
-                >
-                  {link.label}
-                </Link>
-              )
-            })}
-          </nav>
+          <AppHeaderDesktopNav
+            pathname={location.pathname}
+            isAdmin={isAdmin}
+            openFeedback={openFeedback}
+            navLinkClass={navLinkClass}
+          />
         </div>
 
         <div className="flex items-center gap-3">
@@ -264,149 +84,17 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
       </div>
     </header>
 
-    {/* モバイルドロワー — フルスクリーン */}
     {isDrawerOpen ? (
-      <nav
-        ref={drawerRef}
-        role="dialog"
-        aria-modal="true"
-        className="fixed inset-0 z-50 flex flex-col bg-white md:hidden"
-        aria-label="モバイルナビゲーション"
-      >
-        {/* ヘッダー */}
-        <div className="flex h-16 items-center justify-between border-b border-slate-200 px-4">
-          <span className="text-sm font-semibold text-slate-900">メニュー</span>
-          <button
-            className="rounded-lg p-2 text-slate-500 transition hover:bg-slate-100"
-            type="button"
-            onClick={closeDrawer}
-            aria-label="メニューを閉じる"
-          >
-            <X className="h-5 w-5" />
-          </button>
-        </div>
-
-        {/* ユーザー情報 */}
-        <div className="border-b border-slate-100 px-4 py-4">
-          <p className="font-semibold text-slate-900">{displayName}</p>
-          <div className="mt-1 flex items-center gap-3 text-sm text-slate-500">
-            <span><Gem className="inline-block h-3.5 w-3.5 text-amber-600" aria-hidden="true" /> {stats?.total_points ?? 0} Pt</span>
-            <span aria-hidden="true">·</span>
-            <span><Flame className="inline-block h-3.5 w-3.5 text-primary-mint" aria-hidden="true" /> {stats?.current_streak ?? 0}日連続</span>
-          </div>
-        </div>
-
-        {/* ナビゲーションリンク */}
-        <div className="flex-1 overflow-y-auto">
-          {/* メイン */}
-          <div className="border-b border-slate-100 px-4 py-3">
-            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">メイン</p>
-            <Link
-              to="/"
-              className={drawerLinkClass(location.pathname === '/')}
-              aria-current={location.pathname === '/' ? 'page' : undefined}
-            >
-              ダッシュボード
-            </Link>
-            <Link
-              to="/curriculum"
-              className={drawerLinkClass(isCurriculumActive)}
-              aria-current={location.pathname === '/curriculum' ? 'page' : undefined}
-            >
-              カリキュラム
-            </Link>
-          </div>
-
-          {/* 学習コース */}
-          <div className="border-b border-slate-100 px-4 py-3">
-            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">学習コース</p>
-            {CATEGORIES.map((cat) => (
-              <Link
-                key={cat.id}
-                to={`/curriculum#${cat.id}`}
-                className={drawerLinkClass(false)}
-              >
-                {cat.title}
-              </Link>
-            ))}
-          </div>
-
-          {/* 練習モード */}
-          <div className="border-b border-slate-100 px-4 py-3">
-            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">練習モード</p>
-            {PRACTICE_LINKS.map((link) => (
-              <Link
-                key={link.to}
-                to={link.to}
-                className={drawerLinkClass(location.pathname.startsWith(link.to))}
-                aria-current={location.pathname.startsWith(link.to) ? 'page' : undefined}
-              >
-                {link.label}
-              </Link>
-            ))}
-          </div>
-
-          {/* その他 */}
-          <div className="border-b border-slate-100 px-4 py-3">
-            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">その他</p>
-            {TOP_NAV_LINKS.map((link) => {
-              const isActive = location.pathname.startsWith(link.pathPrefix)
-              return (
-                <Link
-                  key={link.to}
-                  to={link.to}
-                  className={drawerLinkClass(isActive)}
-                  aria-current={isActive ? 'page' : undefined}
-                >
-                  {link.label}
-                </Link>
-              )
-            })}
-          </div>
-
-          {/* サポート（全ユーザー） */}
-          <div className="border-b border-slate-100 px-4 py-3">
-            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">サポート</p>
-            <button
-              type="button"
-              onClick={() => {
-                closeDrawer()
-                openFeedback()
-              }}
-              className={`${drawerLinkClass(false)} w-full`}
-            >
-              <MessageSquarePlus className="mr-2 h-4 w-4" aria-hidden="true" />
-              フィードバックを送る
-            </button>
-          </div>
-
-          {/* 管理（admin のみ） */}
-          {isAdmin ? (
-            <div className="border-b border-slate-100 px-4 py-3">
-              <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">管理</p>
-              <Link
-                to="/admin"
-                className={drawerLinkClass(location.pathname.startsWith('/admin'))}
-                aria-current={location.pathname.startsWith('/admin') ? 'page' : undefined}
-              >
-                <Shield className="mr-2 h-4 w-4" aria-hidden="true" />
-                管理画面
-              </Link>
-            </div>
-          ) : null}
-        </div>
-
-        {/* ログアウトボタン */}
-        <div className="border-t border-slate-200 px-4 py-3">
-          <button
-            className="flex min-h-[44px] w-full items-center justify-center rounded-lg border border-slate-300 bg-white text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
-            type="button"
-            onClick={() => { closeDrawer(); onSignOut() }}
-          >
-            ログアウト
-          </button>
-        </div>
-      </nav>
+      <AppHeaderMobileDrawer
+        displayName={displayName}
+        pathname={location.pathname}
+        stats={stats}
+        isAdmin={isAdmin}
+        openFeedback={openFeedback}
+        onClose={closeDrawer}
+        onSignOut={onSignOut}
+        drawerLinkClass={drawerLinkClass}
+      />
     ) : null}
 
     </>

--- a/apps/web/src/features/dashboard/components/AppHeader.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeader.tsx
@@ -3,8 +3,8 @@ import { Link, useLocation } from 'react-router-dom'
 import { ChevronDown, Flame, Gem, MessageSquarePlus, Menu, Shield, X } from 'lucide-react'
 import { CATEGORIES } from '@/content/courseData'
 import { useAuth } from '@/contexts/AuthContext'
+import { useFeedbackContext } from '@/contexts/FeedbackContext'
 import { useLearningContext } from '@/contexts/LearningContext'
-import { FeedbackDialog } from '@/features/feedback/FeedbackDialog'
 
 interface AppHeaderProps {
   displayName: string
@@ -26,10 +26,10 @@ const TOP_NAV_LINKS = [
 export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
   const { stats } = useLearningContext()
   const { isAdmin } = useAuth()
+  const { openFeedback } = useFeedbackContext()
   const location = useLocation()
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
-  const [isFeedbackOpen, setIsFeedbackOpen] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
   const drawerRef = useRef<HTMLElement>(null)
   const menuButtonRef = useRef<HTMLButtonElement>(null)
@@ -190,7 +190,7 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
                     role="menuitem"
                     onClick={() => {
                       setIsDropdownOpen(false)
-                      setIsFeedbackOpen(true)
+                      openFeedback()
                     }}
                     className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50"
                   >
@@ -371,7 +371,7 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
               type="button"
               onClick={() => {
                 closeDrawer()
-                setIsFeedbackOpen(true)
+                openFeedback()
               }}
               className={`${drawerLinkClass(false)} w-full`}
             >
@@ -409,7 +409,6 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
       </nav>
     ) : null}
 
-    <FeedbackDialog open={isFeedbackOpen} onClose={() => setIsFeedbackOpen(false)} />
     </>
   )
 }

--- a/apps/web/src/features/dashboard/components/AppHeaderDesktopNav.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeaderDesktopNav.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { ChevronDown, MessageSquarePlus, Shield } from 'lucide-react'
+import { CATEGORIES } from '@/content/courseData'
+import { PRACTICE_LINKS, TOP_NAV_LINKS } from './appHeaderLinks'
+
+interface AppHeaderDesktopNavProps {
+  pathname: string
+  isAdmin: boolean
+  openFeedback: () => void
+  navLinkClass: (active: boolean) => string
+}
+
+export function AppHeaderDesktopNav({ pathname, isAdmin, openFeedback, navLinkClass }: AppHeaderDesktopNavProps) {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  const isCurriculumActive =
+    pathname === '/curriculum' ||
+    pathname.startsWith('/step') ||
+    pathname.startsWith('/daily') ||
+    pathname.startsWith('/practice')
+
+  // ページ遷移時にドロップダウンを閉じる
+  useEffect(() => {
+    setIsDropdownOpen(false)
+  }, [pathname])
+
+  // ドロップダウン外クリックで閉じる
+  useEffect(() => {
+    if (!isDropdownOpen) return
+    function handleClickOutside(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setIsDropdownOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isDropdownOpen])
+
+  return (
+    <nav className="hidden items-center gap-5 text-sm font-medium md:flex" aria-label="メインナビゲーション">
+      <Link
+        to="/"
+        className={navLinkClass(pathname === '/')}
+        aria-current={pathname === '/' ? 'page' : undefined}
+      >
+        ダッシュボード
+      </Link>
+
+      {/* カリキュラム ドロップダウン */}
+      <div className="relative" ref={dropdownRef}>
+        <button
+          type="button"
+          className={`flex items-center gap-1 ${navLinkClass(isCurriculumActive)}`}
+          onClick={() => setIsDropdownOpen((prev) => !prev)}
+          aria-expanded={isDropdownOpen}
+          aria-haspopup="true"
+          aria-controls="curriculum-menu"
+        >
+          カリキュラム
+          <ChevronDown className={`h-3.5 w-3.5 transition-transform ${isDropdownOpen ? 'rotate-180' : ''}`} aria-hidden="true" />
+        </button>
+
+        {isDropdownOpen && (
+          <div id="curriculum-menu" role="menu" className="absolute left-0 top-full mt-2 w-56 rounded-lg border border-slate-200 bg-white py-2 shadow-lg">
+            <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
+              学習コース
+            </div>
+            {CATEGORIES.map((cat) => (
+              <Link
+                key={cat.id}
+                to={`/curriculum#${cat.id}`}
+                role="menuitem"
+                className="block px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50"
+              >
+                {cat.title}
+              </Link>
+            ))}
+
+            <div className="my-1.5 border-t border-slate-100" />
+
+            <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
+              練習モード
+            </div>
+            {PRACTICE_LINKS.map((link) => (
+              <Link
+                key={link.to}
+                to={link.to}
+                role="menuitem"
+                className="block px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50"
+              >
+                {link.label}
+              </Link>
+            ))}
+
+            <div className="my-1.5 border-t border-slate-100" />
+            <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
+              サポート
+            </div>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setIsDropdownOpen(false)
+                openFeedback()
+              }}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-slate-700 transition hover:bg-slate-50"
+            >
+              <MessageSquarePlus className="h-3.5 w-3.5" aria-hidden="true" />
+              フィードバックを送る
+            </button>
+
+            {isAdmin ? (
+              <>
+                <div className="my-1.5 border-t border-slate-100" />
+                <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wider text-slate-400">
+                  管理
+                </div>
+                <Link
+                  to="/admin"
+                  role="menuitem"
+                  className="flex items-center gap-2 px-3 py-2 text-sm text-slate-700 transition hover:bg-slate-50"
+                >
+                  <Shield className="h-3.5 w-3.5" aria-hidden="true" />
+                  管理画面
+                </Link>
+              </>
+            ) : null}
+          </div>
+        )}
+      </div>
+
+      {TOP_NAV_LINKS.map((link) => {
+        const isActive = pathname.startsWith(link.pathPrefix)
+        return (
+          <Link
+            key={link.to}
+            to={link.to}
+            className={navLinkClass(isActive)}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            {link.label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/apps/web/src/features/dashboard/components/AppHeaderMobileDrawer.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeaderMobileDrawer.tsx
@@ -1,0 +1,224 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { Link } from 'react-router-dom'
+import { Flame, Gem, MessageSquarePlus, Shield, X } from 'lucide-react'
+import { CATEGORIES } from '@/content/courseData'
+import type { LearningStats } from '@/services/statsService'
+import { PRACTICE_LINKS, TOP_NAV_LINKS } from './appHeaderLinks'
+
+interface AppHeaderMobileDrawerProps {
+  displayName: string
+  pathname: string
+  stats: LearningStats | null
+  isAdmin: boolean
+  openFeedback: () => void
+  onClose: () => void
+  onSignOut: () => void
+  drawerLinkClass: (active: boolean) => string
+}
+
+export function AppHeaderMobileDrawer({
+  displayName,
+  pathname,
+  stats,
+  isAdmin,
+  openFeedback,
+  onClose,
+  onSignOut,
+  drawerLinkClass,
+}: AppHeaderMobileDrawerProps) {
+  const drawerRef = useRef<HTMLElement>(null)
+
+  const isCurriculumActive =
+    pathname === '/curriculum' ||
+    pathname.startsWith('/step') ||
+    pathname.startsWith('/daily') ||
+    pathname.startsWith('/practice')
+
+  const handleClose = useCallback(() => {
+    onClose()
+  }, [onClose])
+
+  // ESCキーでドロワーを閉じる
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') handleClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [handleClose])
+
+  // フォーカストラップ: ドロワー内にフォーカスを閉じ込める
+  useEffect(() => {
+    const nav = drawerRef.current
+    if (!nav) return
+    const focusable = Array.from(nav.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ))
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (!first || !last) return
+    const firstEl: HTMLElement = first
+    const lastEl: HTMLElement = last
+    firstEl.focus()
+    function handleTab(e: KeyboardEvent) {
+      if (e.key !== 'Tab') return
+      if (e.shiftKey) {
+        if (document.activeElement === firstEl) { e.preventDefault(); lastEl.focus() }
+      } else {
+        if (document.activeElement === lastEl) { e.preventDefault(); firstEl.focus() }
+      }
+    }
+    nav.addEventListener('keydown', handleTab)
+    return () => nav.removeEventListener('keydown', handleTab)
+  }, [])
+
+  // body スクロール無効化
+  useEffect(() => {
+    document.body.style.overflow = 'hidden'
+    return () => { document.body.style.overflow = '' }
+  }, [])
+
+  return (
+    <nav
+      ref={drawerRef}
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex flex-col bg-white md:hidden"
+      aria-label="モバイルナビゲーション"
+    >
+      {/* ヘッダー */}
+      <div className="flex h-16 items-center justify-between border-b border-slate-200 px-4">
+        <span className="text-sm font-semibold text-slate-900">メニュー</span>
+        <button
+          className="rounded-lg p-2 text-slate-500 transition hover:bg-slate-100"
+          type="button"
+          onClick={handleClose}
+          aria-label="メニューを閉じる"
+        >
+          <X className="h-5 w-5" aria-hidden="true" />
+        </button>
+      </div>
+
+      {/* ユーザー情報 */}
+      <div className="border-b border-slate-100 px-4 py-4">
+        <p className="font-semibold text-slate-900">{displayName}</p>
+        <div className="mt-1 flex items-center gap-3 text-sm text-slate-500">
+          <span><Gem className="inline-block h-3.5 w-3.5 text-amber-600" aria-hidden="true" /> {stats?.total_points ?? 0} Pt</span>
+          <span aria-hidden="true">·</span>
+          <span><Flame className="inline-block h-3.5 w-3.5 text-primary-mint" aria-hidden="true" /> {stats?.current_streak ?? 0}日連続</span>
+        </div>
+      </div>
+
+      {/* ナビゲーションリンク */}
+      <div className="flex-1 overflow-y-auto">
+        {/* メイン */}
+        <div className="border-b border-slate-100 px-4 py-3">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">メイン</p>
+          <Link
+            to="/"
+            className={drawerLinkClass(pathname === '/')}
+            aria-current={pathname === '/' ? 'page' : undefined}
+          >
+            ダッシュボード
+          </Link>
+          <Link
+            to="/curriculum"
+            className={drawerLinkClass(isCurriculumActive)}
+            aria-current={pathname === '/curriculum' ? 'page' : undefined}
+          >
+            カリキュラム
+          </Link>
+        </div>
+
+        {/* 学習コース */}
+        <div className="border-b border-slate-100 px-4 py-3">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">学習コース</p>
+          {CATEGORIES.map((cat) => (
+            <Link
+              key={cat.id}
+              to={`/curriculum#${cat.id}`}
+              className={drawerLinkClass(false)}
+            >
+              {cat.title}
+            </Link>
+          ))}
+        </div>
+
+        {/* 練習モード */}
+        <div className="border-b border-slate-100 px-4 py-3">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">練習モード</p>
+          {PRACTICE_LINKS.map((link) => (
+            <Link
+              key={link.to}
+              to={link.to}
+              className={drawerLinkClass(pathname.startsWith(link.to))}
+              aria-current={pathname.startsWith(link.to) ? 'page' : undefined}
+            >
+              {link.label}
+            </Link>
+          ))}
+        </div>
+
+        {/* その他 */}
+        <div className="border-b border-slate-100 px-4 py-3">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">その他</p>
+          {TOP_NAV_LINKS.map((link) => {
+            const isActive = pathname.startsWith(link.pathPrefix)
+            return (
+              <Link
+                key={link.to}
+                to={link.to}
+                className={drawerLinkClass(isActive)}
+                aria-current={isActive ? 'page' : undefined}
+              >
+                {link.label}
+              </Link>
+            )
+          })}
+        </div>
+
+        {/* サポート（全ユーザー） */}
+        <div className="border-b border-slate-100 px-4 py-3">
+          <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">サポート</p>
+          <button
+            type="button"
+            onClick={() => {
+              handleClose()
+              openFeedback()
+            }}
+            className={`${drawerLinkClass(false)} w-full`}
+          >
+            <MessageSquarePlus className="mr-2 h-4 w-4" aria-hidden="true" />
+            フィードバックを送る
+          </button>
+        </div>
+
+        {/* 管理（admin のみ） */}
+        {isAdmin ? (
+          <div className="border-b border-slate-100 px-4 py-3">
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-400">管理</p>
+            <Link
+              to="/admin"
+              className={drawerLinkClass(pathname.startsWith('/admin'))}
+              aria-current={pathname.startsWith('/admin') ? 'page' : undefined}
+            >
+              <Shield className="mr-2 h-4 w-4" aria-hidden="true" />
+              管理画面
+            </Link>
+          </div>
+        ) : null}
+      </div>
+
+      {/* ログアウトボタン */}
+      <div className="border-t border-slate-200 px-4 py-3">
+        <button
+          className="flex min-h-[44px] w-full items-center justify-center rounded-lg border border-slate-300 bg-white text-sm font-semibold text-slate-700 transition hover:bg-slate-50"
+          type="button"
+          onClick={() => { handleClose(); onSignOut() }}
+        >
+          ログアウト
+        </button>
+      </div>
+    </nav>
+  )
+}

--- a/apps/web/src/features/dashboard/components/__tests__/AppHeaderAdminLink.test.tsx
+++ b/apps/web/src/features/dashboard/components/__tests__/AppHeaderAdminLink.test.tsx
@@ -17,6 +17,10 @@ vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => mockAuth.value,
 }))
 
+vi.mock('@/contexts/FeedbackContext', () => ({
+  useFeedbackContext: () => ({ openFeedback: vi.fn() }),
+}))
+
 function renderHeader() {
   return render(
     <MemoryRouter>

--- a/apps/web/src/features/dashboard/components/__tests__/AppHeaderMobile.test.tsx
+++ b/apps/web/src/features/dashboard/components/__tests__/AppHeaderMobile.test.tsx
@@ -19,6 +19,10 @@ vi.mock('@/contexts/AuthContext', () => ({
   }),
 }))
 
+vi.mock('@/contexts/FeedbackContext', () => ({
+  useFeedbackContext: () => ({ openFeedback: vi.fn() }),
+}))
+
 afterEach(() => {
   cleanup()
 })

--- a/apps/web/src/features/dashboard/components/__tests__/DashboardNavigation.test.tsx
+++ b/apps/web/src/features/dashboard/components/__tests__/DashboardNavigation.test.tsx
@@ -20,6 +20,10 @@ vi.mock('@/contexts/AuthContext', () => ({
   }),
 }))
 
+vi.mock('@/contexts/FeedbackContext', () => ({
+  useFeedbackContext: () => ({ openFeedback: vi.fn() }),
+}))
+
 vi.mock('@/services/statsService', () => ({
   calculatePointGoalProgress: () => ({
     current: 120,

--- a/apps/web/src/features/dashboard/components/appHeaderLinks.ts
+++ b/apps/web/src/features/dashboard/components/appHeaderLinks.ts
@@ -1,0 +1,11 @@
+export const PRACTICE_LINKS = [
+  { to: '/daily', label: 'デイリーチャレンジ' },
+  { to: '/practice/code-doctor', label: 'コードドクター' },
+  { to: '/practice/mini-projects', label: 'ミニプロジェクト' },
+  { to: '/practice/code-reading', label: 'コードリーディング' },
+] as const
+
+export const TOP_NAV_LINKS = [
+  { to: '/base-nook', label: 'ベースヌック', pathPrefix: '/base-nook' },
+  { to: '/profile', label: 'プロフィール', pathPrefix: '/profile' },
+] as const

--- a/apps/web/src/features/feedback/FeedbackDialog.tsx
+++ b/apps/web/src/features/feedback/FeedbackDialog.tsx
@@ -154,7 +154,7 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
         </div>
 
         {isSubmitted ? (
-          <div className="py-6 text-center">
+          <div role="status" aria-live="polite" className="py-6 text-center">
             <p className="text-sm font-semibold text-slate-900">送信しました。ありがとうございます！</p>
             <p className="mt-1 text-xs text-slate-500">いただいた内容は運営が確認いたします。</p>
             <button
@@ -290,7 +290,7 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
             </div>
 
             {error ? (
-              <div className="flex items-start gap-2 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700">
+              <div role="alert" className="flex items-start gap-2 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700">
                 <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
                 <span>{error}</span>
               </div>

--- a/apps/web/src/features/feedback/FeedbackDialog.tsx
+++ b/apps/web/src/features/feedback/FeedbackDialog.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { AlertCircle, Loader2, X } from 'lucide-react'
+import { AlertCircle, ImagePlus, Loader2, Trash2, X } from 'lucide-react'
 import { useAuth } from '../../contexts/AuthContext'
 import {
   captureClientMeta,
   FEEDBACK_CATEGORY_LABELS,
   MAX_FEEDBACK_MESSAGE_LENGTH,
+  MAX_IMAGE_COUNT,
   submitFeedback,
+  validateImageFiles,
   type FeedbackCategory,
 } from '../../services/feedbackService'
 
@@ -23,8 +25,10 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [isSubmitted, setIsSubmitted] = useState(false)
+  const [files, setFiles] = useState<File[]>([])
   const dialogRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   // ダイアログを閉じたらフォーム状態をリセット
   const reset = useCallback(() => {
@@ -33,6 +37,7 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
     setError(null)
     setIsSubmitted(false)
     setIsSubmitting(false)
+    setFiles([])
   }, [])
 
   const handleClose = useCallback(() => {
@@ -96,6 +101,7 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
         message: trimmed,
         pageUrl: meta.pageUrl,
         userAgent: meta.userAgent,
+        ...(files.length > 0 ? { files } : {}),
       })
       setIsSubmitted(true)
     } catch (err) {
@@ -204,6 +210,85 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
               </div>
             </div>
 
+            {/* 画像添付セクション */}
+            <div>
+              <div className="flex items-center justify-between">
+                <span className="block text-xs font-semibold text-slate-700">
+                  スクリーンショット（任意）
+                </span>
+                <span className="text-xs text-slate-400">{files.length}/{MAX_IMAGE_COUNT}</span>
+              </div>
+
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                className="hidden"
+                disabled={isSubmitting || files.length >= MAX_IMAGE_COUNT}
+                onChange={(e) => {
+                  const selected = Array.from(e.target.files ?? [])
+                  if (selected.length === 0) return
+                  const merged = [...files, ...selected].slice(0, MAX_IMAGE_COUNT)
+                  try {
+                    validateImageFiles(merged)
+                    setFiles(merged)
+                    setError(null)
+                  } catch (err) {
+                    setError(err instanceof Error ? err.message : 'ファイルの追加に失敗しました')
+                  }
+                  // 同じファイルを再選択できるようリセット
+                  e.target.value = ''
+                }}
+              />
+
+              {files.length > 0 ? (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {files.map((file, idx) => (
+                    <div
+                      key={`${file.name}-${file.size}-${idx}`}
+                      className="group relative flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-2 py-1.5"
+                    >
+                      <img
+                        src={URL.createObjectURL(file)}
+                        alt={file.name}
+                        className="h-10 w-10 rounded object-cover"
+                      />
+                      <div className="min-w-0">
+                        <p className="max-w-[120px] truncate text-xs font-medium text-slate-700">{file.name}</p>
+                        <p className="text-[10px] text-slate-400">{formatFileSize(file.size)}</p>
+                      </div>
+                      <button
+                        type="button"
+                        onClick={() => setFiles((prev) => prev.filter((_, i) => i !== idx))}
+                        disabled={isSubmitting}
+                        className="ml-1 rounded p-0.5 text-slate-400 transition hover:bg-slate-200 hover:text-rose-600"
+                        aria-label={`${file.name} を削除`}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+
+              {files.length < MAX_IMAGE_COUNT ? (
+                <button
+                  type="button"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={isSubmitting}
+                  className="mt-2 flex items-center gap-1.5 rounded-lg border border-dashed border-slate-300 px-3 py-2 text-xs font-medium text-slate-500 transition hover:border-primary-mint hover:text-primary-mint"
+                >
+                  <ImagePlus className="h-4 w-4" aria-hidden="true" />
+                  画像を追加
+                </button>
+              ) : null}
+
+              <p className="mt-1 text-[10px] text-slate-400">
+                PNG / JPG / GIF など、各 5MB 以下
+              </p>
+            </div>
+
             {error ? (
               <div className="flex items-start gap-2 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700">
                 <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" aria-hidden="true" />
@@ -234,4 +319,10 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
       </div>
     </div>
   )
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }

--- a/apps/web/src/features/feedback/FeedbackDialog.tsx
+++ b/apps/web/src/features/feedback/FeedbackDialog.tsx
@@ -1,15 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { AlertCircle, ImagePlus, Loader2, Trash2, X } from 'lucide-react'
+import { AlertCircle, Loader2, X } from 'lucide-react'
 import { useAuth } from '../../contexts/AuthContext'
 import {
   captureClientMeta,
   FEEDBACK_CATEGORY_LABELS,
   MAX_FEEDBACK_MESSAGE_LENGTH,
-  MAX_IMAGE_COUNT,
   submitFeedback,
-  validateImageFiles,
   type FeedbackCategory,
 } from '../../services/feedbackService'
+import { FeedbackImagePicker } from './FeedbackImagePicker'
 
 interface FeedbackDialogProps {
   open: boolean
@@ -28,7 +27,6 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
   const [files, setFiles] = useState<File[]>([])
   const dialogRef = useRef<HTMLDivElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const fileInputRef = useRef<HTMLInputElement>(null)
 
   // ダイアログを閉じたらフォーム状態をリセット
   const reset = useCallback(() => {
@@ -210,84 +208,12 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
               </div>
             </div>
 
-            {/* 画像添付セクション */}
-            <div>
-              <div className="flex items-center justify-between">
-                <span className="block text-xs font-semibold text-slate-700">
-                  スクリーンショット（任意）
-                </span>
-                <span className="text-xs text-slate-400">{files.length}/{MAX_IMAGE_COUNT}</span>
-              </div>
-
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept="image/*"
-                multiple
-                className="hidden"
-                disabled={isSubmitting || files.length >= MAX_IMAGE_COUNT}
-                onChange={(e) => {
-                  const selected = Array.from(e.target.files ?? [])
-                  if (selected.length === 0) return
-                  const merged = [...files, ...selected].slice(0, MAX_IMAGE_COUNT)
-                  try {
-                    validateImageFiles(merged)
-                    setFiles(merged)
-                    setError(null)
-                  } catch (err) {
-                    setError(err instanceof Error ? err.message : 'ファイルの追加に失敗しました')
-                  }
-                  // 同じファイルを再選択できるようリセット
-                  e.target.value = ''
-                }}
-              />
-
-              {files.length > 0 ? (
-                <div className="mt-2 flex flex-wrap gap-2">
-                  {files.map((file, idx) => (
-                    <div
-                      key={`${file.name}-${file.size}-${idx}`}
-                      className="group relative flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-2 py-1.5"
-                    >
-                      <img
-                        src={URL.createObjectURL(file)}
-                        alt={file.name}
-                        className="h-10 w-10 rounded object-cover"
-                      />
-                      <div className="min-w-0">
-                        <p className="max-w-[120px] truncate text-xs font-medium text-slate-700">{file.name}</p>
-                        <p className="text-[10px] text-slate-400">{formatFileSize(file.size)}</p>
-                      </div>
-                      <button
-                        type="button"
-                        onClick={() => setFiles((prev) => prev.filter((_, i) => i !== idx))}
-                        disabled={isSubmitting}
-                        className="ml-1 rounded p-0.5 text-slate-400 transition hover:bg-slate-200 hover:text-rose-600"
-                        aria-label={`${file.name} を削除`}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
-                      </button>
-                    </div>
-                  ))}
-                </div>
-              ) : null}
-
-              {files.length < MAX_IMAGE_COUNT ? (
-                <button
-                  type="button"
-                  onClick={() => fileInputRef.current?.click()}
-                  disabled={isSubmitting}
-                  className="mt-2 flex items-center gap-1.5 rounded-lg border border-dashed border-slate-300 px-3 py-2 text-xs font-medium text-slate-500 transition hover:border-primary-mint hover:text-primary-mint"
-                >
-                  <ImagePlus className="h-4 w-4" aria-hidden="true" />
-                  画像を追加
-                </button>
-              ) : null}
-
-              <p className="mt-1 text-[10px] text-slate-400">
-                PNG / JPG / GIF など、各 5MB 以下
-              </p>
-            </div>
+            <FeedbackImagePicker
+              files={files}
+              onFilesChange={(next) => { setFiles(next); setError(null) }}
+              disabled={isSubmitting}
+              onError={setError}
+            />
 
             {error ? (
               <div role="alert" className="flex items-start gap-2 rounded-lg border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700">
@@ -319,10 +245,4 @@ export function FeedbackDialog({ open, onClose }: FeedbackDialogProps) {
       </div>
     </div>
   )
-}
-
-function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
 }

--- a/apps/web/src/features/feedback/FeedbackImagePicker.tsx
+++ b/apps/web/src/features/feedback/FeedbackImagePicker.tsx
@@ -1,0 +1,98 @@
+import { useRef } from 'react'
+import { ImagePlus, Trash2 } from 'lucide-react'
+import { MAX_IMAGE_COUNT, validateImageFiles } from '../../services/feedbackService'
+
+interface FeedbackImagePickerProps {
+  files: File[]
+  onFilesChange: (files: File[]) => void
+  disabled: boolean
+  onError: (message: string) => void
+}
+
+export function FeedbackImagePicker({ files, onFilesChange, disabled, onError }: FeedbackImagePickerProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  return (
+    <div>
+      <div className="flex items-center justify-between">
+        <span className="block text-xs font-semibold text-slate-700">
+          スクリーンショット（任意）
+        </span>
+        <span className="text-xs text-slate-400">{files.length}/{MAX_IMAGE_COUNT}</span>
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        className="hidden"
+        disabled={disabled || files.length >= MAX_IMAGE_COUNT}
+        onChange={(e) => {
+          const selected = Array.from(e.target.files ?? [])
+          if (selected.length === 0) return
+          const merged = [...files, ...selected].slice(0, MAX_IMAGE_COUNT)
+          try {
+            validateImageFiles(merged)
+            onFilesChange(merged)
+          } catch (err) {
+            onError(err instanceof Error ? err.message : 'ファイルの追加に失敗しました')
+          }
+          e.target.value = ''
+        }}
+      />
+
+      {files.length > 0 ? (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {files.map((file, idx) => (
+            <div
+              key={`${file.name}-${file.size}-${idx}`}
+              className="group relative flex items-center gap-2 rounded-lg border border-slate-200 bg-slate-50 px-2 py-1.5"
+            >
+              <img
+                src={URL.createObjectURL(file)}
+                alt={file.name}
+                className="h-10 w-10 rounded object-cover"
+              />
+              <div className="min-w-0">
+                <p className="max-w-[120px] truncate text-xs font-medium text-slate-700">{file.name}</p>
+                <p className="text-[10px] text-slate-400">{formatFileSize(file.size)}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => onFilesChange(files.filter((_, i) => i !== idx))}
+                disabled={disabled}
+                className="ml-1 rounded p-0.5 text-slate-400 transition hover:bg-slate-200 hover:text-rose-600"
+                aria-label={`${file.name} を削除`}
+              >
+                <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {files.length < MAX_IMAGE_COUNT ? (
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={disabled}
+          className="mt-2 flex items-center gap-1.5 rounded-lg border border-dashed border-slate-300 px-3 py-2 text-xs font-medium text-slate-500 transition hover:border-primary-mint hover:text-primary-mint"
+        >
+          <ImagePlus className="h-4 w-4" aria-hidden="true" />
+          画像を追加
+        </button>
+      ) : null}
+
+      <p className="mt-1 text-[10px] text-slate-400">
+        PNG / JPG / GIF など、各 5MB 以下
+      </p>
+    </div>
+  )
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}

--- a/apps/web/src/features/feedback/__tests__/FeedbackDialog.test.tsx
+++ b/apps/web/src/features/feedback/__tests__/FeedbackDialog.test.tsx
@@ -107,4 +107,41 @@ describe('FeedbackDialog', () => {
     fireEvent.click(screen.getByRole('button', { name: '閉じる' }))
     expect(onClose).toHaveBeenCalled()
   })
+
+  it('画像追加ボタンが表示される', () => {
+    render(<FeedbackDialog open={true} onClose={() => undefined} />)
+    expect(screen.getByRole('button', { name: '画像を追加' })).toBeTruthy()
+    expect(screen.getByText(/0\/3/)).toBeTruthy()
+  })
+
+  it('不正なファイルを追加するとエラーが表示される', async () => {
+    render(<FeedbackDialog open={true} onClose={() => undefined} />)
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement
+
+    const pdf = new File(['dummy'], 'doc.pdf', { type: 'application/pdf' })
+    fireEvent.change(fileInput, { target: { files: [pdf] } })
+
+    await waitFor(() => {
+      expect(screen.getByText(/画像ファイルではありません/)).toBeTruthy()
+    })
+  })
+
+  it('画像を追加するとプレビューが表示され削除ボタンで除去できる', async () => {
+    render(<FeedbackDialog open={true} onClose={() => undefined} />)
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement
+
+    const img = new File(['x'], 'shot.png', { type: 'image/png' })
+    fireEvent.change(fileInput, { target: { files: [img] } })
+
+    await waitFor(() => {
+      expect(screen.getByText('shot.png')).toBeTruthy()
+      expect(screen.getByText(/1\/3/)).toBeTruthy()
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'shot.png を削除' }))
+    await waitFor(() => {
+      expect(screen.queryByText('shot.png')).toBeNull()
+      expect(screen.getByText(/0\/3/)).toBeTruthy()
+    })
+  })
 })

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -2,11 +2,14 @@ import React, { lazy, Suspense } from 'react'
 import ReactDOM from 'react-dom/client'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
 import { AdminGuard } from './components/AdminGuard'
+import { FeedbackFab } from './components/FeedbackFab'
 import { ProtectedRoute, GuestRoute } from './components/ProtectedRoute'
 import { AuthProvider } from './contexts/AuthContext'
+import { FeedbackProvider, useFeedbackContext } from './contexts/FeedbackContext'
 import { LearningProvider } from './contexts/LearningContext'
 import { AchievementProvider } from './contexts/AchievementContext'
 import { AchievementToast } from './components/AchievementToast'
+import { FeedbackDialog } from './features/feedback/FeedbackDialog'
 import { ConfigErrorView } from './components/ConfigErrorView'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { PageSpinner } from './components/Spinner'
@@ -57,6 +60,12 @@ const AdminStatsPage = lazy(() =>
 const AdminOpsPage = lazy(() =>
   import('./pages/admin/AdminOpsPage').then((m) => ({ default: m.AdminOpsPage })),
 )
+
+// FeedbackContext → FeedbackDialog をつなぐ薄いラッパー
+function ConnectedFeedbackDialog() {
+  const { isOpen, closeFeedback } = useFeedbackContext()
+  return <FeedbackDialog open={isOpen} onClose={closeFeedback} />
+}
 
 // ページ遷移中のフォールバック UI
 function PageLoading() {
@@ -314,8 +323,12 @@ async function startApp() {
           <AuthProvider>
             <LearningProvider>
               <AchievementProvider>
-                <AchievementToast />
-                <RouterProvider router={router} />
+                <FeedbackProvider>
+                  <AchievementToast />
+                  <FeedbackFab />
+                  <ConnectedFeedbackDialog />
+                  <RouterProvider router={router} />
+                </FeedbackProvider>
               </AchievementProvider>
             </LearningProvider>
           </AuthProvider>

--- a/apps/web/src/pages/admin/AdminFeedbackDetailPage.tsx
+++ b/apps/web/src/pages/admin/AdminFeedbackDetailPage.tsx
@@ -95,7 +95,8 @@ export function AdminFeedbackDetailPage() {
         setFeedback(data)
 
         // image_paths がある場合は signed URL を取得
-        const paths = Array.isArray(data.image_paths) ? (data.image_paths as string[]) : []
+        const raw = Array.isArray(data.image_paths) ? data.image_paths : []
+        const paths = raw.filter((p): p is string => typeof p === 'string')
         if (paths.length > 0) {
           try {
             const urls = await getFeedbackImageUrls(paths)

--- a/apps/web/src/pages/admin/AdminFeedbackDetailPage.tsx
+++ b/apps/web/src/pages/admin/AdminFeedbackDetailPage.tsx
@@ -1,21 +1,23 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
-import { AlertCircle, ArrowLeft, Loader2 } from 'lucide-react'
+import { AlertCircle, ArrowLeft, ImageIcon, Loader2 } from 'lucide-react'
 import { useAuth } from '../../contexts/AuthContext'
 import { AdminLayout } from '../../features/admin/components/AdminLayout'
 import { FeedbackNoteForm } from '../../features/admin/components/FeedbackNoteForm'
 import { FeedbackStatusForm } from '../../features/admin/components/FeedbackStatusForm'
 import { FeedbackUserInfo } from '../../features/admin/components/FeedbackUserInfo'
+import { ImageLightbox } from '../../features/admin/components/ImageLightbox'
 import { formatJstDateTime } from '../../lib/dateFormat'
 import { useDocumentTitle } from '../../hooks/useDocumentTitle'
 import {
   FEEDBACK_CATEGORY_LABELS,
   FEEDBACK_STATUS_LABELS,
   getFeedback,
+  getFeedbackImageUrls,
   isFeedbackCategory,
   isFeedbackStatus,
 } from '../../services/feedbackService'
-import type { UserFeedback } from '../../services/feedbackService'
+import type { FeedbackImageUrl, UserFeedback } from '../../services/feedbackService'
 import { CATEGORY_BADGE_CLASSES, STATUS_BADGE_CLASSES } from '../../features/feedback/feedbackBadge'
 
 // ─── Badge helpers ──────────────────────────────────────────────────────────
@@ -67,6 +69,11 @@ export function AdminFeedbackDetailPage() {
   const [notFound, setNotFound] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
 
+  const [imageUrls, setImageUrls] = useState<FeedbackImageUrl[]>([])
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null)
+
+  const closeLightbox = useCallback(() => setLightboxIndex(null), [])
+
   useEffect(() => {
     if (!id) {
       setNotFound(true)
@@ -86,6 +93,17 @@ export function AdminFeedbackDetailPage() {
           return
         }
         setFeedback(data)
+
+        // image_paths がある場合は signed URL を取得
+        const paths = Array.isArray(data.image_paths) ? (data.image_paths as string[]) : []
+        if (paths.length > 0) {
+          try {
+            const urls = await getFeedbackImageUrls(paths)
+            if (isMounted) setImageUrls(urls)
+          } catch {
+            // 画像 URL 取得失敗はフィードバック表示をブロックしない
+          }
+        }
       } catch (e) {
         if (!isMounted) return
         setLoadError(e instanceof Error ? e.message : 'フィードバックの取得に失敗しました')
@@ -153,6 +171,33 @@ export function AdminFeedbackDetailPage() {
             </pre>
           </section>
 
+          {/* Images */}
+          {imageUrls.length > 0 && (
+            <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+              <h2 className="mb-3 flex items-center gap-1.5 text-sm font-semibold text-slate-700">
+                <ImageIcon className="h-4 w-4" aria-hidden="true" />
+                添付画像（{imageUrls.length}枚）
+              </h2>
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                {imageUrls.map((img, i) => (
+                  <button
+                    key={img.path}
+                    type="button"
+                    onClick={() => setLightboxIndex(i)}
+                    className="group relative aspect-video overflow-hidden rounded-lg border border-slate-200 bg-slate-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    aria-label={`添付画像 ${i + 1} を拡大`}
+                  >
+                    <img
+                      src={img.url}
+                      alt={`添付画像 ${i + 1}`}
+                      className="h-full w-full object-cover transition-transform group-hover:scale-105"
+                    />
+                  </button>
+                ))}
+              </div>
+            </section>
+          )}
+
           <FeedbackUserInfo userId={feedback.user_id} />
 
           {/* Meta info */}
@@ -191,6 +236,16 @@ export function AdminFeedbackDetailPage() {
           )}
         </div>
       </div>
+
+      {/* Lightbox */}
+      {lightboxIndex !== null && (
+        <ImageLightbox
+          images={imageUrls}
+          currentIndex={lightboxIndex}
+          onClose={closeLightbox}
+          onChangeIndex={setLightboxIndex}
+        />
+      )}
     </AdminLayout>
   )
 }

--- a/apps/web/src/pages/admin/__tests__/AdminFeedbackDetailPage.test.tsx
+++ b/apps/web/src/pages/admin/__tests__/AdminFeedbackDetailPage.test.tsx
@@ -1,0 +1,184 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// ─── Mocks ──────────────────────────────────────────────────────
+
+const mockAuth = vi.hoisted(() => ({
+  value: {
+    user: { id: 'admin-1' } as { id: string } | null,
+    isLoadingAuth: false,
+    isAdmin: true,
+  },
+}))
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => mockAuth.value,
+}))
+
+vi.mock('../../../hooks/useDocumentTitle', () => ({
+  useDocumentTitle: () => undefined,
+}))
+
+vi.mock('../../../features/admin/components/AdminLayout', () => ({
+  AdminLayout: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="admin-layout">{children}</div>
+  ),
+}))
+
+vi.mock('../../../features/admin/components/FeedbackUserInfo', () => ({
+  FeedbackUserInfo: ({ userId }: { userId: string }) => (
+    <div data-testid="user-info">{userId}</div>
+  ),
+}))
+
+vi.mock('../../../features/admin/components/FeedbackStatusForm', () => ({
+  FeedbackStatusForm: () => <div data-testid="status-form" />,
+}))
+
+vi.mock('../../../features/admin/components/FeedbackNoteForm', () => ({
+  FeedbackNoteForm: () => <div data-testid="note-form" />,
+}))
+
+const getFeedbackMock = vi.hoisted(() => vi.fn())
+const getFeedbackImageUrlsMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../services/feedbackService', async () => {
+  const actual = await vi.importActual<typeof import('../../../services/feedbackService')>(
+    '../../../services/feedbackService',
+  )
+  return {
+    ...actual,
+    getFeedback: (...args: unknown[]) => getFeedbackMock(...args),
+    getFeedbackImageUrls: (...args: unknown[]) => getFeedbackImageUrlsMock(...args),
+  }
+})
+
+import { AdminFeedbackDetailPage } from '../AdminFeedbackDetailPage'
+
+// ─── Helpers ────────────────────────────────────────────────────
+
+const FEEDBACK_ID = '33333333-3333-3333-3333-333333333333'
+
+const baseFeedback = {
+  id: FEEDBACK_ID,
+  user_id: '11111111-1111-1111-1111-111111111111',
+  category: 'bug',
+  status: 'new',
+  message: 'テストメッセージ',
+  page_url: '/dashboard',
+  user_agent: 'Mozilla/5.0',
+  admin_note: null,
+  image_paths: [],
+  created_at: '2026-04-20T12:00:00Z',
+  updated_at: '2026-04-20T12:00:00Z',
+}
+
+function renderPage(feedbackId = FEEDBACK_ID) {
+  return render(
+    <MemoryRouter initialEntries={[`/admin/feedback/${feedbackId}`]}>
+      <Routes>
+        <Route path="/admin/feedback/:id" element={<AdminFeedbackDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+// ─── Tests ──────────────────────────────────────────────────────
+
+afterEach(() => {
+  cleanup()
+  mockAuth.value = { user: { id: 'admin-1' }, isLoadingAuth: false, isAdmin: true }
+})
+
+beforeEach(() => {
+  getFeedbackMock.mockReset()
+  getFeedbackImageUrlsMock.mockReset()
+})
+
+describe('AdminFeedbackDetailPage', () => {
+  it('読み込み中はスピナーを表示する', () => {
+    getFeedbackMock.mockReturnValue(new Promise(() => {})) // never resolves
+    renderPage()
+    expect(screen.getByLabelText('読み込み中')).toBeTruthy()
+  })
+
+  it('フィードバック詳細を表示する', async () => {
+    getFeedbackMock.mockResolvedValue(baseFeedback)
+    renderPage()
+
+    expect(await screen.findByText('テストメッセージ')).toBeTruthy()
+    expect(screen.getByText('フィードバック詳細')).toBeTruthy()
+  })
+
+  it('画像がない場合は画像セクションを表示しない', async () => {
+    getFeedbackMock.mockResolvedValue({ ...baseFeedback, image_paths: [] })
+    renderPage()
+
+    await screen.findByText('テストメッセージ')
+    expect(screen.queryByText(/添付画像/)).toBeNull()
+  })
+
+  it('画像がある場合はサムネイルを表示する', async () => {
+    getFeedbackMock.mockResolvedValue({
+      ...baseFeedback,
+      image_paths: ['uid/fid/a.png', 'uid/fid/b.jpg'],
+    })
+    getFeedbackImageUrlsMock.mockResolvedValue([
+      { path: 'uid/fid/a.png', url: 'https://example.com/a.png' },
+      { path: 'uid/fid/b.jpg', url: 'https://example.com/b.jpg' },
+    ])
+    renderPage()
+
+    await waitFor(() => {
+      expect(screen.getByText(/添付画像（2枚）/)).toBeTruthy()
+    })
+    expect(screen.getByAltText('添付画像 1').getAttribute('src')).toBe('https://example.com/a.png')
+    expect(screen.getByAltText('添付画像 2').getAttribute('src')).toBe('https://example.com/b.jpg')
+  })
+
+  it('サムネイルクリックで Lightbox が開く', async () => {
+    getFeedbackMock.mockResolvedValue({
+      ...baseFeedback,
+      image_paths: ['uid/fid/a.png'],
+    })
+    getFeedbackImageUrlsMock.mockResolvedValue([
+      { path: 'uid/fid/a.png', url: 'https://example.com/a.png' },
+    ])
+    renderPage()
+
+    const thumb = await screen.findByRole('button', { name: '添付画像 1 を拡大' })
+    fireEvent.click(thumb)
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog', { name: '画像プレビュー' })).toBeTruthy()
+    })
+  })
+
+  it('画像 URL 取得失敗でもフィードバック詳細は表示される', async () => {
+    getFeedbackMock.mockResolvedValue({
+      ...baseFeedback,
+      image_paths: ['uid/fid/a.png'],
+    })
+    getFeedbackImageUrlsMock.mockRejectedValue(new Error('access denied'))
+    renderPage()
+
+    expect(await screen.findByText('テストメッセージ')).toBeTruthy()
+    expect(screen.queryByText(/添付画像/)).toBeNull()
+  })
+
+  it('フィードバックが見つからない場合はメッセージを表示する', async () => {
+    getFeedbackMock.mockResolvedValue(null)
+    renderPage()
+
+    expect(await screen.findByText('フィードバックが見つかりません')).toBeTruthy()
+  })
+
+  it('取得エラーはアラートを表示する', async () => {
+    getFeedbackMock.mockRejectedValue(new Error('rls violation'))
+    renderPage()
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('rls violation')
+  })
+})

--- a/apps/web/src/services/__tests__/feedbackService.test.ts
+++ b/apps/web/src/services/__tests__/feedbackService.test.ts
@@ -3,6 +3,7 @@ import {
   FEEDBACK_CATEGORIES,
   FEEDBACK_STATUSES,
   getFeedback,
+  getFeedbackImageUrls,
   listFeedback,
   submitFeedback,
   updateFeedbackNote,
@@ -111,6 +112,10 @@ function createAuditLogBuilder() {
 const storageState = {
   uploadCalls: [] as Array<{ path: string; file: File; options: Record<string, unknown> }>,
   uploadResult: { error: null as unknown },
+  signedUrlsResult: {
+    data: null as Array<{ path: string; signedUrl: string }> | null,
+    error: null as unknown,
+  },
 }
 
 const storageUpload = vi.fn((path: string, file: File, options: Record<string, unknown>) => {
@@ -118,9 +123,14 @@ const storageUpload = vi.fn((path: string, file: File, options: Record<string, u
   return Promise.resolve({ data: { path }, error: storageState.uploadResult.error })
 })
 
+const storageCreateSignedUrls = vi.fn(() => {
+  return Promise.resolve(storageState.signedUrlsResult)
+})
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const storageFrom = vi.fn((_bucket: string) => ({
   upload: storageUpload,
+  createSignedUrls: storageCreateSignedUrls,
 }))
 
 const from = vi.fn((table: string) => {
@@ -159,6 +169,7 @@ function resetState() {
   auditLogState.insertResult = { error: null }
   storageState.uploadCalls = []
   storageState.uploadResult = { error: null }
+  storageState.signedUrlsResult = { data: null, error: null }
 }
 
 describe('FEEDBACK_CATEGORIES / FEEDBACK_STATUSES', () => {
@@ -580,5 +591,51 @@ describe('submitFeedback with files', () => {
 
     expect(storageState.uploadCalls).toHaveLength(0)
     expect(userFeedbackState.updatePayload).toBeNull()
+  })
+})
+
+// ─── getFeedbackImageUrls ──────────────────────────────────
+
+describe('getFeedbackImageUrls', () => {
+  beforeEach(resetState)
+
+  it('空配列を渡すと空配列を返す（API を呼ばない）', async () => {
+    const result = await getFeedbackImageUrls([])
+    expect(result).toEqual([])
+    expect(storageCreateSignedUrls).not.toHaveBeenCalled()
+  })
+
+  it('paths に対する signed URL の配列を返す', async () => {
+    storageState.signedUrlsResult = {
+      data: [
+        { path: 'uid/fid/a.png', signedUrl: 'https://example.com/signed/a' },
+        { path: 'uid/fid/b.jpg', signedUrl: 'https://example.com/signed/b' },
+      ],
+      error: null,
+    }
+    const result = await getFeedbackImageUrls(['uid/fid/a.png', 'uid/fid/b.jpg'])
+
+    expect(storageFrom).toHaveBeenCalledWith('feedback-images')
+    expect(storageCreateSignedUrls).toHaveBeenCalledWith(
+      ['uid/fid/a.png', 'uid/fid/b.jpg'],
+      3600,
+    )
+    expect(result).toEqual([
+      { path: 'uid/fid/a.png', url: 'https://example.com/signed/a' },
+      { path: 'uid/fid/b.jpg', url: 'https://example.com/signed/b' },
+    ])
+  })
+
+  it('Storage エラー時にアプリ共通エラーを投げる', async () => {
+    storageState.signedUrlsResult = {
+      data: null,
+      error: { message: 'access denied' },
+    }
+    await expect(
+      getFeedbackImageUrls(['uid/fid/a.png']),
+    ).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: '画像 URL の生成に失敗しました',
+    })
   })
 })

--- a/apps/web/src/services/__tests__/feedbackService.test.ts
+++ b/apps/web/src/services/__tests__/feedbackService.test.ts
@@ -7,6 +7,8 @@ import {
   submitFeedback,
   updateFeedbackNote,
   updateFeedbackStatus,
+  uploadFeedbackImages,
+  validateImageFiles,
 } from '../feedbackService'
 
 // Supabase chain mocks. 単一テーブルごとにビルダーを返す `from` を作成する。
@@ -106,6 +108,21 @@ function createAuditLogBuilder() {
   }
 }
 
+const storageState = {
+  uploadCalls: [] as Array<{ path: string; file: File; options: Record<string, unknown> }>,
+  uploadResult: { error: null as unknown },
+}
+
+const storageUpload = vi.fn((path: string, file: File, options: Record<string, unknown>) => {
+  storageState.uploadCalls.push({ path, file, options })
+  return Promise.resolve({ data: { path }, error: storageState.uploadResult.error })
+})
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const storageFrom = vi.fn((_bucket: string) => ({
+  upload: storageUpload,
+}))
+
 const from = vi.fn((table: string) => {
   if (table === 'user_feedback') return createUserFeedbackBuilder()
   if (table === 'admin_audit_log') return createAuditLogBuilder()
@@ -115,6 +132,9 @@ const from = vi.fn((table: string) => {
 vi.mock('../../lib/supabaseClient', () => ({
   supabase: {
     from: (...args: unknown[]) => from(...(args as [string])),
+    storage: {
+      from: (...args: unknown[]) => storageFrom(...(args as [string])),
+    },
   },
 }))
 
@@ -137,6 +157,8 @@ function resetState() {
   userFeedbackState.limitCalls = []
   auditLogState.lastInsertPayload = null
   auditLogState.insertResult = { error: null }
+  storageState.uploadCalls = []
+  storageState.uploadResult = { error: null }
 }
 
 describe('FEEDBACK_CATEGORIES / FEEDBACK_STATUSES', () => {
@@ -434,5 +456,129 @@ describe('updateFeedbackNote', () => {
       userMessage: 'フィードバックのメモ更新に失敗しました',
     })
     expect(auditLogState.lastInsertPayload).toBeNull()
+  })
+})
+
+// ─── 画像バリデーション・アップロード ─────────────────────
+
+function createTestFile(name: string, size: number, type = 'image/png'): File {
+  const buf = new ArrayBuffer(size)
+  return new File([buf], name, { type })
+}
+
+describe('validateImageFiles', () => {
+  it('空配列は正常に通過する', () => {
+    expect(() => validateImageFiles([])).not.toThrow()
+  })
+
+  it('3枚以下の画像は正常に通過する', () => {
+    const files = [
+      createTestFile('a.png', 1024),
+      createTestFile('b.jpg', 2048),
+      createTestFile('c.gif', 512),
+    ]
+    expect(() => validateImageFiles(files)).not.toThrow()
+  })
+
+  it('4枚以上で例外を投げる', () => {
+    const files = Array.from({ length: 4 }, (_, i) => createTestFile(`${i}.png`, 100))
+    expect(() => validateImageFiles(files)).toThrow('画像は最大 3 枚まで添付できます')
+  })
+
+  it('5MB超過のファイルで例外を投げる', () => {
+    const big = createTestFile('huge.png', 6 * 1024 * 1024)
+    expect(() => validateImageFiles([big])).toThrow('huge.png のサイズが上限（5MB）を超えています')
+  })
+
+  it('image/* 以外の MIME タイプで例外を投げる', () => {
+    const pdf = createTestFile('doc.pdf', 1024, 'application/pdf')
+    expect(() => validateImageFiles([pdf])).toThrow('doc.pdf は画像ファイルではありません')
+  })
+})
+
+describe('uploadFeedbackImages', () => {
+  beforeEach(resetState)
+
+  it('Storage にアップロードしパスの配列を返す', async () => {
+    const files = [createTestFile('a.png', 100), createTestFile('b.jpg', 200, 'image/jpeg')]
+    const paths = await uploadFeedbackImages(VALID_USER_ID, VALID_FEEDBACK_ID, files)
+
+    expect(storageFrom).toHaveBeenCalledWith('feedback-images')
+    expect(storageState.uploadCalls).toHaveLength(2)
+    expect(storageState.uploadCalls[0]!.path).toMatch(
+      new RegExp(`^${VALID_USER_ID}/${VALID_FEEDBACK_ID}/\\d+_a\\.png$`),
+    )
+    expect(storageState.uploadCalls[1]!.options).toEqual({ contentType: 'image/jpeg' })
+    expect(paths).toHaveLength(2)
+    expect(paths[0]).toContain(VALID_USER_ID)
+  })
+
+  it('ファイル名の特殊文字をアンダースコアに置換する', async () => {
+    const files = [createTestFile('スクショ (1).png', 100)]
+    await uploadFeedbackImages(VALID_USER_ID, VALID_FEEDBACK_ID, files)
+    const uploaded = storageState.uploadCalls[0]!.path
+    expect(uploaded).not.toMatch(/[^a-zA-Z0-9._\-/]/)
+  })
+
+  it('Storage エラー時にアプリ共通エラーを投げる', async () => {
+    storageState.uploadResult = { error: { message: 'bucket not found' } }
+    const files = [createTestFile('fail.png', 100)]
+    await expect(
+      uploadFeedbackImages(VALID_USER_ID, VALID_FEEDBACK_ID, files),
+    ).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: '画像「fail.png」のアップロードに失敗しました',
+    })
+  })
+})
+
+describe('submitFeedback with files', () => {
+  beforeEach(resetState)
+
+  it('画像付き送信で INSERT → Storage アップロード → UPDATE の順に実行する', async () => {
+    const feedbackRow = {
+      id: VALID_FEEDBACK_ID,
+      user_id: VALID_USER_ID,
+      category: 'bug',
+      message: 'hello',
+      status: 'new',
+      image_paths: [],
+    }
+    userFeedbackState.insertResult = { data: feedbackRow, error: null }
+    userFeedbackState.updateResult = {
+      data: { ...feedbackRow, image_paths: ['path/a.png'] },
+      error: null,
+    }
+
+    const files = [createTestFile('screenshot.png', 1024)]
+    const result = await submitFeedback({
+      userId: VALID_USER_ID,
+      category: 'bug',
+      message: 'hello',
+      files,
+    })
+
+    // INSERT が呼ばれている
+    expect(userFeedbackState.insertPayload).not.toBeNull()
+    // Storage アップロードが呼ばれている
+    expect(storageState.uploadCalls).toHaveLength(1)
+    // UPDATE で image_paths が設定されている
+    expect(userFeedbackState.updatePayload).toHaveProperty('image_paths')
+    expect(result.image_paths).toEqual(['path/a.png'])
+  })
+
+  it('画像なし送信では Storage アップロードも UPDATE も呼ばない', async () => {
+    userFeedbackState.insertResult = {
+      data: { id: VALID_FEEDBACK_ID, image_paths: [] },
+      error: null,
+    }
+    await submitFeedback({
+      userId: VALID_USER_ID,
+      category: 'bug',
+      message: 'hello',
+    })
+
+    expect(storageState.uploadCalls).toHaveLength(0)
+    expect(userFeedbackState.updatePayload).toBeNull()
   })
 })

--- a/apps/web/src/services/__tests__/feedbackService.test.ts
+++ b/apps/web/src/services/__tests__/feedbackService.test.ts
@@ -517,7 +517,7 @@ describe('uploadFeedbackImages', () => {
     expect(storageFrom).toHaveBeenCalledWith('feedback-images')
     expect(storageState.uploadCalls).toHaveLength(2)
     expect(storageState.uploadCalls[0]!.path).toMatch(
-      new RegExp(`^${VALID_USER_ID}/${VALID_FEEDBACK_ID}/\\d+_a\\.png$`),
+      new RegExp(`^${VALID_USER_ID}/${VALID_FEEDBACK_ID}/\\d+_0_a\\.png$`),
     )
     expect(storageState.uploadCalls[1]!.options).toEqual({ contentType: 'image/jpeg' })
     expect(paths).toHaveLength(2)

--- a/apps/web/src/services/feedbackService.ts
+++ b/apps/web/src/services/feedbackService.ts
@@ -190,25 +190,26 @@ export async function uploadFeedbackImages(
   feedbackId: string,
   files: File[],
 ): Promise<string[]> {
-  const paths: string[] = []
+  const now = Date.now()
 
-  for (const file of files) {
-    // ファイル名の衝突を避けるため timestamp を付与
-    const safeName = `${Date.now()}_${file.name.replace(/[^a-zA-Z0-9._-]/g, '_')}`
-    const path = `${userId}/${feedbackId}/${safeName}`
+  const paths = await Promise.all(
+    files.map(async (file, index) => {
+      const safeName = `${now}_${index}_${file.name.replace(/[^a-zA-Z0-9._-]/g, '_')}`
+      const path = `${userId}/${feedbackId}/${safeName}`
 
-    const { error } = await supabase.storage
-      .from(FEEDBACK_IMAGES_BUCKET)
-      .upload(path, file, { contentType: file.type })
+      const { error } = await supabase.storage
+        .from(FEEDBACK_IMAGES_BUCKET)
+        .upload(path, file, { contentType: file.type })
 
-    if (error) {
-      throw fromSupabaseError(
-        { code: 'STORAGE_ERROR', message: error.message },
-        `画像「${file.name}」のアップロードに失敗しました`,
-      )
-    }
-    paths.push(path)
-  }
+      if (error) {
+        throw fromSupabaseError(
+          { code: 'STORAGE_ERROR', message: error.message },
+          `画像「${file.name}」のアップロードに失敗しました`,
+        )
+      }
+      return path
+    }),
+  )
 
   return paths
 }

--- a/apps/web/src/services/feedbackService.ts
+++ b/apps/web/src/services/feedbackService.ts
@@ -339,6 +339,41 @@ export async function updateFeedbackNote(
   return data
 }
 
+// ─── 画像 URL ────────────────────────────────────────────
+
+/** signed URL の有効期限（秒）: 1 時間 */
+const SIGNED_URL_EXPIRES_IN = 3600
+
+export interface FeedbackImageUrl {
+  path: string
+  url: string
+}
+
+/**
+ * image_paths から signed URL を一括生成する（admin 向け）。
+ * Storage RLS `feedback_images_select_admin` により admin のみ全画像を閲覧可能。
+ */
+export async function getFeedbackImageUrls(
+  paths: string[],
+): Promise<FeedbackImageUrl[]> {
+  if (paths.length === 0) return []
+
+  const { data, error } = await supabase.storage
+    .from(FEEDBACK_IMAGES_BUCKET)
+    .createSignedUrls(paths, SIGNED_URL_EXPIRES_IN)
+
+  if (error) {
+    throw fromSupabaseError(
+      { code: 'STORAGE_ERROR', message: error.message },
+      '画像 URL の生成に失敗しました',
+    )
+  }
+
+  return (data ?? [])
+    .filter((item) => item.signedUrl)
+    .map((item) => ({ path: item.path ?? '', url: item.signedUrl }))
+}
+
 // ─── ユーティリティ ──────────────────────────────────────
 
 /** 現在のページ情報から送信元メタデータを取得する（クライアント専用） */

--- a/apps/web/src/services/feedbackService.ts
+++ b/apps/web/src/services/feedbackService.ts
@@ -44,6 +44,13 @@ export const FEEDBACK_STATUS_LABELS: Record<FeedbackStatus, string> = {
   archived: 'アーカイブ',
 }
 
+/** 添付画像の最大枚数 */
+export const MAX_IMAGE_COUNT = 3
+/** 添付画像の最大サイズ（5 MB） */
+export const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024
+/** Storage バケット名 */
+export const FEEDBACK_IMAGES_BUCKET = 'feedback-images'
+
 /** 本文の最大文字数（DB 側制約 4000 と一致させる） */
 export const MAX_FEEDBACK_MESSAGE_LENGTH = 4000
 /** page_url の最大文字数（長大な URL で DB を肥大化させないため短めに丸める） */
@@ -92,6 +99,8 @@ export interface SubmitFeedbackInput {
   message: string
   pageUrl?: string | null
   userAgent?: string | null
+  /** 添付する画像ファイル（最大3枚、各5MB以下） */
+  files?: File[]
 }
 
 /**
@@ -109,9 +118,14 @@ export async function submitFeedback(input: SubmitFeedbackInput): Promise<UserFe
   }
   assertMaxLength(trimmedMessage, MAX_FEEDBACK_MESSAGE_LENGTH, 'message')
 
+  // 画像バリデーション
+  const files = input.files ?? []
+  validateImageFiles(files)
+
   const normalizedPageUrl = normalizeOptionalText(input.pageUrl, MAX_PAGE_URL_LENGTH)
   const normalizedUserAgent = normalizeOptionalText(input.userAgent, MAX_USER_AGENT_LENGTH)
 
+  // 1. feedback レコードを INSERT
   const { data, error } = await supabase
     .from('user_feedback')
     .insert({
@@ -128,7 +142,75 @@ export async function submitFeedback(input: SubmitFeedbackInput): Promise<UserFe
     throw fromSupabaseError(error, 'フィードバックの送信に失敗しました')
   }
 
+  // 2. 画像があれば Storage にアップロードし image_paths を UPDATE
+  if (files.length > 0) {
+    const paths = await uploadFeedbackImages(input.userId, data.id, files)
+    const { data: updated, error: updateError } = await supabase
+      .from('user_feedback')
+      .update({ image_paths: paths as Json[] })
+      .eq('id', data.id)
+      .select()
+      .single()
+
+    if (updateError) {
+      throw fromSupabaseError(updateError, '画像パスの保存に失敗しました')
+    }
+    return updated
+  }
+
   return data
+}
+
+/**
+ * 画像ファイルのバリデーション。
+ * - 枚数: MAX_IMAGE_COUNT 以下
+ * - 各ファイルサイズ: MAX_IMAGE_SIZE_BYTES 以下
+ * - MIME タイプ: image/* のみ
+ */
+export function validateImageFiles(files: File[]): void {
+  if (files.length > MAX_IMAGE_COUNT) {
+    throw new Error(`画像は最大 ${MAX_IMAGE_COUNT} 枚まで添付できます`)
+  }
+  for (const file of files) {
+    if (file.size > MAX_IMAGE_SIZE_BYTES) {
+      throw new Error(`${file.name} のサイズが上限（5MB）を超えています`)
+    }
+    if (!file.type.startsWith('image/')) {
+      throw new Error(`${file.name} は画像ファイルではありません`)
+    }
+  }
+}
+
+/**
+ * Storage にフィードバック画像をアップロードし、保存パスの配列を返す。
+ * パス構造: {userId}/{feedbackId}/{filename}
+ */
+export async function uploadFeedbackImages(
+  userId: string,
+  feedbackId: string,
+  files: File[],
+): Promise<string[]> {
+  const paths: string[] = []
+
+  for (const file of files) {
+    // ファイル名の衝突を避けるため timestamp を付与
+    const safeName = `${Date.now()}_${file.name.replace(/[^a-zA-Z0-9._-]/g, '_')}`
+    const path = `${userId}/${feedbackId}/${safeName}`
+
+    const { error } = await supabase.storage
+      .from(FEEDBACK_IMAGES_BUCKET)
+      .upload(path, file, { contentType: file.type })
+
+    if (error) {
+      throw fromSupabaseError(
+        { code: 'STORAGE_ERROR', message: error.message },
+        `画像「${file.name}」のアップロードに失敗しました`,
+      )
+    }
+    paths.push(path)
+  }
+
+  return paths
 }
 
 function normalizeOptionalText(value: string | null | undefined, maxLength: number): string | null {

--- a/apps/web/src/shared/types/database.types.ts
+++ b/apps/web/src/shared/types/database.types.ts
@@ -173,6 +173,7 @@ export type Database = {
           category: string
           created_at: string
           id: string
+          image_paths: Json
           message: string
           page_url: string | null
           status: string
@@ -185,6 +186,7 @@ export type Database = {
           category: string
           created_at?: string
           id?: string
+          image_paths?: Json
           message: string
           page_url?: string | null
           status?: string
@@ -197,6 +199,7 @@ export type Database = {
           category?: string
           created_at?: string
           id?: string
+          image_paths?: Json
           message?: string
           page_url?: string | null
           status?: string

--- a/apps/web/supabase/sql/013_admin_and_feedback.sql
+++ b/apps/web/supabase/sql/013_admin_and_feedback.sql
@@ -67,6 +67,12 @@ create policy user_feedback_insert_own on public.user_feedback
   for insert
   with check (auth.uid() = user_id);
 
+-- 本人は自分のフィードバックを SELECT できる（INSERT 後の returning に必要）
+drop policy if exists user_feedback_select_own on public.user_feedback;
+create policy user_feedback_select_own on public.user_feedback
+  for select
+  using (auth.uid() = user_id);
+
 -- admin は全件 SELECT できる
 drop policy if exists user_feedback_select_admin on public.user_feedback;
 create policy user_feedback_select_admin on public.user_feedback

--- a/apps/web/supabase/sql/018_auto_create_profile_trigger.sql
+++ b/apps/web/supabase/sql/018_auto_create_profile_trigger.sql
@@ -1,0 +1,55 @@
+-- Issue #254: サインアップ時に profiles レコードを自動作成するトリガー + 既存ユーザー補完
+--
+-- 構成:
+--   1. handle_new_user() トリガー関数（SECURITY DEFINER で RLS をバイパス）
+--   2. auth.users AFTER INSERT トリガー
+--   3. 既存ユーザーの profiles 一括補完
+
+-- =========================================================================
+-- 1. トリガー関数
+--    auth.users に新規行が挿入されたときに profiles を自動作成する。
+--    SECURITY DEFINER にすることで RLS の INSERT ポリシーをバイパスする。
+-- =========================================================================
+
+create or replace function public.handle_new_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.profiles (id, display_name, is_admin, created_at)
+  values (
+    new.id,
+    coalesce(new.raw_user_meta_data ->> 'display_name', null),
+    false,
+    now()
+  )
+  on conflict (id) do nothing;
+  return new;
+end;
+$$;
+
+-- =========================================================================
+-- 2. トリガー定義
+-- =========================================================================
+
+drop trigger if exists on_auth_user_created on auth.users;
+create trigger on_auth_user_created
+  after insert on auth.users
+  for each row execute function public.handle_new_user();
+
+-- =========================================================================
+-- 3. 既存ユーザーの profiles 一括補完
+--    auth.users に存在するが profiles に行がないユーザーを補完する。
+-- =========================================================================
+
+insert into public.profiles (id, display_name, is_admin, created_at)
+select
+  au.id,
+  null,
+  false,
+  au.created_at
+from auth.users au
+left join public.profiles p on p.id = au.id
+where p.id is null;

--- a/apps/web/supabase/sql/019_feedback_images.sql
+++ b/apps/web/supabase/sql/019_feedback_images.sql
@@ -1,0 +1,66 @@
+-- 019_feedback_images.sql
+-- user_feedback にスクリーンショット添付機能を追加する。
+-- 1) image_paths jsonb 列を追加
+-- 2) feedback-images Storage バケットを作成
+-- 3) Storage RLS ポリシーを設定
+
+-- ─── 1. user_feedback.image_paths 列追加 ───────────────────────────
+ALTER TABLE public.user_feedback
+  ADD COLUMN IF NOT EXISTS image_paths jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+COMMENT ON COLUMN public.user_feedback.image_paths
+  IS '添付画像のパス配列（最大3枚）。形式: ["user_id/feedback_id/filename", ...]';
+
+-- ─── 2. Storage バケット作成 ────────────────────────────────────────
+-- private バケット（signed URL 経由でのみアクセス可能）
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('feedback-images', 'feedback-images', false)
+ON CONFLICT (id) DO NOTHING;
+
+-- ─── 3. Storage RLS ポリシー ───────────────────────────────────────
+
+-- 3a. INSERT: 認証済みユーザーが自分のディレクトリにのみアップロード可能
+--     パス構造: {user_id}/{feedback_id}/{filename}
+--     → path の先頭セグメントが auth.uid() と一致することを検証
+CREATE POLICY "feedback_images_insert_own"
+  ON storage.objects
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'feedback-images'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- 3b. SELECT: 自分のファイルのみ閲覧可能（一般ユーザー）
+CREATE POLICY "feedback_images_select_own"
+  ON storage.objects
+  FOR SELECT
+  TO authenticated
+  USING (
+    bucket_id = 'feedback-images'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- 3c. SELECT: admin は全ファイル閲覧可能
+CREATE POLICY "feedback_images_select_admin"
+  ON storage.objects
+  FOR SELECT
+  TO authenticated
+  USING (
+    bucket_id = 'feedback-images'
+    AND EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE profiles.id = auth.uid()
+        AND profiles.is_admin = true
+    )
+  );
+
+-- 3d. DELETE: 自分のファイルのみ削除可能（アップロード取り消し用）
+CREATE POLICY "feedback_images_delete_own"
+  ON storage.objects
+  FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'feedback-images'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );

--- a/apps/web/supabase/sql/019_feedback_images.sql
+++ b/apps/web/supabase/sql/019_feedback_images.sql
@@ -11,6 +11,16 @@ ALTER TABLE public.user_feedback
 COMMENT ON COLUMN public.user_feedback.image_paths
   IS '添付画像のパス配列（最大3枚）。形式: ["user_id/feedback_id/filename", ...]';
 
+-- ─── 1b. 本人が自分の feedback の image_paths を UPDATE できるポリシー ──
+-- 既存の UPDATE ポリシーは admin のみ。一般ユーザーが画像アップロード後に
+-- image_paths を書き込むために必要。
+CREATE POLICY "user_feedback_update_own_images"
+  ON public.user_feedback
+  FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
 -- ─── 2. Storage バケット作成 ────────────────────────────────────────
 -- private バケット（signed URL 経由でのみアクセス可能）
 INSERT INTO storage.buckets (id, name, public)


### PR DESCRIPTION
## Summary
- **#254**: サインアップ時に profiles レコードを自動作成するトリガーを追加
- **#256**: user_feedback に SELECT own ポリシーを追加し送信エラーを修正
- **#257-#259**: フィードバック UX 改善 M1-M3（FeedbackContext/FAB導線、スクリーンショット添付、管理画面画像表示）
- **#260-#266**: v4roadmap03 design-audit FAIL 7件修正（型ガード、ARIA属性、Promise.all並列化、コンポーネント分割）

## Test plan
- [x] typecheck pass
- [x] lint pass
- [x] test 829 pass
- [x] build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)