### PR TITLE
feat: 復習基盤のDBとサービスを追加

### DIFF
--- a/apps/web/src/services/__tests__/reviewService.test.ts
+++ b/apps/web/src/services/__tests__/reviewService.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { supabase } from '../../lib/supabaseClient'
+import {
+  getOpenCount,
+  listOpen,
+  recordWrongAnswer,
+  resolveReviewItem,
+  type ReviewItem,
+} from '../reviewService'
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}))
+
+const mockFrom = vi.mocked(supabase.from)
+const userId = '00000000-0000-0000-0000-000000000001'
+
+function makeMaybeSingleQuery(result: unknown) {
+  const query = {
+    eq: vi.fn(() => query),
+    is: vi.fn(() => query),
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  }
+
+  return query
+}
+
+function makeInsertQuery(result: unknown) {
+  const terminal = {
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  }
+  const select = vi.fn(() => terminal)
+  const insert = vi.fn(() => ({ select }))
+
+  return { insert, select, terminal }
+}
+
+function makeUpdateQuery(result: unknown) {
+  const terminal = {
+    maybeSingle: vi.fn().mockResolvedValue(result),
+  }
+  const chain = {
+    eq: vi.fn(() => chain),
+    select: vi.fn(() => terminal),
+  }
+  const update = vi.fn(() => chain)
+
+  return { update, chain, terminal }
+}
+
+function makeThenableEqQuery(result: unknown) {
+  const query = {
+    eq: vi.fn(() => query),
+    then: vi.fn((resolve, reject) => Promise.resolve(result).then(resolve, reject)),
+  }
+
+  return query
+}
+
+describe('reviewService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('recordWrongAnswer は未登録の誤答を open item として保存する', async () => {
+    const findQuery = makeMaybeSingleQuery({ data: null, error: null })
+    const insertQuery = makeInsertQuery({ data: { id: 'review-1' }, error: null })
+
+    mockFrom
+      .mockReturnValueOnce({ select: vi.fn(() => findQuery) } as unknown as ReturnType<typeof supabase.from>)
+      .mockReturnValueOnce({ insert: insertQuery.insert } as unknown as ReturnType<typeof supabase.from>)
+
+    await recordWrongAnswer({
+      userId,
+      stepId: 'usestate-basic',
+      mode: 'practice',
+      questionId: 'practice-1',
+      expected: 'setCount',
+      userInput: 'count = count + 1',
+    })
+
+    expect(insertQuery.insert).toHaveBeenCalledWith({
+      user_id: userId,
+      step_id: 'usestate-basic',
+      mode: 'practice',
+      question_id: 'practice-1',
+      expected: 'setCount',
+      user_input: 'count = count + 1',
+      status: 'open',
+      resolved_at: null,
+    })
+  })
+
+  it('recordWrongAnswer は登録済み item を再 open する', async () => {
+    const findQuery = makeMaybeSingleQuery({ data: { id: 'review-1' }, error: null })
+    const updateQuery = makeUpdateQuery({ data: { id: 'review-1' }, error: null })
+
+    mockFrom
+      .mockReturnValueOnce({ select: vi.fn(() => findQuery) } as unknown as ReturnType<typeof supabase.from>)
+      .mockReturnValueOnce({ update: updateQuery.update } as unknown as ReturnType<typeof supabase.from>)
+
+    await recordWrongAnswer({
+      userId,
+      stepId: 'usestate-basic',
+      mode: 'test',
+      expected: 'useState',
+      userInput: 'useEffect',
+    })
+
+    expect(updateQuery.update).toHaveBeenCalledWith({
+      expected: 'useState',
+      user_input: 'useEffect',
+      status: 'open',
+      resolved_at: null,
+    })
+  })
+
+  it('resolveReviewItem は対象 item があれば resolved にする', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-03T12:00:00.000Z'))
+
+    const findQuery = makeMaybeSingleQuery({ data: { id: 'review-1' }, error: null })
+    const updateQuery = makeUpdateQuery({ data: { id: 'review-1' }, error: null })
+
+    mockFrom
+      .mockReturnValueOnce({ select: vi.fn(() => findQuery) } as unknown as ReturnType<typeof supabase.from>)
+      .mockReturnValueOnce({ update: updateQuery.update } as unknown as ReturnType<typeof supabase.from>)
+
+    await resolveReviewItem({
+      userId,
+      stepId: 'usestate-basic',
+      mode: 'challenge',
+      questionId: null,
+    })
+
+    expect(updateQuery.update).toHaveBeenCalledWith({
+      status: 'resolved',
+      resolved_at: '2026-06-03T12:00:00.000Z',
+    })
+
+    vi.useRealTimers()
+  })
+
+  it('resolveReviewItem は対象 item がなければ何もしない', async () => {
+    const findQuery = makeMaybeSingleQuery({ data: null, error: null })
+
+    mockFrom.mockReturnValueOnce({ select: vi.fn(() => findQuery) } as unknown as ReturnType<typeof supabase.from>)
+
+    await resolveReviewItem({
+      userId,
+      stepId: 'usestate-basic',
+      mode: 'practice',
+    })
+
+    expect(mockFrom).toHaveBeenCalledTimes(1)
+  })
+
+  it('getOpenCount は open item の件数を返す', async () => {
+    const countQuery = makeThenableEqQuery({ count: 3, error: null })
+    const select = vi.fn(() => countQuery)
+
+    mockFrom.mockReturnValueOnce({ select } as unknown as ReturnType<typeof supabase.from>)
+
+    await expect(getOpenCount(userId)).resolves.toBe(3)
+    expect(select).toHaveBeenCalledWith('id', { count: 'exact', head: true })
+  })
+
+  it('listOpen は open item を古い順に指定件数返す', async () => {
+    const rows: ReviewItem[] = [
+      {
+        id: 'review-1',
+        user_id: userId,
+        step_id: 'usestate-basic',
+        mode: 'daily',
+        question_id: 'daily-1',
+        expected: 'setCount',
+        user_input: 'wrong',
+        status: 'open',
+        created_at: '2026-06-03T12:00:00.000Z',
+        resolved_at: null,
+      },
+    ]
+    const query = {
+      eq: vi.fn(() => query),
+      order: vi.fn(() => query),
+      limit: vi.fn().mockResolvedValue({ data: rows, error: null }),
+    }
+    const select = vi.fn(() => query)
+
+    mockFrom.mockReturnValueOnce({ select } as unknown as ReturnType<typeof supabase.from>)
+
+    await expect(listOpen(userId, 5)).resolves.toEqual(rows)
+    expect(query.order).toHaveBeenCalledWith('created_at', { ascending: true })
+    expect(query.limit).toHaveBeenCalledWith(5)
+  })
+})

