### PR TITLE
feat: 学習主導線を一本化

### DIFF
--- a/apps/web/src/contexts/LearningContext.tsx
+++ b/apps/web/src/contexts/LearningContext.tsx
@@ -1,10 +1,11 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useAuth } from './AuthContext'
 import { getLearningStats, type LearningStats } from '../services/statsService'
-import { getAllStepProgress, isStepCompleted } from '../services/progressService'
+import { getAllStepProgress, isStepCompleted, type StepProgressRow } from '../services/progressService'
 
 interface LearningContextType {
     stats: LearningStats | null
+    allStepProgress: readonly StepProgressRow[]
     completedStepIds: ReadonlySet<string>
     completedStepsCount: number
     isLoadingStats: boolean
@@ -12,9 +13,11 @@ interface LearningContextType {
 }
 
 const EMPTY_SET: ReadonlySet<string> = new Set()
+const EMPTY_PROGRESS: readonly StepProgressRow[] = []
 
 const LearningContext = createContext<LearningContextType>({
     stats: null,
+    allStepProgress: EMPTY_PROGRESS,
     completedStepIds: EMPTY_SET,
     completedStepsCount: 0,
     isLoadingStats: true,
@@ -24,6 +27,7 @@ const LearningContext = createContext<LearningContextType>({
 export function LearningProvider({ children }: { children: ReactNode }) {
     const { user } = useAuth()
     const [stats, setStats] = useState<LearningStats | null>(null)
+    const [allStepProgress, setAllStepProgress] = useState<readonly StepProgressRow[]>(EMPTY_PROGRESS)
     const [completedStepIds, setCompletedStepIds] = useState<ReadonlySet<string>>(EMPTY_SET)
     const [isLoadingStats, setIsLoadingStats] = useState(true)
     const isMountedRef = useRef(true)
@@ -40,6 +44,7 @@ export function LearningProvider({ children }: { children: ReactNode }) {
     const refreshStats = useCallback(async () => {
         if (!user) {
             setStats(null)
+            setAllStepProgress(EMPTY_PROGRESS)
             setCompletedStepIds(EMPTY_SET)
             setIsLoadingStats(false)
             return
@@ -52,6 +57,7 @@ export function LearningProvider({ children }: { children: ReactNode }) {
             ])
             if (!isMountedRef.current) return
             setStats(currentStats)
+            setAllStepProgress(progresses)
             const ids = new Set(
                 progresses.filter(isStepCompleted).map((p) => p.step_id),
             )
@@ -79,8 +85,8 @@ export function LearningProvider({ children }: { children: ReactNode }) {
     }, [refreshStats])
 
     const value = useMemo(
-        () => ({ stats, completedStepIds, completedStepsCount, isLoadingStats, refreshStats }),
-        [stats, completedStepIds, completedStepsCount, isLoadingStats, refreshStats],
+        () => ({ stats, allStepProgress, completedStepIds, completedStepsCount, isLoadingStats, refreshStats }),
+        [stats, allStepProgress, completedStepIds, completedStepsCount, isLoadingStats, refreshStats],
     )
 
     return (

--- a/apps/web/src/contexts/__tests__/LearningContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/LearningContext.test.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../AuthContext'
 import { getLearningStats } from '../../services/statsService'
 import { getAllStepProgress } from '../../services/progressService'
 import type { LearningStats } from '../../services/statsService'
+import type { StepProgressRow } from '../../services/progressService'
 import type { User } from '@supabase/supabase-js'
 
 // --- Mocks ---
@@ -33,6 +34,7 @@ const mockGetAllStepProgress = vi.mocked(getAllStepProgress)
 
 interface LearningContextType {
   stats: LearningStats | null
+  allStepProgress: readonly StepProgressRow[]
   completedStepIds: ReadonlySet<string>
   completedStepsCount: number
   isLoadingStats: boolean
@@ -112,6 +114,8 @@ describe('LearningContext', () => {
     })
 
     expect(captured!.stats).toEqual(fakeStats)
+    expect(captured!.allStepProgress).toHaveLength(3)
+    expect(captured!.allStepProgress[0]?.step_id).toBe('usestate-basic')
     expect(captured!.completedStepIds.has('usestate-basic')).toBe(true)
     expect(captured!.completedStepIds.has('events')).toBe(true)
     expect(captured!.completedStepIds.has('conditional')).toBe(false)
@@ -144,6 +148,7 @@ describe('LearningContext', () => {
     })
 
     expect(captured!.stats).toBeNull()
+    expect(captured!.allStepProgress).toHaveLength(0)
     expect(captured!.completedStepIds.size).toBe(0)
   })
 

--- a/apps/web/src/features/daily/components/PracticeModeNav.tsx
+++ b/apps/web/src/features/daily/components/PracticeModeNav.tsx
@@ -2,10 +2,10 @@ import { Link, useLocation } from 'react-router-dom'
 import { Zap, Stethoscope, FolderOpen, BookOpen } from 'lucide-react'
 
 const NAV_ITEMS = [
-  { path: '/daily', label: 'デイリー', icon: Zap },
-  { path: '/practice/code-doctor', label: 'ドクター', icon: Stethoscope },
-  { path: '/practice/mini-projects', label: 'ミニプロ', icon: FolderOpen },
-  { path: '/practice/code-reading', label: 'リーディング', icon: BookOpen },
+  { path: '/daily', label: 'デイリー', purpose: '昨日の復習', icon: Zap },
+  { path: '/practice/code-doctor', label: 'ドクター', purpose: 'バグ修正', icon: Stethoscope },
+  { path: '/practice/mini-projects', label: 'ミニプロ', purpose: '成果物作成', icon: FolderOpen },
+  { path: '/practice/code-reading', label: 'リーディング', purpose: 'コードを読む', icon: BookOpen },
 ]
 
 export function PracticeModeNav() {
@@ -19,22 +19,27 @@ export function PracticeModeNav() {
           練習モード
         </p>
         <ul className="space-y-1">
-          {NAV_ITEMS.map(({ path, label, icon: Icon }) => {
+          {NAV_ITEMS.map(({ path, label, purpose, icon: Icon }) => {
             const isActive = pathname === path || pathname.startsWith(path + '/')
             return (
               <li key={path}>
                 <Link
                   to={path}
                   className={[
-                    'flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
+                    'flex items-start gap-2 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
                     isActive
                       ? 'bg-amber-100 text-amber-700'
                       : 'text-text-muted hover:bg-bg-surface hover:text-text-dark',
                   ].join(' ')}
                   aria-current={isActive ? 'page' : undefined}
                 >
-                  <Icon size={16} aria-hidden="true" />
-                  {label}
+                  <Icon className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+                  <span className="min-w-0">
+                    <span className="block leading-tight">{label}</span>
+                    <span className={`mt-0.5 block text-[11px] leading-tight ${isActive ? 'text-amber-700/75' : 'text-slate-400'}`}>
+                      {purpose}
+                    </span>
+                  </span>
                 </Link>
               </li>
             )
@@ -44,22 +49,27 @@ export function PracticeModeNav() {
 
       {/* モバイル: セグメンテッドコントロール */}
       <nav className="mb-2 flex rounded-lg border border-slate-200 bg-white p-0.5 lg:hidden" aria-label="練習モード">
-        {NAV_ITEMS.map(({ path, label, icon: Icon }) => {
+        {NAV_ITEMS.map(({ path, label, purpose, icon: Icon }) => {
           const isActive = pathname === path || pathname.startsWith(path + '/')
           return (
             <Link
               key={path}
               to={path}
               className={[
-                'flex flex-1 items-center justify-center gap-0.5 rounded-md px-0.5 py-2 text-[11px] font-medium transition-colors',
+                'flex min-h-[48px] flex-1 flex-col items-center justify-center gap-0.5 rounded-md px-0.5 py-1.5 text-center text-[11px] font-medium transition-colors',
                 isActive
                   ? 'bg-amber-500 text-white shadow-sm'
                   : 'text-text-muted hover:text-amber-600',
               ].join(' ')}
               aria-current={isActive ? 'page' : undefined}
             >
-              <Icon size={12} aria-hidden="true" />
-              {label}
+              <span className="flex items-center justify-center gap-0.5">
+                <Icon size={12} aria-hidden="true" />
+                <span>{label}</span>
+              </span>
+              <span className={`text-[9px] leading-none ${isActive ? 'text-white/80' : 'text-slate-400'}`}>
+                {purpose}
+              </span>
             </Link>
           )
         })}

--- a/apps/web/src/features/daily/components/__tests__/PracticeModeNav.test.tsx
+++ b/apps/web/src/features/daily/components/__tests__/PracticeModeNav.test.tsx
@@ -24,6 +24,14 @@ describe('PracticeModeNav', () => {
     expect(screen.getAllByText('リーディング').length).toBeGreaterThanOrEqual(1)
   })
 
+  it('各練習モードの役割ラベルを表示する', () => {
+    renderWithRouter('/daily')
+    expect(screen.getAllByText('昨日の復習').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('バグ修正').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('成果物作成').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText('コードを読む').length).toBeGreaterThanOrEqual(1)
+  })
+
   it('現在のパスに対応するリンクがアクティブになる', () => {
     renderWithRouter('/daily')
     const activeLinks = screen.getAllByRole('link', { current: 'page' })

--- a/apps/web/src/features/dashboard/components/OnboardingCard.tsx
+++ b/apps/web/src/features/dashboard/components/OnboardingCard.tsx
@@ -1,0 +1,93 @@
+import { CheckCircle2, X } from 'lucide-react'
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+
+export const ONBOARDING_DISMISSED_KEY = 'coden_onboarding_dismissed'
+
+interface OnboardingCardProps {
+  startTo: string
+}
+
+function readDismissed(): boolean {
+  if (typeof window === 'undefined') return false
+
+  try {
+    return window.localStorage.getItem(ONBOARDING_DISMISSED_KEY) === 'true'
+  } catch {
+    return false
+  }
+}
+
+function persistDismissed() {
+  if (typeof window === 'undefined') return
+
+  try {
+    window.localStorage.setItem(ONBOARDING_DISMISSED_KEY, 'true')
+  } catch {
+    // localStorage が使えない環境でも画面内では閉じられるようにする
+  }
+}
+
+export function OnboardingCard({ startTo }: OnboardingCardProps) {
+  const [isDismissed, setIsDismissed] = useState(readDismissed)
+
+  function dismiss() {
+    persistDismissed()
+    setIsDismissed(true)
+  }
+
+  if (isDismissed) return null
+
+  return (
+    <section className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm sm:p-6" aria-labelledby="onboarding-title">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="text-sm font-bold text-primary-dark">はじめての方へ</p>
+          <h2 id="onboarding-title" className="mt-1 text-lg font-black text-slate-950">
+            4つの流れで1ステップずつ進めます
+          </h2>
+        </div>
+        <button
+          type="button"
+          className="grid h-9 w-9 shrink-0 place-items-center rounded-full text-slate-400 transition hover:bg-slate-100 hover:text-slate-600 focus:outline-none focus:ring-2 focus:ring-primary-mint/30"
+          aria-label="オンボーディングを閉じる"
+          onClick={dismiss}
+        >
+          <X className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+
+      <div className="mt-4 grid gap-2 text-sm text-slate-600">
+        <p className="flex gap-2">
+          <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary-mint" aria-hidden="true" />
+          Readで概念を読み、Practiceで手を動かします。
+        </p>
+        <p className="flex gap-2">
+          <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary-mint" aria-hidden="true" />
+          Testで理解を確認し、Challengeで自分のコードにします。
+        </p>
+        <p className="flex gap-2">
+          <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-primary-mint" aria-hidden="true" />
+          迷ったら「今日のおすすめ」から次の行動へ戻れます。
+        </p>
+      </div>
+
+      <div className="mt-5 flex flex-wrap items-center gap-3">
+        <Link
+          to={startTo}
+          className="inline-flex items-center justify-center rounded-xl bg-primary-mint px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-mint/30"
+          onClick={dismiss}
+        >
+          始める
+        </Link>
+        <button
+          type="button"
+          className="inline-flex items-center justify-center rounded-xl border border-slate-200 bg-white px-5 py-3 text-sm font-bold text-slate-600 transition hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-primary-mint/30"
+          onClick={dismiss}
+        >
+          閉じる
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/features/dashboard/components/TodayActionCard.tsx
+++ b/apps/web/src/features/dashboard/components/TodayActionCard.tsx
@@ -1,0 +1,52 @@
+import { ArrowRight, CheckCircle2, RotateCcw, Sparkles, Target } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import type { RecommendedAction, RecommendedActionType } from '../../../services/recommendationService'
+
+interface TodayActionCardProps {
+  action: RecommendedAction
+}
+
+const ACTION_META: Record<RecommendedActionType, { label: string; icon: typeof Target }> = {
+  review: { label: '復習', icon: RotateCcw },
+  resume: { label: '再開', icon: Target },
+  start: { label: '開始', icon: Sparkles },
+  next: { label: '次のステップ', icon: ArrowRight },
+  complete: { label: '完了後の練習', icon: CheckCircle2 },
+}
+
+export function TodayActionCard({ action }: TodayActionCardProps) {
+  const meta = ACTION_META[action.type]
+  const Icon = meta.icon
+
+  return (
+    <section className="rounded-2xl border border-emerald-200 bg-white p-5 shadow-sm sm:p-6" aria-labelledby="today-action-title">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-primary-mint/10 px-3 py-1 text-xs font-bold text-primary-dark">
+              <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+              今日のおすすめ
+            </span>
+            <span className="rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-600">
+              {meta.label}
+            </span>
+          </div>
+          <h2 id="today-action-title" className="mt-3 text-xl font-black leading-snug text-slate-950 sm:text-2xl">
+            {action.title}
+          </h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-600 sm:text-base">
+            {action.description}
+          </p>
+        </div>
+
+        <Link
+          to={action.to}
+          className="inline-flex shrink-0 items-center justify-center gap-2 rounded-xl bg-primary-mint px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-primary-mint/30 sm:text-base"
+        >
+          {action.ctaLabel}
+          <ArrowRight className="h-4 w-4" aria-hidden="true" />
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/features/dashboard/components/__tests__/OnboardingCard.test.tsx
+++ b/apps/web/src/features/dashboard/components/__tests__/OnboardingCard.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { ONBOARDING_DISMISSED_KEY, OnboardingCard } from '../OnboardingCard'
+
+function renderCard() {
+  return render(
+    <MemoryRouter>
+      <OnboardingCard startTo="/step/usestate-basic" />
+    </MemoryRouter>,
+  )
+}
+
+describe('OnboardingCard', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('4段階フローと開始リンクを表示する', () => {
+    renderCard()
+
+    expect(screen.getByText('はじめての方へ')).toBeTruthy()
+    expect(screen.getByText('4つの流れで1ステップずつ進めます')).toBeTruthy()
+    expect(screen.getByText('Readで概念を読み、Practiceで手を動かします。')).toBeTruthy()
+    expect(screen.getByText('Testで理解を確認し、Challengeで自分のコードにします。')).toBeTruthy()
+    expect(screen.getByRole('link', { name: '始める' }).getAttribute('href')).toBe('/step/usestate-basic')
+  })
+
+  it('閉じるとlocalStorageへ保存し、画面から消える', async () => {
+    const user = userEvent.setup()
+    renderCard()
+
+    await user.click(screen.getByRole('button', { name: '閉じる' }))
+
+    expect(window.localStorage.getItem(ONBOARDING_DISMISSED_KEY)).toBe('true')
+    expect(screen.queryByText('4つの流れで1ステップずつ進めます')).toBeNull()
+  })
+
+  it('保存済みの場合は表示しない', () => {
+    window.localStorage.setItem(ONBOARDING_DISMISSED_KEY, 'true')
+
+    renderCard()
+
+    expect(screen.queryByText('はじめての方へ')).toBeNull()
+  })
+})

--- a/apps/web/src/features/dashboard/components/__tests__/TodayActionCard.test.tsx
+++ b/apps/web/src/features/dashboard/components/__tests__/TodayActionCard.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { TodayActionCard } from '../TodayActionCard'
+import type { RecommendedAction } from '../../../../services/recommendationService'
+
+const action: RecommendedAction = {
+  type: 'resume',
+  title: 'Step 1 の Practice から再開',
+  description: '途中までの学習をそのまま活かしましょう。',
+  ctaLabel: 'Practice へ戻る',
+  to: '/step/usestate-basic',
+  stepId: 'usestate-basic',
+  mode: 'practice',
+}
+
+describe('TodayActionCard', () => {
+  it('推奨アクションとCTAを表示する', () => {
+    render(
+      <MemoryRouter>
+        <TodayActionCard action={action} />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('今日のおすすめ')).toBeTruthy()
+    expect(screen.getByText('Step 1 の Practice から再開')).toBeTruthy()
+    expect(screen.getByText('途中までの学習をそのまま活かしましょう。')).toBeTruthy()
+    expect(screen.getByRole('link', { name: /Practice へ戻る/ }).getAttribute('href')).toBe('/step/usestate-basic')
+  })
+})

--- a/apps/web/src/features/learning/hooks/__tests__/useLearningStep.test.ts
+++ b/apps/web/src/features/learning/hooks/__tests__/useLearningStep.test.ts
@@ -54,6 +54,7 @@ beforeEach(() => {
 
   mockUseLearningContext.mockReturnValue({
     stats: null,
+    allStepProgress: [],
     completedStepIds: new Set<string>(),
     completedStepsCount: 99,
     isLoadingStats: false,

--- a/apps/web/src/pages/CurriculumPage.tsx
+++ b/apps/web/src/pages/CurriculumPage.tsx
@@ -66,6 +66,7 @@ export function CurriculumPage() {
                 <h3 className="mt-3 text-sm font-bold text-slate-900 group-hover:text-primary-dark">
                   {card.title}
                 </h3>
+                <p className="mt-1 text-xs font-semibold text-slate-600">{card.purpose}</p>
                 <p className="mt-1 text-xs text-slate-500">{card.description}</p>
               </Link>
             ))}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Atom, BookOpen, Zap } from 'lucide-react'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
@@ -10,19 +10,26 @@ import { CATEGORIES, type CategoryMeta, getFirstImplementedStep } from '../conte
 import { useLearningContext } from '../contexts/LearningContext'
 import { AppHeader } from '../features/dashboard/components/AppHeader'
 import { DashboardSidebar } from '../features/dashboard/components/DashboardSidebar'
+import { OnboardingCard } from '../features/dashboard/components/OnboardingCard'
+import { TodayActionCard } from '../features/dashboard/components/TodayActionCard'
 import { WelcomeBanner } from '../features/dashboard/components/WelcomeBanner'
 import { isCourseCompleted } from '../lib/courseLock'
 import { supabaseConfigError } from '../lib/supabaseClient'
+import { getRecommendedAction } from '../services/recommendationService'
 import { CATEGORY_ICONS, PRACTICE_MODE_CARDS } from '../shared/constants'
 
 export function DashboardPage() {
   useDocumentTitle('ダッシュボード')
-  const { completedStepIds, completedStepsCount } = useLearningContext()
+  const { allStepProgress, completedStepIds, completedStepsCount } = useLearningContext()
   const { greetingName } = useGreetingName()
   const [error, setError] = useState<string | null>(null)
   const onSignOutError = useCallback((msg: string) => setError(msg), [])
   const handleSignOut = useSignOut(onSignOutError)
   const firstImplementedStep = getFirstImplementedStep()
+  const recommendedAction = useMemo(
+    () => getRecommendedAction({ progress: allStepProgress, enableReviewQueue: false }),
+    [allStepProgress],
+  )
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50">
@@ -35,18 +42,9 @@ export function DashboardPage() {
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
           <section className="space-y-6 lg:col-span-8">
             <WelcomeBanner displayName={greetingName} />
-
+            <TodayActionCard action={recommendedAction} />
             {completedStepsCount === 0 && firstImplementedStep ? (
-              <div className="rounded-2xl border border-primary-mint/30 bg-gradient-to-r from-primary-mint/10 via-white to-primary-mint/5 p-6 shadow-sm">
-                <p className="text-sm font-semibold text-slate-600">はじめての方へ</p>
-                <p className="mt-1 text-lg font-bold text-slate-900">React学習を始めましょう</p>
-                <Link
-                  className="mt-4 inline-flex items-center gap-2 rounded-xl bg-primary-mint px-6 py-3 text-base font-bold text-white shadow-sm transition-all duration-200 hover:bg-primary-dark active:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-primary-mint/30"
-                  to={`/step/${firstImplementedStep.id}`}
-                >
-                  最初のレッスンから始める →
-                </Link>
-              </div>
+              <OnboardingCard startTo={`/step/${firstImplementedStep.id}`} />
             ) : null}
 
             {/* カテゴリカード群 */}
@@ -71,6 +69,7 @@ export function DashboardPage() {
                   </div>
                   <div>
                     <h3 className="font-bold text-slate-900">ベースヌック</h3>
+                    <p className="mt-0.5 text-xs font-semibold text-sky-700">基礎の補習</p>
                     <p className="text-sm text-slate-500">コードの「なぜ？」がわかる基礎知識</p>
                   </div>
                 </div>
@@ -85,6 +84,7 @@ export function DashboardPage() {
                   </div>
                   <div>
                     <h3 className="font-bold text-slate-900">デイリーチャレンジ</h3>
+                    <p className="mt-0.5 text-xs font-semibold text-amber-700">昨日の復習</p>
                     <p className="text-sm text-slate-500">今日の1問に挑戦して知識を定着させましょう</p>
                   </div>
                 </div>
@@ -107,6 +107,7 @@ export function DashboardPage() {
                     <h3 className="mt-2 text-sm font-bold text-slate-900 group-hover:text-primary-dark">
                       {card.title}
                     </h3>
+                    <p className="mt-0.5 text-xs font-semibold text-slate-600">{card.purpose}</p>
                     <p className="mt-0.5 hidden text-xs text-slate-500 sm:block">{card.description}</p>
                   </Link>
                 ))}

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -64,6 +64,13 @@ const MODE_META: Record<
   },
 }
 
+const NEXT_ACTION_REASON: Record<LearningMode, string> = {
+  read: '理解した概念を穴埋めで確認しましょう。',
+  practice: '手を動かした内容を小さなテストで確かめましょう。',
+  test: '確認できた理解を使って、自分で実装して仕上げましょう。',
+  challenge: '今の実装力を土台に、次のステップへ進みましょう。',
+}
+
 export function StepPage() {
   const { stepId = '' } = useParams()
   const { user } = useAuth()
@@ -305,7 +312,8 @@ export function StepPage() {
             ) : null}
 
             {activeMode === 'read' && modeStatus.read ? (
-              <div className="mt-4 flex justify-center">
+              <div className="mt-4 flex flex-col items-center gap-3 text-center">
+                <p className="max-w-xl text-sm font-medium text-slate-600">{NEXT_ACTION_REASON.read}</p>
                 <button
                   className="inline-flex items-center gap-2 rounded-xl bg-amber-400 px-6 py-3 text-base font-bold text-slate-950 shadow-sm transition-all duration-200 hover:bg-amber-500 active:bg-amber-600 focus:outline-none focus:ring-2 focus:ring-amber-300/30"
                   type="button"
@@ -325,7 +333,8 @@ export function StepPage() {
             ) : null}
 
             {activeMode === 'practice' && modeStatus.practice ? (
-              <div className="mt-4 flex justify-center">
+              <div className="mt-4 flex flex-col items-center gap-3 text-center">
+                <p className="max-w-xl text-sm font-medium text-slate-600">{NEXT_ACTION_REASON.practice}</p>
                 <button
                   className="inline-flex items-center gap-2 rounded-xl bg-sky-500 px-6 py-3 text-base font-bold text-white shadow-sm transition-all duration-200 hover:bg-sky-600 active:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-400/30"
                   type="button"
@@ -341,7 +350,8 @@ export function StepPage() {
             ) : null}
 
             {activeMode === 'test' && modeStatus.test ? (
-              <div className="mt-4 flex justify-center">
+              <div className="mt-4 flex flex-col items-center gap-3 text-center">
+                <p className="max-w-xl text-sm font-medium text-slate-600">{NEXT_ACTION_REASON.test}</p>
                 <button
                   className="inline-flex items-center gap-2 rounded-xl bg-violet-500 px-6 py-3 text-base font-bold text-white shadow-sm transition-all duration-200 hover:bg-violet-600 active:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-violet-400/30"
                   type="button"
@@ -374,6 +384,9 @@ export function StepPage() {
                   {nextStep
                     ? `このステップを完了しました！ 次は「${nextStep.title}」へ進めます。`
                     : 'おめでとうございます！ 現在の学習フローをすべて完了しました。'}
+                </p>
+                <p className="mt-2 text-sm font-medium text-emerald-700">
+                  {nextStep ? NEXT_ACTION_REASON.challenge : 'ここまでの知識を復習やミニプロジェクトで固めましょう。'}
                 </p>
                 <button
                   className="mt-4 inline-flex items-center gap-2 rounded-xl bg-primary-mint px-6 py-3 text-base font-bold text-white shadow-sm transition-all duration-200 hover:bg-primary-dark active:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-primary-mint/30"

--- a/apps/web/src/pages/__tests__/DashboardPage.test.tsx
+++ b/apps/web/src/pages/__tests__/DashboardPage.test.tsx
@@ -1,9 +1,37 @@
-import { render, screen } from '@testing-library/react'
+import { cleanup, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DashboardPage } from '../DashboardPage'
 
-const getProfileMock = vi.fn()
+const testState = vi.hoisted(() => ({
+  getProfileMock: vi.fn(),
+  learningContext: {
+    allStepProgress: [
+      {
+        user_id: 'user-1',
+        step_id: 'usestate-basic',
+        read_done: true,
+        practice_done: true,
+        test_done: true,
+        challenge_done: true,
+        updated_at: '2026-06-03T00:00:00Z',
+        completed_at: '2026-06-03T00:00:00Z',
+      },
+      {
+        user_id: 'user-1',
+        step_id: 'events',
+        read_done: true,
+        practice_done: false,
+        test_done: false,
+        challenge_done: false,
+        updated_at: '2026-06-03T00:00:00Z',
+        completed_at: null,
+      },
+    ],
+    completedStepIds: new Set(['usestate-basic', 'events', 'conditional']),
+    completedStepsCount: 3,
+  },
+}))
 
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
@@ -16,10 +44,7 @@ vi.mock('@/contexts/AuthContext', () => ({
 }))
 
 vi.mock('@/contexts/LearningContext', () => ({
-  useLearningContext: () => ({
-    completedStepIds: new Set(['usestate-basic', 'events', 'conditional']),
-    completedStepsCount: 3,
-  }),
+  useLearningContext: () => testState.learningContext,
 }))
 
 vi.mock('@/features/dashboard/components/AppHeader', () => ({
@@ -35,7 +60,7 @@ vi.mock('@/features/dashboard/components/WelcomeBanner', () => ({
 }))
 
 vi.mock('@/services/profileService', () => ({
-  getProfile: (...args: unknown[]) => getProfileMock(...args),
+  getProfile: (...args: unknown[]) => testState.getProfileMock(...args),
 }))
 
 vi.mock('@/lib/supabaseClient', () => ({
@@ -44,10 +69,41 @@ vi.mock('@/lib/supabaseClient', () => ({
 
 describe('DashboardPage', () => {
   beforeEach(() => {
-    getProfileMock.mockReset()
-    getProfileMock.mockResolvedValue({
+    window.localStorage.clear()
+    testState.getProfileMock.mockReset()
+    testState.getProfileMock.mockResolvedValue({
       display_name: 'Coden User',
     })
+    testState.learningContext = {
+      allStepProgress: [
+        {
+          user_id: 'user-1',
+          step_id: 'usestate-basic',
+          read_done: true,
+          practice_done: true,
+          test_done: true,
+          challenge_done: true,
+          updated_at: '2026-06-03T00:00:00Z',
+          completed_at: '2026-06-03T00:00:00Z',
+        },
+        {
+          user_id: 'user-1',
+          step_id: 'events',
+          read_done: true,
+          practice_done: false,
+          test_done: false,
+          challenge_done: false,
+          updated_at: '2026-06-03T00:00:00Z',
+          completed_at: null,
+        },
+      ],
+      completedStepIds: new Set(['usestate-basic', 'events', 'conditional']),
+      completedStepsCount: 3,
+    }
+  })
+
+  afterEach(() => {
+    cleanup()
   })
 
   it('カテゴリカードとスキルアップセクションが表示される', async () => {
@@ -58,10 +114,37 @@ describe('DashboardPage', () => {
     )
 
     expect(await screen.findByText('学習コース')).toBeTruthy()
+    expect(screen.getByText('今日のおすすめ')).toBeTruthy()
+    expect(screen.getByText('Step 2 の Practice から再開')).toBeTruthy()
     expect(screen.getByText('React')).toBeTruthy()
     expect(screen.getByText('TypeScript')).toBeTruthy()
     expect(screen.getByText('スキルアップ')).toBeTruthy()
     expect(screen.getByText('デイリーチャレンジ')).toBeTruthy()
-    expect(getProfileMock).toHaveBeenCalledWith('user-1')
+    expect(screen.getAllByText('昨日の復習').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('基礎の補習')).toBeTruthy()
+    expect(screen.getByText('バグ修正')).toBeTruthy()
+    expect(screen.getByText('成果物作成')).toBeTruthy()
+    expect(screen.getByText('コードを読む')).toBeTruthy()
+    expect(screen.queryByText('はじめての方へ')).toBeNull()
+    expect(testState.getProfileMock).toHaveBeenCalledWith('user-1')
+  })
+
+  it('未着手でオンボーディング未完了の場合は初回カードを表示する', async () => {
+    testState.learningContext = {
+      allStepProgress: [],
+      completedStepIds: new Set<string>(),
+      completedStepsCount: 0,
+    }
+
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('学習コース')).toBeTruthy()
+    expect(screen.getByText('はじめての方へ')).toBeTruthy()
+    expect(screen.getByText('4つの流れで1ステップずつ進めます')).toBeTruthy()
+    expect(screen.getByRole('link', { name: '始める' }).getAttribute('href')).toBe('/step/usestate-basic')
   })
 })

--- a/apps/web/src/pages/__tests__/StepPage.test.tsx
+++ b/apps/web/src/pages/__tests__/StepPage.test.tsx
@@ -21,6 +21,7 @@ vi.mock('@/contexts/AuthContext', () => ({
 
 vi.mock('@/contexts/LearningContext', () => ({
   useLearningContext: () => ({
+    allStepProgress: [],
     completedStepIds: new Set(['usestate-basic', 'events', 'conditional', 'lists', 'useeffect', 'forms', 'usecontext', 'usereducer', 'custom-hooks', 'api-fetch', 'performance', 'testing', 'api-counter-get', 'api-counter-post', 'api-tasks-list', 'api-tasks-create', 'api-tasks-update', 'api-tasks-delete', 'api-custom-hook', 'api-error-loading']),
     completedStepsCount: 20,
     isLoadingStats: false,
@@ -63,7 +64,12 @@ vi.mock('@/features/learning/hooks/useLearningStep', () => ({
   useLearningStep: (...args: unknown[]) => useLearningStepMock(...args),
 }))
 
-function mockLearningStep() {
+function mockLearningStep(modeStatus = {
+  read: false,
+  practice: false,
+  test: false,
+  challenge: false,
+}) {
   useLearningStepMock.mockReturnValue({
     step: {
       id: 'usestate-basic',
@@ -91,12 +97,7 @@ function mockLearningStep() {
       order: 1,
     },
     isUnavailableStep: false,
-    modeStatus: {
-      read: false,
-      practice: false,
-      test: false,
-      challenge: false,
-    },
+    modeStatus,
     syncMessage: null,
     toastMessage: null,
     nextStep: undefined,
@@ -185,6 +186,40 @@ describe('StepPage', () => {
     expect(screen.getByText('最新の提出')).toBeTruthy()
     expect(screen.getByText('合格')).toBeTruthy()
     expect(screen.getByText('const [count, setCount] = useState(0);')).toBeTruthy()
+  })
+
+  it('完了した各モードの次アクション理由を表示する', async () => {
+    const user = userEvent.setup()
+
+    useChallengeSubmissionMock.mockReturnValue(vi.fn())
+    useRecentChallengeSubmissionsMock.mockReturnValue({
+      submissions: [],
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+    })
+    mockLearningStep({
+      read: true,
+      practice: true,
+      test: true,
+      challenge: false,
+    })
+
+    render(
+      <MemoryRouter initialEntries={['/step/usestate-basic']}>
+        <Routes>
+          <Route path="/step/:stepId" element={<StepPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('理解した概念を穴埋めで確認しましょう。')).toBeTruthy()
+
+    await user.click(screen.getByRole('tab', { name: 'Practice' }))
+    expect(screen.getByText('手を動かした内容を小さなテストで確かめましょう。')).toBeTruthy()
+
+    await user.click(screen.getByRole('tab', { name: 'Test' }))
+    expect(screen.getByText('確認できた理解を使って、自分で実装して仕上げましょう。')).toBeTruthy()
   })
 
   it('Challenge 完了時に完了バナーまでスムーズスクロールする', async () => {
@@ -280,6 +315,7 @@ describe('StepPage', () => {
       expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: 'smooth', block: 'nearest' })
     })
     expect(screen.getByText('このステップを完了しました！ 次は「イベント処理」へ進めます。')).toBeTruthy()
+    expect(screen.getByText('今の実装力を土台に、次のステップへ進みましょう。')).toBeTruthy()
   })
 
   it('完了したモードが増えたときにステッパーへ pulse 演出を付与する', async () => {

--- a/apps/web/src/services/__tests__/recommendationService.test.ts
+++ b/apps/web/src/services/__tests__/recommendationService.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import { getRecommendedAction } from '../recommendationService'
+import type { StepProgressRow } from '../progressService'
+import type { StepMeta } from '../../content/courseData'
+
+const steps: StepMeta[] = [
+  {
+    id: 'usestate-basic',
+    order: 1,
+    title: 'useState基礎',
+    description: '状態管理の基本',
+    isImplemented: true,
+  },
+  {
+    id: 'events',
+    order: 2,
+    title: 'イベント処理',
+    description: 'イベントの基本',
+    isImplemented: true,
+  },
+]
+
+function makeProgress(stepId: string, done: Partial<StepProgressRow>): StepProgressRow {
+  return {
+    user_id: 'user-1',
+    step_id: stepId,
+    read_done: false,
+    practice_done: false,
+    test_done: false,
+    challenge_done: false,
+    updated_at: '2026-06-03T00:00:00Z',
+    completed_at: null,
+    ...done,
+  }
+}
+
+describe('getRecommendedAction', () => {
+  it('復習キューが有効で復習待ちがある場合は復習を最優先する', () => {
+    const action = getRecommendedAction({
+      progress: [],
+      reviewCount: 2,
+      enableReviewQueue: true,
+      steps,
+    })
+
+    expect(action.type).toBe('review')
+    expect(action.title).toContain('復習')
+    expect(action.to).toBe('/daily')
+  })
+
+  it('復習キューが無効な場合は復習待ちがあっても最初のステップを返す', () => {
+    const action = getRecommendedAction({
+      progress: [],
+      reviewCount: 2,
+      enableReviewQueue: false,
+      steps,
+    })
+
+    expect(action.type).toBe('start')
+    expect(action.stepId).toBe('usestate-basic')
+  })
+
+  it('未着手の場合は最初の実装済みステップを返す', () => {
+    const action = getRecommendedAction({ progress: [], steps })
+
+    expect(action.type).toBe('start')
+    expect(action.title).toContain('useState基礎')
+    expect(action.to).toBe('/step/usestate-basic')
+  })
+
+  it('進行中ステップの最初の未完了モードを返す', () => {
+    const action = getRecommendedAction({
+      progress: [
+        makeProgress('usestate-basic', {
+          read_done: true,
+          practice_done: true,
+        }),
+      ],
+      steps,
+    })
+
+    expect(action.type).toBe('resume')
+    expect(action.stepId).toBe('usestate-basic')
+    expect(action.mode).toBe('test')
+    expect(action.title).toContain('Test')
+  })
+
+  it('完了済みステップの次にある未着手ステップを返す', () => {
+    const action = getRecommendedAction({
+      progress: [
+        makeProgress('usestate-basic', {
+          read_done: true,
+          practice_done: true,
+          test_done: true,
+          challenge_done: true,
+        }),
+      ],
+      steps,
+    })
+
+    expect(action.type).toBe('next')
+    expect(action.stepId).toBe('events')
+    expect(action.to).toBe('/step/events')
+  })
+
+  it('全ステップ完了済みの場合はスキルアップ導線を返す', () => {
+    const action = getRecommendedAction({
+      progress: [
+        makeProgress('usestate-basic', {
+          read_done: true,
+          practice_done: true,
+          test_done: true,
+          challenge_done: true,
+        }),
+        makeProgress('events', {
+          read_done: true,
+          practice_done: true,
+          test_done: true,
+          challenge_done: true,
+        }),
+      ],
+      steps,
+    })
+
+    expect(action.type).toBe('complete')
+    expect(action.to).toBe('/practice/mini-projects')
+  })
+})

--- a/apps/web/src/services/progressService.ts
+++ b/apps/web/src/services/progressService.ts
@@ -5,7 +5,7 @@ import type { Tables, TablesInsert } from '../shared/types/database.types'
 export type ProgressMode = 'read' | 'practice' | 'test' | 'challenge'
 
 // クエリで SELECT する列のみを含む型（id は SELECT しないため除外）
-type StepProgressRow = Pick<
+export type StepProgressRow = Pick<
   Tables<'step_progress'>,
   'user_id' | 'step_id' | 'read_done' | 'practice_done' | 'test_done' | 'challenge_done' | 'updated_at' | 'completed_at'
 >

--- a/apps/web/src/services/recommendationService.ts
+++ b/apps/web/src/services/recommendationService.ts
@@ -1,0 +1,145 @@
+import { getAllSteps, getFirstImplementedStep, type StepMeta } from '../content/courseData'
+import type { StepProgressRow } from './progressService'
+
+export type RecommendationMode = 'read' | 'practice' | 'test' | 'challenge'
+
+type ModeMeta = {
+  mode: RecommendationMode
+  label: string
+  doneKey: keyof Pick<StepProgressRow, 'read_done' | 'practice_done' | 'test_done' | 'challenge_done'>
+}
+
+const MODE_ORDER: readonly ModeMeta[] = [
+  { mode: 'read', label: 'Read', doneKey: 'read_done' },
+  { mode: 'practice', label: 'Practice', doneKey: 'practice_done' },
+  { mode: 'test', label: 'Test', doneKey: 'test_done' },
+  { mode: 'challenge', label: 'Challenge', doneKey: 'challenge_done' },
+] as const
+
+const READ_MODE: ModeMeta = { mode: 'read', label: 'Read', doneKey: 'read_done' }
+
+export type RecommendedActionType = 'review' | 'resume' | 'start' | 'next' | 'complete'
+
+export interface RecommendedAction {
+  type: RecommendedActionType
+  title: string
+  description: string
+  ctaLabel: string
+  to: string
+  stepId?: string
+  mode?: RecommendationMode
+}
+
+export interface RecommendationState {
+  progress: readonly StepProgressRow[]
+  reviewCount?: number
+  enableReviewQueue?: boolean
+  steps?: readonly StepMeta[]
+}
+
+function isAllModesDone(progress: StepProgressRow | undefined): boolean {
+  return Boolean(progress?.read_done && progress.practice_done && progress.test_done && progress.challenge_done)
+}
+
+function hasAnyModeDone(progress: StepProgressRow | undefined): boolean {
+  return Boolean(progress?.read_done || progress?.practice_done || progress?.test_done || progress?.challenge_done)
+}
+
+function getFirstIncompleteMode(progress: StepProgressRow): ModeMeta {
+  const mode = MODE_ORDER.find((item) => !progress[item.doneKey])
+  return mode ?? READ_MODE
+}
+
+function getOrderedImplementedSteps(steps?: readonly StepMeta[]): StepMeta[] {
+  return [...(steps ?? getAllSteps())].filter((step) => step.isImplemented).sort((a, b) => a.order - b.order)
+}
+
+export function getRecommendedAction({
+  progress,
+  reviewCount = 0,
+  enableReviewQueue = false,
+  steps,
+}: RecommendationState): RecommendedAction {
+  if (enableReviewQueue && reviewCount > 0) {
+    return {
+      type: 'review',
+      title: '昨日間違えた問題を復習',
+      description: `復習待ちが ${reviewCount} 件あります。まずは弱点を軽く戻しましょう。`,
+      ctaLabel: '復習へ進む',
+      to: '/daily',
+    }
+  }
+
+  const implementedSteps = getOrderedImplementedSteps(steps)
+  const firstStep = implementedSteps[0] ?? getFirstImplementedStep()
+
+  if (!firstStep) {
+    return {
+      type: 'complete',
+      title: '学習コンテンツを準備中です',
+      description: '次に取り組めるステップが追加されるまで少しお待ちください。',
+      ctaLabel: 'カリキュラムを見る',
+      to: '/curriculum',
+    }
+  }
+
+  const progressByStepId = new Map(progress.map((item) => [item.step_id, item]))
+  const inProgressStep = implementedSteps.find((step) => {
+    const item = progressByStepId.get(step.id)
+    return hasAnyModeDone(item) && !isAllModesDone(item)
+  })
+
+  if (inProgressStep) {
+    const item = progressByStepId.get(inProgressStep.id)
+
+    if (item) {
+      const mode = getFirstIncompleteMode(item)
+
+      return {
+        type: 'resume',
+        title: `Step ${inProgressStep.order} の ${mode.label} から再開`,
+        description: `「${inProgressStep.title}」の続きから進めます。途中までの学習をそのまま活かしましょう。`,
+        ctaLabel: `${mode.label} へ戻る`,
+        to: `/step/${inProgressStep.id}`,
+        stepId: inProgressStep.id,
+        mode: mode.mode,
+      }
+    }
+  }
+
+  const hasStarted = implementedSteps.some((step) => hasAnyModeDone(progressByStepId.get(step.id)))
+
+  if (!hasStarted) {
+    return {
+      type: 'start',
+      title: `${firstStep.title} から始める`,
+      description: 'Read → Practice → Test → Challenge の順に、まずは1ステップ進めましょう。',
+      ctaLabel: '最初のレッスンへ',
+      to: `/step/${firstStep.id}`,
+      stepId: firstStep.id,
+      mode: 'read',
+    }
+  }
+
+  const nextStep = implementedSteps.find((step) => !isAllModesDone(progressByStepId.get(step.id)))
+
+  if (nextStep) {
+    return {
+      type: 'next',
+      title: `次は Step ${nextStep.order}「${nextStep.title}」`,
+      description: '完了したステップの流れを保ったまま、次の概念へ進みましょう。',
+      ctaLabel: '次のステップへ',
+      to: `/step/${nextStep.id}`,
+      stepId: nextStep.id,
+      mode: 'read',
+    }
+  }
+
+  return {
+    type: 'complete',
+    title: '全ステップ完了済みです',
+    description: '復習やミニプロジェクトで、身につけた知識を実装力へつなげましょう。',
+    ctaLabel: 'スキルアップを見る',
+    to: '/practice/mini-projects',
+  }
+}

--- a/apps/web/src/shared/constants.ts
+++ b/apps/web/src/shared/constants.ts
@@ -117,6 +117,7 @@ export interface PracticeCard {
   readonly to: string
   readonly icon: LucideIcon
   readonly title: string
+  readonly purpose: string
   readonly description: string
   readonly color: string
 }
@@ -127,6 +128,7 @@ export const PRACTICE_MODE_CARDS: readonly PracticeCard[] = [
     to: '/daily',
     icon: Zap,
     title: 'デイリーチャレンジ',
+    purpose: '昨日の復習',
     description: '日替わり1問で知識を定着',
     color: 'text-amber-600 bg-amber-50 border-amber-200',
   },
@@ -134,6 +136,7 @@ export const PRACTICE_MODE_CARDS: readonly PracticeCard[] = [
     to: '/practice/code-doctor',
     icon: Stethoscope,
     title: 'コードドクター',
+    purpose: 'バグ修正',
     description: 'バグ入りコードを修正',
     color: 'text-rose-600 bg-rose-50 border-rose-200',
   },
@@ -141,6 +144,7 @@ export const PRACTICE_MODE_CARDS: readonly PracticeCard[] = [
     to: '/practice/mini-projects',
     icon: Puzzle,
     title: 'ミニプロジェクト',
+    purpose: '成果物作成',
     description: '仕様からゼロ実装',
     color: 'text-violet-600 bg-violet-50 border-violet-200',
   },
@@ -148,6 +152,7 @@ export const PRACTICE_MODE_CARDS: readonly PracticeCard[] = [
     to: '/practice/code-reading',
     icon: BookOpen,
     title: 'コードリーディング',
+    purpose: 'コードを読む',
     description: 'コードを読んで理解度テスト',
     color: 'text-sky-600 bg-sky-50 border-sky-200',
   },


### PR DESCRIPTION
﻿## Summary
- 今日のおすすめアクションを追加し、進捗状態から次の行動を1件提示
- 練習モード/補習導線に役割ラベルを追加
- 初回オンボーディングカードとモード完了後の次アクション文言を追加

## Test plan
- npm run typecheck
- npm run lint
- npm run test
- npm run build
- pre-commit: lint / typecheck
- pre-push: test / build

## Issue
- Issue不要: v5roadmap01 でスコープ定義済み

## Notes
- ブラウザーでの表示確認はユーザー側で実施予定
