### PR TITLE
feat: 復習導線を学習フローへ接続

### DIFF
--- a/apps/web/src/features/dashboard/components/ReviewQueueCard.tsx
+++ b/apps/web/src/features/dashboard/components/ReviewQueueCard.tsx
@@ -1,0 +1,56 @@
+import { Link } from 'react-router-dom'
+import { RotateCcw } from 'lucide-react'
+import { findStepById } from '@/content/courseData'
+import type { ReviewItem } from '@/services/reviewService'
+
+interface ReviewQueueCardProps {
+  count: number
+  firstItem: ReviewItem | null
+  isLoading?: boolean
+  error?: string | null
+}
+
+function formatCount(count: number) {
+  return count > 99 ? '99+' : String(count)
+}
+
+export function ReviewQueueCard({ count, firstItem, isLoading = false, error = null }: ReviewQueueCardProps) {
+  const firstStep = firstItem ? findStepById(firstItem.step_id) : undefined
+  const hasOpenItems = count > 0
+
+  return (
+    <section className="rounded-2xl border border-amber-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-3">
+          <div className="rounded-lg bg-amber-100 p-2.5">
+            <RotateCcw className="h-5 w-5 text-amber-700" aria-hidden="true" />
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">復習キュー</p>
+            <h2 className="mt-1 text-lg font-bold text-slate-900">
+              {isLoading ? '復習待ちを確認中' : `復習待ち ${formatCount(count)} 件`}
+            </h2>
+            {error ? (
+              <p className="mt-1 text-sm text-rose-600">{error}</p>
+            ) : hasOpenItems ? (
+              <p className="mt-1 text-sm text-slate-600">
+                最優先: {firstStep ? `Step ${firstStep.order}「${firstStep.title}」` : firstItem?.step_id}
+              </p>
+            ) : (
+              <p className="mt-1 text-sm text-slate-600">
+                今のところ復習待ちはありません。通常の学習かDailyでリズムを保ちましょう。
+              </p>
+            )}
+          </div>
+        </div>
+
+        <Link
+          to={hasOpenItems ? '/daily' : '/curriculum'}
+          className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-amber-500 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-amber-600"
+        >
+          {hasOpenItems ? '復習へ進む' : '学習を進める'}
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/features/dashboard/hooks/useReviewList.ts
+++ b/apps/web/src/features/dashboard/hooks/useReviewList.ts
@@ -1,25 +1,60 @@
 import { useEffect, useState } from 'react'
-import {
-  getReviewList,
-  removeFromReviewList,
-  subscribeReviewList,
-} from '@/services/reviewListService'
+import { useAuth } from '@/contexts/AuthContext'
+import { listOpen, resolveReviewItem, type ReviewItem } from '@/services/reviewService'
 
 export function useReviewList() {
+  const { user } = useAuth()
+  const userId = user?.id
+  const [items, setItems] = useState<ReviewItem[]>([])
   const [stepIds, setStepIds] = useState<string[]>([])
 
   useEffect(() => {
-    const sync = () => {
-      setStepIds(getReviewList())
+    let cancelled = false
+
+    async function sync() {
+      if (!userId) {
+        setItems([])
+        setStepIds([])
+        return
+      }
+
+      let openItems: ReviewItem[]
+      try {
+        openItems = await listOpen(userId, 50)
+      } catch {
+        openItems = []
+      }
+
+      if (cancelled) return
+
+      setItems(openItems)
+      setStepIds([...new Set(openItems.map((item) => item.step_id))])
     }
 
-    sync()
+    void sync()
 
-    return subscribeReviewList(sync)
-  }, [])
+    return () => {
+      cancelled = true
+    }
+  }, [userId])
 
   function handleRemove(stepId: string) {
-    removeFromReviewList(stepId)
+    if (!userId) return
+
+    const targets = items.filter((item) => item.step_id === stepId)
+    setItems((prev) => prev.filter((item) => item.step_id !== stepId))
+    setStepIds((prev) => prev.filter((id) => id !== stepId))
+
+    void Promise.all(
+      targets.map((item) =>
+        resolveReviewItem({
+          userId,
+          stepId: item.step_id,
+          mode: item.mode,
+          questionId: item.question_id,
+        }),
+      ),
+    )
   }
 
   return {

--- a/apps/web/src/features/learning/ChallengeMode.tsx
+++ b/apps/web/src/features/learning/ChallengeMode.tsx
@@ -5,6 +5,7 @@ import { ErrorBanner } from '../../components/ErrorBanner'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import type { ChallengePattern, ChallengeTask } from '../../content/fundamentals/steps'
 import { JudgmentResult } from './components/JudgmentResult'
+import { useJudgmentAction } from './hooks/useJudgmentAction'
 import { getMissingKeywords } from './utils/keywordMatcher'
 import { ChallengePuzzleMulti } from './ChallengePuzzle/ChallengePuzzleMulti'
 
@@ -27,8 +28,8 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
   const [pattern, setPattern] = useState<ChallengePattern>(() => getRandomPattern(task))
   const [code, setCode] = useState(() => pattern.starterCode)
   const [checked, setChecked] = useState(false)
-  const [reported, setReported] = useState(false)
   const [submissionError, setSubmissionError] = useState<string | null>(null)
+  const { handleResult } = useJudgmentAction(stepId, 'challenge', onComplete)
 
   const hasMobilePuzzle = isMobile && pattern.mobilePuzzle != null
 
@@ -37,7 +38,6 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
     setPattern(nextPattern)
     setCode(nextPattern.starterCode)
     setChecked(false)
-    setReported(false)
     setSubmissionError(null)
   }, [stepId, task])
 
@@ -68,10 +68,11 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
       }
     }
 