--- a/apps/web/src/services/reviewService.ts
+++ b/apps/web/src/services/reviewService.ts
@@ -1,0 +1,181 @@
+import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+import { assertMaxLength, assertOneOf, assertPositiveInteger, assertUuid } from '../shared/validation'
+import type { Tables, TablesInsert, TablesUpdate } from '../shared/types/database.types'
+
+export type ReviewItem = Tables<'review_items'>
+export type ReviewMode = ReviewItem['mode']
+export type ReviewStatus = ReviewItem['status']
+
+const REVIEW_MODES = new Set<ReviewMode>(['practice', 'test', 'challenge', 'daily'])
+const MAX_REVIEW_TEXT_LENGTH = 2000
+
+export type ReviewTarget = {
+  userId: string
+  stepId: string
+  mode: ReviewMode
+  questionId?: string | null
+}
+
+export type RecordWrongAnswerInput = ReviewTarget & {
+  expected?: string | null
+  userInput?: string | null
+}
+
+type ReviewItemId = Pick<ReviewItem, 'id'>
+
+function normalizeQuestionId(questionId?: string | null): string | null {
+  const normalized = questionId?.trim()
+  return normalized ? normalized : null
+}
+
+function normalizeOptionalText(value?: string | null): string | null {
+  return value ?? null
+}
+
+function validateTarget(target: ReviewTarget) {
+  assertUuid(target.userId, 'userId')
+  assertMaxLength(target.stepId, 120, 'stepId')
+  assertOneOf(target.mode, REVIEW_MODES, 'mode')
+
+  const questionId = normalizeQuestionId(target.questionId)
+  if (questionId) {
+    assertMaxLength(questionId, 160, 'questionId')
+  }
+}
+
+function validateRecordInput(input: RecordWrongAnswerInput) {
+  validateTarget(input)
+
+  if (input.expected) {
+    assertMaxLength(input.expected, MAX_REVIEW_TEXT_LENGTH, 'expected')
+  }
+
+  if (input.userInput) {
+    assertMaxLength(input.userInput, MAX_REVIEW_TEXT_LENGTH, 'userInput')
+  }
+}
+
+async function findReviewItemId(target: ReviewTarget): Promise<ReviewItemId | null> {
+  const questionId = normalizeQuestionId(target.questionId)
+  const query = supabase
+    .from('review_items')
+    .select('id')
+    .eq('user_id', target.userId)
+    .eq('step_id', target.stepId)
+    .eq('mode', target.mode)
+
+  const filteredQuery = questionId ? query.eq('question_id', questionId) : query.is('question_id', null)
+  const { data, error } = await filteredQuery.maybeSingle()
+
+  if (error) {
+    throw fromSupabaseError(error, '復習アイテムの取得に失敗しました')
+  }
+
+  return data
+}
+
+async function updateReviewItem(id: string, patch: TablesUpdate<'review_items'>) {
+  const { error } = await supabase
+    .from('review_items')
+    .update(patch)
+    .eq('id', id)
+    .select('id')
+    .maybeSingle()
+
+  if (error) {
+    throw fromSupabaseError(error, '復習アイテムの更新に失敗しました')
+  }
+}
+
+async function insertReviewItem(payload: TablesInsert<'review_items'>) {
+  const { error } = await supabase
+    .from('review_items')
+    .insert(payload)
+    .select('id')
+    .maybeSingle()
+
+  if (error) {
+    throw fromSupabaseError(error, '復習アイテムの保存に失敗しました')
+  }
+}
+
+export async function recordWrongAnswer(input: RecordWrongAnswerInput): Promise<void> {
+  validateRecordInput(input)
+
+  const questionId = normalizeQuestionId(input.questionId)
+  const expected = normalizeOptionalText(input.expected)
+  const userInput = normalizeOptionalText(input.userInput)
+  const payload: TablesInsert<'review_items'> = {
+    user_id: input.userId,
+    step_id: input.stepId,
+    mode: input.mode,
+    question_id: questionId,
+    expected,
+    user_input: userInput,
+    status: 'open',
+    resolved_at: null,
+  }
+
+  const existing = await findReviewItemId(input)
+  if (existing) {
+    await updateReviewItem(existing.id, {
+      expected,
+      user_input: userInput,
+      status: 'open',
+      resolved_at: null,
+    })
+    return
+  }
+
+  await insertReviewItem(payload)
+}
+
+export async function resolveReviewItem(target: ReviewTarget): Promise<void> {
+  validateTarget(target)
+
+  const existing = await findReviewItemId(target)
+  if (!existing) {
+    return
+  }
+
+  await updateReviewItem(existing.id, {
+    status: 'resolved',
+    resolved_at: new Date().toISOString(),
+  })
+}
+
+export async function getOpenCount(userId: string): Promise<number> {
+  assertUuid(userId, 'userId')
+
+  const { count, error } = await supabase
+    .from('review_items')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', userId)
+    .eq('status', 'open')
+
+  if (error) {
+    throw fromSupabaseError(error, '復習待ち件数の取得に失敗しました')
+  }
+
+  return count ?? 0
+}
+
+export async function listOpen(userId: string, limit = 10): Promise<ReviewItem[]> {
+  assertUuid(userId, 'userId')
+  assertPositiveInteger(limit, 'limit')
+
+  const { data, error } = await supabase
+    .from('review_items')
+    .select('id, user_id, step_id, mode, question_id, expected, user_input, status, created_at, resolved_at')
+    .eq('user_id', userId)
+    .eq('status', 'open')
+    .order('created_at', { ascending: true })
+    .limit(limit)
+
+  if (error) {
+    throw fromSupabaseError(error, '復習キューの取得に失敗しました')
+  }
+
+  return data ?? []
+}