-    if (hasSatisfiedRequirements && !reported) {
-      onComplete()
-      setReported(true)
-    }
+    await handleResult(hasSatisfiedRequirements, {
+      questionId: pattern.id,
+      expected: pattern.expectedKeywords.join(', '),
+      userInput: code,
+    })
   }
 
   const handleCodeChange = useCallback((nextValue: string) => {

--- a/apps/web/src/features/learning/PracticeMode.tsx
+++ b/apps/web/src/features/learning/PracticeMode.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 import { Button } from '../../components/Button'
 import type { PracticeQuestion } from '../../content/fundamentals/steps'
-import { useJudgmentAction } from './hooks/useJudgmentAction'
+import { useJudgmentAction, type ReviewPayload } from './hooks/useJudgmentAction'
 import { useStepReset } from './hooks/useStepReset'
 
 interface PracticeModeProps {
@@ -18,7 +18,7 @@ export function PracticeMode({ stepId, questions, onComplete }: PracticeModeProp
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [hints, setHints] = useState<Record<string, boolean>>({})
   const [isJudged, setIsJudged] = useState(false)
-  const { handleResult } = useJudgmentAction(stepId, onComplete)
+  const { handleResult } = useJudgmentAction(stepId, 'practice', onComplete)
 
   useStepReset(stepId, () => {
     setAnswers({})
@@ -35,9 +35,23 @@ export function PracticeMode({ stepId, questions, onComplete }: PracticeModeProp
     [answers, questions],
   )
 
-  function handleJudge() {
+  function getReviewPayload(question: PracticeQuestion): ReviewPayload {
+    return {
+      questionId: question.id,
+      expected: question.answer,
+      userInput: answers[question.id] ?? '',
+    }
+  }
+
+  async function handleJudge() {
     setIsJudged(true)
-    handleResult(isAllCorrect)
+    const payloads = questions.filter((question) => {
+      const answer = answers[question.id] ?? ''
+      const isCorrect = normalize(answer) === normalize(question.answer)
+      return isAllCorrect || !isCorrect
+    }).map(getReviewPayload)
+
+    await handleResult(isAllCorrect, payloads)
   }
 
   function handleAnswerChange(questionId: string, value: string) {
@@ -142,7 +156,7 @@ export function PracticeMode({ stepId, questions, onComplete }: PracticeModeProp
       })}
 
       <div className="flex flex-col items-start gap-4 pt-4 sm:flex-row sm:items-center">
-        <Button size="lg" onClick={handleJudge}>
+        <Button size="lg" onClick={() => void handleJudge()}>
           判定する
         </Button>
 

--- a/apps/web/src/features/learning/TestMode.tsx
+++ b/apps/web/src/features/learning/TestMode.tsx
@@ -21,7 +21,7 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
   const isMobile = useIsMobile()
   const [blankInput, setBlankInput] = useState('')
   const [isJudged, setIsJudged] = useState(false)
-  const { handleResult } = useJudgmentAction(stepId, onComplete)
+  const { handleResult } = useJudgmentAction(stepId, 'test', onComplete)
 
   useStepReset(stepId, () => {
     setBlankInput('')
@@ -34,9 +34,17 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
     [blankInput, mergedCode, task.expectedKeywords],
   )
 
-  function handleJudge() {
+  const getReviewPayload = useCallback((userInput: string) => {
+    return {
+      questionId: 'test',
+      expected: task.expectedKeywords.join(', '),
+      userInput,
+    }
+  }, [task.expectedKeywords])
+
+  async function handleJudge() {
     setIsJudged(true)
-    handleResult(isPassed)
+    await handleResult(isPassed, getReviewPayload(mergedCode))
   }
 
   function handleInputChange(value: string) {
@@ -45,12 +53,12 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
   }
 
   const handlePuzzleSubmit = useCallback(
-    (mergedCode: string) => {
+    async (mergedCode: string) => {
       const isCorrect = checkAllKeywords(mergedCode, task.expectedKeywords)
       setIsJudged(true)
-      handleResult(isCorrect)
+      await handleResult(isCorrect, getReviewPayload(mergedCode))
     },
-    [task.expectedKeywords, handleResult],
+    [task.expectedKeywords, handleResult, getReviewPayload],
   )
 
   const parts = task.starterCode.split('____')
@@ -92,7 +100,7 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
           </pre>
 
           <div className="flex flex-col items-start gap-4 pt-4 sm:flex-row sm:items-center">
-            <Button size="lg" onClick={handleJudge}>
+            <Button size="lg" onClick={() => void handleJudge()}>
               判定する
             </Button>
 

--- a/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
@@ -1,8 +1,22 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChallengeMode } from '../ChallengeMode'
 import type { ChallengeTask } from '../../../content/fundamentals/steps'
+
+const recordWrongAnswer = vi.fn()
+const resolveReviewItem = vi.fn()
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: '00000000-0000-0000-0000-000000000001' },
+  }),
+}))
+
+vi.mock('@/services/reviewService', () => ({
+  recordWrongAnswer: (...args: unknown[]) => recordWrongAnswer(...args),
+  resolveReviewItem: (...args: unknown[]) => resolveReviewItem(...args),
+}))
 
 vi.mock('@/components/CodeEditor', () => ({
   CodeEditor: ({ value, onChange }: { value?: string; onChange?: (nextValue: string) => void }) => (
@@ -60,6 +74,13 @@ describe('ChallengeMode', () => {
     cleanup()
   })
 
+  beforeEach(() => {
+    recordWrongAnswer.mockReset()
+    resolveReviewItem.mockReset()
+    recordWrongAnswer.mockResolvedValue(undefined)
+    resolveReviewItem.mockResolvedValue(undefined)
+  })
+
   it('初回の正解判定で onComplete を呼ぶ', async () => {
     const user = userEvent.setup()
     const onComplete = vi.fn()
@@ -78,6 +99,12 @@ describe('ChallengeMode', () => {
       code: 'const [count, setCount] = useState(0); <button onClick={() => setCount(count + 1)} />',
       isPassed: true,
       matchedKeywords: ['useState', 'onClick'],
+    })
+    expect(resolveReviewItem).toHaveBeenCalledWith({
+      userId: '00000000-0000-0000-0000-000000000001',
+      stepId: 'step-a',
+      mode: 'challenge',
+      questionId: 'pattern-1',
     })
     expect(screen.getByRole('status').textContent).toContain('Challengeを完了しました')
     expect(screen.getByRole('status').className).toContain('animate-fadeIn')
@@ -105,6 +132,14 @@ describe('ChallengeMode', () => {
 
     // Assert
     expect(screen.getByRole('status').textContent).toContain('要件を満たしていません。')
+    expect(recordWrongAnswer).toHaveBeenCalledWith({
+      userId: '00000000-0000-0000-0000-000000000001',
+      stepId: 'step-a',
+      mode: 'challenge',
+      questionId: 'pattern-1',
+      expected: 'useState, onClick',
+      userInput: 'const x = 1',
+    })
     expect(screen.getByText('useState')).toBeTruthy()
     expect(screen.getByText('onClick')).toBeTruthy()
   })

--- a/apps/web/src/features/learning/__tests__/PracticeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/PracticeMode.test.tsx
@@ -4,12 +4,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { PracticeMode } from '../PracticeMode'
 import type { PracticeQuestion } from '../../../content/fundamentals/steps'
 
-const addToReviewList = vi.fn()
-const removeFromReviewList = vi.fn()
+const recordWrongAnswer = vi.fn()
+const resolveReviewItem = vi.fn()
 
-vi.mock('../../../services/reviewListService', () => ({
-  addToReviewList: (...args: unknown[]) => addToReviewList(...args),
-  removeFromReviewList: (...args: unknown[]) => removeFromReviewList(...args),
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: '00000000-0000-0000-0000-000000000001' },
+  }),
+}))
+
+vi.mock('../../../services/reviewService', () => ({
+  recordWrongAnswer: (...args: unknown[]) => recordWrongAnswer(...args),
+  resolveReviewItem: (...args: unknown[]) => resolveReviewItem(...args),
 }))
 
 const firstQuestions: PracticeQuestion[] = [
@@ -49,8 +55,10 @@ describe('PracticeMode', () => {
   })
 
   beforeEach(() => {
-    addToReviewList.mockReset()
-    removeFromReviewList.mockReset()
+    recordWrongAnswer.mockReset()
+    resolveReviewItem.mockReset()
+    recordWrongAnswer.mockResolvedValue(undefined)
+    resolveReviewItem.mockResolvedValue(undefined)
   })
 
   it('choices がある問題は選択ボタンを表示し、input は表示しない', () => {
@@ -98,7 +106,12 @@ describe('PracticeMode', () => {
     await user.click(screen.getByRole('button', { name: '判定する' }))
 
     expect(onComplete).toHaveBeenCalledTimes(1)
-    expect(removeFromReviewList).toHaveBeenCalledWith('step-a')
+    expect(resolveReviewItem).toHaveBeenCalledWith({
+      userId: '00000000-0000-0000-0000-000000000001',
+      stepId: 'step-a',
+      mode: 'practice',
+      questionId: 'q1',
+    })
     expect(screen.getByRole('status').textContent).toContain('Practiceを完了しました')
     expect(screen.getByRole('status').className).toContain('animate-fadeIn')
     expect(screen.getByText('ヒント1')).toBeTruthy()

--- a/apps/web/src/features/learning/__tests__/TestMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/TestMode.test.tsx
@@ -6,8 +6,14 @@ import { getAllCourses, findCategoryByStepId } from '../../../content/courseData
 import type { TestTask } from '../../../content/fundamentals/steps'
 import { previewByStepId } from '../testModePreview'
 
-const addToReviewList = vi.fn()
-const removeFromReviewList = vi.fn()
+const recordWrongAnswer = vi.fn()
+const resolveReviewItem = vi.fn()
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: '00000000-0000-0000-0000-000000000001' },
+  }),
+}))
 
 vi.mock('@/hooks/useIsMobile', () => ({
   useIsMobile: () => false,
@@ -24,9 +30,9 @@ vi.mock('prismjs/components/prism-jsx', () => ({}))
 vi.mock('prismjs/components/prism-typescript', () => ({}))
 vi.mock('prismjs/components/prism-tsx', () => ({}))
 
-vi.mock('../../../services/reviewListService', () => ({
-  addToReviewList: (...args: unknown[]) => addToReviewList(...args),
-  removeFromReviewList: (...args: unknown[]) => removeFromReviewList(...args),
+vi.mock('../../../services/reviewService', () => ({
+  recordWrongAnswer: (...args: unknown[]) => recordWrongAnswer(...args),
+  resolveReviewItem: (...args: unknown[]) => resolveReviewItem(...args),
 }))
 
 const firstTask: TestTask = {
@@ -49,8 +55,10 @@ describe('TestMode', () => {
   })
 
   beforeEach(() => {
-    addToReviewList.mockReset()
-    removeFromReviewList.mockReset()
+    recordWrongAnswer.mockReset()
+    resolveReviewItem.mockReset()
+    recordWrongAnswer.mockResolvedValue(undefined)
+    resolveReviewItem.mockResolvedValue(undefined)
   })
 
   it('stepId が変わると入力内容と判定状態をリセットする', async () => {
@@ -63,7 +71,12 @@ describe('TestMode', () => {
     await user.click(screen.getByRole('button', { name: '判定する' }))
 
     expect(onComplete).toHaveBeenCalledTimes(1)
-    expect(removeFromReviewList).toHaveBeenCalledWith('step-a')
+    expect(resolveReviewItem).toHaveBeenCalledWith({
+      userId: '00000000-0000-0000-0000-000000000001',
+      stepId: 'step-a',
+      mode: 'test',
+      questionId: 'test',
+    })
     expect(screen.getByRole('status').textContent).toContain('テスト合格')
     expect(screen.getByRole('status').className).toContain('animate-fadeIn')
 

--- a/apps/web/src/features/learning/hooks/useJudgmentAction.ts
+++ b/apps/web/src/features/learning/hooks/useJudgmentAction.ts
@@ -1,26 +1,70 @@
 import { useCallback, useState } from 'react'
-import { addToReviewList, removeFromReviewList } from '@/services/reviewListService'
+import { useAuth } from '@/contexts/AuthContext'
+import { recordWrongAnswer, resolveReviewItem, type ReviewMode } from '@/services/reviewService'
 import { useStepReset } from './useStepReset'
 
+export type ReviewPayload = {
+  questionId?: string | null
+  expected?: string | null
+  userInput?: string | null
+}
+
 /** 判定結果に応じてレビューリスト操作と onComplete 呼び出しを行うフック */
-export function useJudgmentAction(stepId: string, onComplete: () => void) {
+export function useJudgmentAction(stepId: string, mode: ReviewMode, onComplete: () => void) {
+  const { user } = useAuth()
+  const userId = user?.id
   const [reported, setReported] = useState(false)
 
   useStepReset(stepId, () => setReported(false))
 
   const handleResult = useCallback(
-    (isCorrect: boolean) => {
+    async (isCorrect: boolean, payloads: ReviewPayload | ReviewPayload[] = {}) => {
+      const items = Array.isArray(payloads) ? payloads : [payloads]
+
+      if (userId) {
+        try {
+          if (isCorrect) {
+            await Promise.all(
+              items.map((item) => {
+                const questionId = item.questionId ?? null
+                return resolveReviewItem({
+                  userId,
+                  stepId,
+                  mode,
+                  questionId,
+                })
+              }),
+            )
+          } else {
+            await Promise.all(
+              items.map((item) => {
+                const questionId = item.questionId ?? null
+                const expected = item.expected ?? null
+                const userInput = item.userInput ?? null
+                return recordWrongAnswer({
+                  userId,
+                  stepId,
+                  mode,
+                  questionId,
+                  expected,
+                  userInput,
+                })
+              }),
+            )
+          }
+        } catch {
+          // 復習キュー同期の失敗で学習モード完了を止めない。
+        }
+      }
+
       if (isCorrect) {
-        removeFromReviewList(stepId)
         if (!reported) {
           onComplete()
           setReported(true)
         }
-      } else {
-        addToReviewList(stepId)
       }
     },
-    [stepId, reported, onComplete],
+    [stepId, mode, reported, onComplete, userId],
   )
 
   return { reported, handleResult }

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,6 +1,7 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { Atom, BookOpen, Zap } from 'lucide-react'
+import { useAuth } from '../contexts/AuthContext'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useGreetingName } from '../hooks/useGreetingName'
 import { useSignOut } from '../hooks/useSignOut'
@@ -11,24 +12,72 @@ import { useLearningContext } from '../contexts/LearningContext'
 import { AppHeader } from '../features/dashboard/components/AppHeader'
 import { DashboardSidebar } from '../features/dashboard/components/DashboardSidebar'
 import { OnboardingCard } from '../features/dashboard/components/OnboardingCard'
+import { ReviewQueueCard } from '../features/dashboard/components/ReviewQueueCard'
 import { TodayActionCard } from '../features/dashboard/components/TodayActionCard'
 import { WelcomeBanner } from '../features/dashboard/components/WelcomeBanner'
 import { isCourseCompleted } from '../lib/courseLock'
 import { supabaseConfigError } from '../lib/supabaseClient'
 import { getRecommendedAction } from '../services/recommendationService'
+import { getOpenCount, listOpen, type ReviewItem } from '../services/reviewService'
 import { CATEGORY_ICONS, PRACTICE_MODE_CARDS } from '../shared/constants'
 
 export function DashboardPage() {
   useDocumentTitle('ダッシュボード')
+  const { user } = useAuth()
+  const userId = user?.id
   const { allStepProgress, completedStepIds, completedStepsCount } = useLearningContext()
   const { greetingName } = useGreetingName()
   const [error, setError] = useState<string | null>(null)
+  const [reviewCount, setReviewCount] = useState(0)
+  const [firstReviewItem, setFirstReviewItem] = useState<ReviewItem | null>(null)
+  const [isLoadingReview, setIsLoadingReview] = useState(false)
+  const [reviewError, setReviewError] = useState<string | null>(null)
   const onSignOutError = useCallback((msg: string) => setError(msg), [])
   const handleSignOut = useSignOut(onSignOutError)
   const firstImplementedStep = getFirstImplementedStep()
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadReviewSummary() {
+      if (!userId) {
+        setReviewCount(0)
+        setFirstReviewItem(null)
+        setReviewError(null)
+        return
+      }
+
+      setIsLoadingReview(true)
+      setReviewError(null)
+      try {
+        const [count, items] = await Promise.all([
+          getOpenCount(userId),
+          listOpen(userId, 1),
+        ])
+
+        if (cancelled) return
+        setReviewCount(count)
+        setFirstReviewItem(items[0] ?? null)
+      } catch (e) {
+        if (cancelled) return
+        setReviewCount(0)
+        setFirstReviewItem(null)
+        setReviewError(e instanceof Error ? e.message : '復習キューの取得に失敗しました')
+      } finally {
+        if (!cancelled) setIsLoadingReview(false)
+      }
+    }
+
+    void loadReviewSummary()
+
+    return () => {
+      cancelled = true
+    }
+  }, [userId])
+
   const recommendedAction = useMemo(
-    () => getRecommendedAction({ progress: allStepProgress, enableReviewQueue: false }),
-    [allStepProgress],
+    () => getRecommendedAction({ progress: allStepProgress, reviewCount, enableReviewQueue: true }),
+    [allStepProgress, reviewCount],
   )
 
   return (
@@ -43,6 +92,12 @@ export function DashboardPage() {
           <section className="space-y-6 lg:col-span-8">
             <WelcomeBanner displayName={greetingName} />
             <TodayActionCard action={recommendedAction} />
+            <ReviewQueueCard
+              count={reviewCount}
+              firstItem={firstReviewItem}
+              isLoading={isLoadingReview}
+              error={reviewError}
+            />
             {completedStepsCount === 0 && firstImplementedStep ? (
               <OnboardingCard startTo={`/step/${firstImplementedStep.id}`} />
             ) : null}

--- a/apps/web/src/pages/__tests__/DashboardPage.test.tsx
+++ b/apps/web/src/pages/__tests__/DashboardPage.test.tsx
@@ -5,6 +5,8 @@ import { DashboardPage } from '../DashboardPage'
 
 const testState = vi.hoisted(() => ({
   getProfileMock: vi.fn(),
+  getOpenCountMock: vi.fn(),
+  listOpenMock: vi.fn(),
   learningContext: {
     allStepProgress: [
       {
@@ -63,6 +65,11 @@ vi.mock('@/services/profileService', () => ({
   getProfile: (...args: unknown[]) => testState.getProfileMock(...args),
 }))
 
+vi.mock('@/services/reviewService', () => ({
+  getOpenCount: (...args: unknown[]) => testState.getOpenCountMock(...args),
+  listOpen: (...args: unknown[]) => testState.listOpenMock(...args),
+}))
+
 vi.mock('@/lib/supabaseClient', () => ({
   supabaseConfigError: null,
 }))
@@ -74,6 +81,10 @@ describe('DashboardPage', () => {
     testState.getProfileMock.mockResolvedValue({
       display_name: 'Coden User',
     })
+    testState.getOpenCountMock.mockReset()
+    testState.getOpenCountMock.mockResolvedValue(0)
+    testState.listOpenMock.mockReset()
+    testState.listOpenMock.mockResolvedValue([])
     testState.learningContext = {
       allStepProgress: [
         {
@@ -116,6 +127,7 @@ describe('DashboardPage', () => {
     expect(await screen.findByText('学習コース')).toBeTruthy()
     expect(screen.getByText('今日のおすすめ')).toBeTruthy()
     expect(screen.getByText('Step 2 の Practice から再開')).toBeTruthy()
+    expect(await screen.findByText('復習待ち 0 件')).toBeTruthy()
     expect(screen.getByText('React')).toBeTruthy()
     expect(screen.getByText('TypeScript')).toBeTruthy()
     expect(screen.getByText('スキルアップ')).toBeTruthy()
@@ -146,5 +158,34 @@ describe('DashboardPage', () => {
     expect(screen.getByText('はじめての方へ')).toBeTruthy()
     expect(screen.getByText('4つの流れで1ステップずつ進めます')).toBeTruthy()
     expect(screen.getByRole('link', { name: '始める' }).getAttribute('href')).toBe('/step/usestate-basic')
+  })
+
+  it('復習待ちがある場合は復習カードと今日のおすすめで復習を優先する', async () => {
+    testState.getOpenCountMock.mockResolvedValue(2)
+    testState.listOpenMock.mockResolvedValue([
+      {
+        id: 'review-1',
+        user_id: 'user-1',
+        step_id: 'events',
+        mode: 'practice',
+        question_id: 'q1',
+        expected: 'onClick',
+        user_input: 'onclick',
+        status: 'open',
+        created_at: '2026-06-04T00:00:00Z',
+        resolved_at: null,
+      },
+    ])
+
+    render(
+      <MemoryRouter>
+        <DashboardPage />
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByText('復習待ち 2 件')).toBeTruthy()
+    expect(screen.getByText('昨日間違えた問題を復習')).toBeTruthy()
+    expect(screen.getByText(/最優先: Step 2/)).toBeTruthy()
+    expect(screen.getAllByRole('link', { name: '復習へ進む' }).length).toBeGreaterThanOrEqual(1)
   })
 })

--- a/apps/web/src/services/__tests__/dailyChallengeService.test.ts
+++ b/apps/web/src/services/__tests__/dailyChallengeService.test.ts
@@ -1,6 +1,7 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { supabase } from '../../lib/supabaseClient'
 import { awardPoints } from '../pointService'
+import { recordWrongAnswer, resolveReviewItem } from '../reviewService'
 import {
   getTodayJst,
   getCurrentWeekDates,
@@ -22,8 +23,15 @@ vi.mock('../pointService', () => ({
   awardPoints: vi.fn(),
 }))
 
+vi.mock('../reviewService', () => ({
+  recordWrongAnswer: vi.fn(),
+  resolveReviewItem: vi.fn(),
+}))
+
 const mockFrom = vi.mocked(supabase.from)
 const mockAwardPoints = vi.mocked(awardPoints)
+const mockRecordWrongAnswer = vi.mocked(recordWrongAnswer)
+const mockResolveReviewItem = vi.mocked(resolveReviewItem)
 
 // ─── 純粋関数テスト ──────────────────────────────────────
 
@@ -224,12 +232,20 @@ describe('submitDailyAnswer', () => {
       }),
     } as unknown as ReturnType<typeof supabase.from>))
     mockAwardPoints.mockResolvedValue()
+    mockRecordWrongAnswer.mockResolvedValue()
+    mockResolveReviewItem.mockResolvedValue()
   })
 
   it('正解の場合は isCorrect: true と 20pt を返す', async () => {
     const result = await submitDailyAnswer(userId, question, 'setCount', dateStr)
     expect(result.isCorrect).toBe(true)
     expect(result.pointsEarned).toBe(20)
+    expect(mockResolveReviewItem).toHaveBeenCalledWith({
+      userId,
+      stepId: 'usestate-basic',
+      mode: 'daily',
+      questionId: 'usestate-basic-daily-0',
+    })
     expect(mockAwardPoints).toHaveBeenCalledWith(20, 'デイリーチャレンジ正解')
   })
 
@@ -237,6 +253,14 @@ describe('submitDailyAnswer', () => {
     const result = await submitDailyAnswer(userId, question, 'wrongAnswer', dateStr)
     expect(result.isCorrect).toBe(false)
     expect(result.pointsEarned).toBe(0)
+    expect(mockRecordWrongAnswer).toHaveBeenCalledWith({
+      userId,
+      stepId: 'usestate-basic',
+      mode: 'daily',
+      questionId: 'usestate-basic-daily-0',
+      expected: 'setCount',
+      userInput: 'wrongAnswer',
+    })
     expect(mockAwardPoints).not.toHaveBeenCalled()
   })
 

--- a/apps/web/src/services/dailyChallengeService.ts
+++ b/apps/web/src/services/dailyChallengeService.ts
@@ -3,6 +3,7 @@ import { MAX_ANSWER_LENGTH, POINTS_DAILY_CORRECT, POINTS_DAILY_STREAK_BONUS } fr
 import { fromSupabaseError } from '../shared/errors'
 import { assertMaxLength, assertUuid } from '../shared/validation'
 import { awardPoints } from './pointService'
+import { recordWrongAnswer, resolveReviewItem } from './reviewService'
 import { DAILY_QUESTIONS } from '../content/daily/questions'
 import type {
   DailyQuestion,
@@ -150,12 +151,35 @@ export async function submitDailyAnswer(
   }
 
   if (isCorrect) {
+    try {
+      await resolveReviewItem({
+        userId,
+        stepId: question.stepId,
+        mode: 'daily',
+        questionId: question.id,
+      })
+    } catch {
+      // 復習キュー同期の失敗でDaily回答完了を止めない。
+    }
     await awardPoints(POINTS_DAILY_CORRECT, 'デイリーチャレンジ正解')
 
     // 7日連続ボーナスチェック（7の倍数日ごとに付与）
     const streak = await getDailyConsecutiveStreak(userId, dateStr)
     if (streak > 0 && streak % 7 === 0) {
       await awardPoints(POINTS_DAILY_STREAK_BONUS, `デイリー${streak}日連続ボーナス`)
+    }
+  } else {
+    try {
+      await recordWrongAnswer({
+        userId,
+        stepId: question.stepId,
+        mode: 'daily',
+        questionId: question.id,
+        expected: question.answer,
+        userInput: userAnswer,
+      })
+    } catch {
+      // 復習キュー同期の失敗でDaily回答結果の表示を止めない。
     }
   }
 


### PR DESCRIPTION
﻿## Summary
- Practice / Test / Challenge / Daily の正誤判定を reviewService の record / resolve に接続
- Dashboard に復習待ち件数・最優先ステップ・CTA を表示する ReviewQueueCard を追加
- TodayActionCard の復習優先を有効化し、復習待ちがある場合は復習導線を最優先表示
- 復習キュー同期は fail-soft にし、DB同期失敗で学習完了やDaily回答が止まらないよう調整

## Test plan
- npm run typecheck
- npm run lint
- npm run test
- npm run build
- pre-commit: lint / typecheck
- pre-push: test / build

## Notes
- Issue不要: v5roadmap02 M2 でスコープ定義済み
- ブラウザー表示確認はユーザー側で実施予定