--- a/apps/web/src/shared/types/database.types.ts
+++ b/apps/web/src/shared/types/database.types.ts
@@ -146,6 +146,45 @@ export type Database = {
         }
         Relationships: []
       }
+      review_items: {
+        Row: {
+          created_at: string
+          expected: string | null
+          id: string
+          mode: 'practice' | 'test' | 'challenge' | 'daily'
+          question_id: string | null
+          resolved_at: string | null
+          status: 'open' | 'resolved'
+          step_id: string
+          user_id: string
+          user_input: string | null
+        }
+        Insert: {
+          created_at?: string
+          expected?: string | null
+          id?: string
+          mode: 'practice' | 'test' | 'challenge' | 'daily'
+          question_id?: string | null
+          resolved_at?: string | null
+          status?: 'open' | 'resolved'
+          step_id: string
+          user_id: string
+          user_input?: string | null
+        }
+        Update: {
+          created_at?: string
+          expected?: string | null
+          id?: string
+          mode?: 'practice' | 'test' | 'challenge' | 'daily'
+          question_id?: string | null
+          resolved_at?: string | null
+          status?: 'open' | 'resolved'
+          step_id?: string
+          user_id?: string
+          user_input?: string | null
+        }
+        Relationships: []
+      }
       profiles: {
         Row: {
           created_at: string

--- a/apps/web/supabase/sql/020_review_items.sql
+++ b/apps/web/supabase/sql/020_review_items.sql
@@ -1,0 +1,59 @@
+-- 020_review_items.sql
+-- 弱点ベース復習基盤: 誤答・未完了・Challenge失敗を復習キューとして保存する。
+
+CREATE TABLE IF NOT EXISTS public.review_items (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  step_id TEXT NOT NULL,
+  mode TEXT NOT NULL CHECK (mode IN ('practice', 'test', 'challenge', 'daily')),
+  question_id TEXT,
+  expected TEXT,
+  user_input TEXT,
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'resolved')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  resolved_at TIMESTAMPTZ
+);
+
+COMMENT ON TABLE public.review_items
+  IS '誤答・未完了・Challenge失敗を保存する復習キュー。question_id が NULL の場合はステップ単位の復習対象。';
+
+COMMENT ON COLUMN public.review_items.question_id
+  IS '問題単位で保存する場合の問題ID。NULL の場合はステップ単位。';
+
+ALTER TABLE public.review_items ENABLE ROW LEVEL SECURITY;
+
+-- question_id が NULL のステップ単位復習も重複登録されないよう、式indexで正規化する。
+CREATE UNIQUE INDEX IF NOT EXISTS review_items_unique_target_idx
+  ON public.review_items (user_id, step_id, mode, COALESCE(question_id, '__step__'));
+
+CREATE INDEX IF NOT EXISTS review_items_user_status_idx
+  ON public.review_items (user_id, status, created_at DESC);
+
+DROP POLICY IF EXISTS "review_items_select_own" ON public.review_items;
+CREATE POLICY "review_items_select_own"
+  ON public.review_items
+  FOR SELECT
+  TO authenticated
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "review_items_insert_own" ON public.review_items;
+CREATE POLICY "review_items_insert_own"
+  ON public.review_items
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "review_items_update_own" ON public.review_items;
+CREATE POLICY "review_items_update_own"
+  ON public.review_items
+  FOR UPDATE
+  TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "review_items_delete_own" ON public.review_items;
+CREATE POLICY "review_items_delete_own"
+  ON public.review_items
+  FOR DELETE
+  TO authenticated
+  USING (auth.uid() = user_id);


### PR DESCRIPTION
﻿## Summary
- review_items テーブル用SQLを追加し、RLS・index・重複防止制約を定義
- review_items の database.types を追加
- recordWrongAnswer / resolveReviewItem / getOpenCount / listOpen を持つ reviewService を追加
- reviewService のサービステストを追加

## Test plan
- npm run typecheck
- npm run lint
- npm run test
- npm run build
- pre-commit: lint / typecheck
- pre-push: test / build

## Notes
- ローカル Supabase 適用は未実施です。リポジトリに supabase/config.toml が無いため、SQLは手動適用対象として扱っています。
- Issue不要: v5roadmap02 M1 でスコープ定義済み
