### PR TITLE
feat: prioritize review items in daily challenge

### DIFF
--- a/apps/web/src/content/daily/types.ts
+++ b/apps/web/src/content/daily/types.ts
@@ -15,6 +15,7 @@ export interface TodayChallengeResult {
   completedAt: string | null
   pointsEarned: number
   dateStr: string
+  reviewReason?: string | null
 }
 
 export interface SubmitResult {

--- a/apps/web/src/features/daily/components/DailyChallengeCard.tsx
+++ b/apps/web/src/features/daily/components/DailyChallengeCard.tsx
@@ -4,10 +4,11 @@ import type { DailyQuestion, SubmitResult } from '../../../content/daily/types'
 interface DailyChallengeCardProps {
   question: DailyQuestion
   dateStr: string
+  reviewReason?: string | null | undefined
   onSubmit: (answer: string) => Promise<SubmitResult>
 }
 
-export function DailyChallengeCard({ question, dateStr, onSubmit }: DailyChallengeCardProps) {
+export function DailyChallengeCard({ question, dateStr, reviewReason, onSubmit }: DailyChallengeCardProps) {
   const [answer, setAnswer] = useState('')
   const [result, setResult] = useState<SubmitResult | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -38,6 +39,12 @@ export function DailyChallengeCard({ question, dateStr, onSubmit }: DailyChallen
       <p className="mb-5 whitespace-pre-wrap text-base font-medium leading-relaxed text-text-dark">
         {question.prompt}
       </p>
+
+      {reviewReason && (
+        <p className="mb-5 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
+          {reviewReason}
+        </p>
+      )}
 
       {!result && (
         <>

--- a/apps/web/src/features/daily/components/__tests__/DailyChallengeCard.test.tsx
+++ b/apps/web/src/features/daily/components/__tests__/DailyChallengeCard.test.tsx
@@ -47,6 +47,18 @@ describe('DailyChallengeCard', () => {
     expect(screen.getByText('onclick')).toBeTruthy()
   })
 
+  it('復習優先の理由がある場合は表示される', () => {
+    render(
+      <DailyChallengeCard
+        question={blankQuestion}
+        dateStr="2026-04-02"
+        reviewReason="Practiceで復習待ちになったStepから出題しています。"
+        onSubmit={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('Practiceで復習待ちになったStepから出題しています。')).toBeTruthy()
+  })
+
   it('ヒントの表示/非表示を切り替えられる', () => {
     render(
       <DailyChallengeCard question={blankQuestion} dateStr="2026-04-02" onSubmit={vi.fn()} />,

--- a/apps/web/src/pages/DailyChallengePage.tsx
+++ b/apps/web/src/pages/DailyChallengePage.tsx
@@ -107,6 +107,7 @@ export function DailyChallengePage() {
               <DailyChallengeCard
                 question={challenge.question}
                 dateStr={challenge.dateStr}
+                reviewReason={challenge.reviewReason}
                 onSubmit={handleSubmit}
               />
             ) : null}

--- a/apps/web/src/services/__tests__/dailyChallengeService.test.ts
+++ b/apps/web/src/services/__tests__/dailyChallengeService.test.ts
@@ -1,7 +1,7 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { supabase } from '../../lib/supabaseClient'
 import { awardPoints } from '../pointService'
-import { recordWrongAnswer, resolveReviewItem } from '../reviewService'
+import { pickForDaily, recordWrongAnswer, resolveReviewItem } from '../reviewService'
 import {
   getTodayJst,
   getCurrentWeekDates,
@@ -24,12 +24,14 @@ vi.mock('../pointService', () => ({
 }))
 
 vi.mock('../reviewService', () => ({
+  pickForDaily: vi.fn(),
   recordWrongAnswer: vi.fn(),
   resolveReviewItem: vi.fn(),
 }))
 
 const mockFrom = vi.mocked(supabase.from)
 const mockAwardPoints = vi.mocked(awardPoints)
+const mockPickForDaily = vi.mocked(pickForDaily)
 const mockRecordWrongAnswer = vi.mocked(recordWrongAnswer)
 const mockResolveReviewItem = vi.mocked(resolveReviewItem)
 
@@ -125,6 +127,32 @@ describe('selectDailyQuestion', () => {
     expect(uniqueStepIds.has('events')).toBe(false)
     expect(uniqueStepIds.has('usestate-basic')).toBe(true)
   })
+
+  it('復習候補がDaily問題IDを持つ場合はその問題を優先する', () => {
+    const completedStepIds = new Set(['events'])
+    const result = selectDailyQuestion(completedStepIds, '2026-03-30', {
+      id: 'review-1',
+      step_id: 'events',
+      mode: 'daily',
+      question_id: 'events-daily-1',
+      created_at: '2026-06-03T12:00:00.000Z',
+    })
+
+    expect(result?.id).toBe('events-daily-1')
+  })
+
+  it('復習候補がPractice問題IDの場合は同じStepのDaily問題を優先する', () => {
+    const completedStepIds = new Set(['usestate-basic', 'events'])
+    const result = selectDailyQuestion(completedStepIds, '2026-03-30', {
+      id: 'review-1',
+      step_id: 'events',
+      mode: 'practice',
+      question_id: 'practice-q1',
+      created_at: '2026-06-03T12:00:00.000Z',
+    })
+
+    expect(result?.stepId).toBe('events')
+  })
 })
 
 // ─── DB 関数テスト ───────────────────────────────────────
@@ -135,6 +163,7 @@ describe('getTodayChallenge', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockPickForDaily.mockResolvedValue(null)
   })
 
   it('未完了の場合は question を返す', async () => {
@@ -152,6 +181,7 @@ describe('getTodayChallenge', () => {
     expect(result.alreadyCompleted).toBe(false)
     expect(result.question).toBeDefined()
     expect(result.question?.stepId).toBe('usestate-basic')
+    expect(result.reviewReason).toBeNull()
   })
 
   it('完了済みの場合は alreadyCompleted: true を返す', async () => {
@@ -177,6 +207,7 @@ describe('getTodayChallenge', () => {
     expect(result.alreadyCompleted).toBe(true)
     expect(result.question).toBeNull()
     expect(result.pointsEarned).toBe(20)
+    expect(result.reviewReason).toBeNull()
   })
 
   it('完了済みステップがない場合は question: null を返す', async () => {
@@ -193,6 +224,30 @@ describe('getTodayChallenge', () => {
     const result = await getTodayChallenge(userId, new Set())
     expect(result.question).toBeNull()
     expect(result.alreadyCompleted).toBe(false)
+  })
+
+  it('open 誤答がある場合はDailyで弱点Stepを優先し理由を返す', async () => {
+    mockFrom.mockReturnValue({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          }),
+        }),
+      }),
+    } as unknown as ReturnType<typeof supabase.from>)
+    mockPickForDaily.mockResolvedValue({
+      id: 'review-1',
+      step_id: 'events',
+      mode: 'practice',
+      question_id: 'practice-q1',
+      created_at: '2026-06-03T12:00:00.000Z',
+    })
+
+    const result = await getTodayChallenge(userId, new Set(['usestate-basic', 'events']))
+
+    expect(result.question?.stepId).toBe('events')
+    expect(result.reviewReason).toContain('Practice')
   })
 })
 

--- a/apps/web/src/services/__tests__/reviewService.test.ts
+++ b/apps/web/src/services/__tests__/reviewService.test.ts
@@ -3,6 +3,7 @@ import { supabase } from '../../lib/supabaseClient'
 import {
   getOpenCount,
   listOpen,
+  pickForDaily,
   recordWrongAnswer,
   resolveReviewItem,
   type ReviewItem,
@@ -57,6 +58,34 @@ function makeThenableEqQuery(result: unknown) {
   }
 
   return query
+}
+
+function makeReviewItem(overrides: Partial<ReviewItem> = {}): ReviewItem {
+  return {
+    id: 'review-1',
+    user_id: userId,
+    step_id: 'usestate-basic',
+    mode: 'daily',
+    question_id: 'daily-1',
+    expected: 'setCount',
+    user_input: 'wrong',
+    status: 'open',
+    created_at: '2026-06-03T12:00:00.000Z',
+    resolved_at: null,
+    ...overrides,
+  }
+}
+
+function mockListOpenRows(rows: ReviewItem[]) {
+  const query = {
+    eq: vi.fn(() => query),
+    order: vi.fn(() => query),
+    limit: vi.fn().mockResolvedValue({ data: rows, error: null }),
+  }
+  const select = vi.fn(() => query)
+
+  mockFrom.mockReturnValueOnce({ select } as unknown as ReturnType<typeof supabase.from>)
+  return { query, select }
 }
 
 describe('reviewService', () => {
@@ -168,31 +197,44 @@ describe('reviewService', () => {
   })
 
   it('listOpen は open item を古い順に指定件数返す', async () => {
-    const rows: ReviewItem[] = [
-      {
-        id: 'review-1',
-        user_id: userId,
-        step_id: 'usestate-basic',
-        mode: 'daily',
-        question_id: 'daily-1',
-        expected: 'setCount',
-        user_input: 'wrong',
-        status: 'open',
-        created_at: '2026-06-03T12:00:00.000Z',
-        resolved_at: null,
-      },
-    ]
-    const query = {
-      eq: vi.fn(() => query),
-      order: vi.fn(() => query),
-      limit: vi.fn().mockResolvedValue({ data: rows, error: null }),
-    }
-    const select = vi.fn(() => query)
-
-    mockFrom.mockReturnValueOnce({ select } as unknown as ReturnType<typeof supabase.from>)
+    const rows: ReviewItem[] = [makeReviewItem()]
+    const { query } = mockListOpenRows(rows)
 
     await expect(listOpen(userId, 5)).resolves.toEqual(rows)
     expect(query.order).toHaveBeenCalledWith('created_at', { ascending: true })
     expect(query.limit).toHaveBeenCalledWith(5)
+  })
+
+  it('pickForDaily は完了済みStepに一致する最初の open item を返す', async () => {
+    const rows: ReviewItem[] = [
+      makeReviewItem({
+        id: 'review-1',
+        step_id: 'conditional',
+        mode: 'test',
+        question_id: 'test-q1',
+      }),
+      makeReviewItem({
+        id: 'review-2',
+        step_id: 'events',
+        mode: 'practice',
+        question_id: 'practice-q1',
+      }),
+    ]
+    const { query } = mockListOpenRows(rows)
+
+    await expect(pickForDaily(userId, new Set(['events']), 25)).resolves.toEqual(rows[1])
+    expect(query.limit).toHaveBeenCalledWith(25)
+  })
+
+  it('pickForDaily は完了済みStepに一致する open item がなければ null を返す', async () => {
+    const rows: ReviewItem[] = [
+      makeReviewItem({
+        id: 'review-1',
+        step_id: 'conditional',
+      }),
+    ]
+    mockListOpenRows(rows)
+
+    await expect(pickForDaily(userId, new Set(['events']))).resolves.toBeNull()
   })
 })

--- a/apps/web/src/services/dailyChallengeService.ts
+++ b/apps/web/src/services/dailyChallengeService.ts
@@ -3,7 +3,13 @@ import { MAX_ANSWER_LENGTH, POINTS_DAILY_CORRECT, POINTS_DAILY_STREAK_BONUS } fr
 import { fromSupabaseError } from '../shared/errors'
 import { assertMaxLength, assertUuid } from '../shared/validation'
 import { awardPoints } from './pointService'
-import { recordWrongAnswer, resolveReviewItem } from './reviewService'
+import {
+  pickForDaily,
+  recordWrongAnswer,
+  resolveReviewItem,
+  type DailyReviewCandidate,
+  type ReviewMode,
+} from './reviewService'
 import { DAILY_QUESTIONS } from '../content/daily/questions'
 import type {
   DailyQuestion,
@@ -37,10 +43,36 @@ export function getCurrentWeekDates(now?: Date): string[] {
   })
 }
 
-/** 完了済みステップのプールから日付に基づいて問題を選択する（決定論的） */
+const REVIEW_MODE_LABELS: Record<ReviewMode, string> = {
+  practice: 'Practice',
+  test: 'Test',
+  challenge: 'Challenge',
+  daily: 'Daily',
+}
+
+function selectByDate(pool: DailyQuestion[], dateStr: string): DailyQuestion | undefined {
+  if (pool.length === 0) return undefined
+
+  const epochDays = Math.floor(new Date(dateStr + 'T00:00:00Z').getTime() / (1000 * 60 * 60 * 24))
+  return pool[epochDays % pool.length]
+}
+
+function getReviewReason(
+  reviewCandidate: DailyReviewCandidate | null | undefined,
+  question: DailyQuestion | undefined,
+): string | null {
+  if (!reviewCandidate || !question || reviewCandidate.step_id !== question.stepId) {
+    return null
+  }
+
+  return `${REVIEW_MODE_LABELS[reviewCandidate.mode]}で復習待ちになったStepから出題しています。`
+}
+
+/** 完了済みステップのプールから日付に基づいて問題を選択する（復習候補があれば優先） */
 export function selectDailyQuestion(
   completedStepIds: ReadonlySet<string>,
   dateStr: string,
+  reviewCandidate?: DailyReviewCandidate | null,
 ): DailyQuestion | undefined {
   if (completedStepIds.size === 0) return undefined
 
@@ -48,9 +80,23 @@ export function selectDailyQuestion(
   const pool = DAILY_QUESTIONS.filter((q) => completedStepIds.has(q.stepId))
   if (pool.length === 0) return undefined
 
-  // epochDays を決定論的シードとして使用
-  const epochDays = Math.floor(new Date(dateStr + 'T00:00:00Z').getTime() / (1000 * 60 * 60 * 24))
-  return pool[epochDays % pool.length]
+  if (reviewCandidate && completedStepIds.has(reviewCandidate.step_id)) {
+    const exactQuestion = reviewCandidate.question_id
+      ? pool.find((q) => q.id === reviewCandidate.question_id)
+      : undefined
+
+    if (exactQuestion) {
+      return exactQuestion
+    }
+
+    const stepPool = pool.filter((q) => q.stepId === reviewCandidate.step_id)
+    const stepQuestion = selectByDate(stepPool, dateStr)
+    if (stepQuestion) {
+      return stepQuestion
+    }
+  }
+
+  return selectByDate(pool, dateStr)
 }
 
 // ─── DB 関数 ─────────────────────────────────────────────
@@ -82,10 +128,18 @@ export async function getTodayChallenge(
       completedAt: history.completed_at,
       pointsEarned: history.points_earned,
       dateStr,
+      reviewReason: null,
     }
   }
 
-  const question = selectDailyQuestion(completedStepIds, dateStr)
+  let reviewCandidate: DailyReviewCandidate | null = null
+  try {
+    reviewCandidate = await pickForDaily(userId, completedStepIds)
+  } catch {
+    reviewCandidate = null
+  }
+
+  const question = selectDailyQuestion(completedStepIds, dateStr, reviewCandidate)
 
   return {
     question: question ?? null,
@@ -93,6 +147,7 @@ export async function getTodayChallenge(
     completedAt: null,
     pointsEarned: 0,
     dateStr,
+    reviewReason: getReviewReason(reviewCandidate, question),
   }
 }
 

--- a/apps/web/src/services/reviewService.ts
+++ b/apps/web/src/services/reviewService.ts
@@ -6,6 +6,10 @@ import type { Tables, TablesInsert, TablesUpdate } from '../shared/types/databas
 export type ReviewItem = Tables<'review_items'>
 export type ReviewMode = ReviewItem['mode']
 export type ReviewStatus = ReviewItem['status']
+export type DailyReviewCandidate = Pick<
+  ReviewItem,
+  'id' | 'step_id' | 'mode' | 'question_id' | 'created_at'
+>
 
 const REVIEW_MODES = new Set<ReviewMode>(['practice', 'test', 'challenge', 'daily'])
 const MAX_REVIEW_TEXT_LENGTH = 2000
@@ -178,4 +182,20 @@ export async function listOpen(userId: string, limit = 10): Promise<ReviewItem[]
   }
 
   return data ?? []
+}
+
+export async function pickForDaily(
+  userId: string,
+  completedStepIds: ReadonlySet<string>,
+  limit = 50,
+): Promise<DailyReviewCandidate | null> {
+  assertUuid(userId, 'userId')
+  assertPositiveInteger(limit, 'limit')
+
+  if (completedStepIds.size === 0) {
+    return null
+  }
+
+  const items = await listOpen(userId, limit)
+  return items.find((item) => completedStepIds.has(item.step_id)) ?? null
 }


### PR DESCRIPTION
## Summary
- add reviewService.pickForDaily to choose the oldest open review item from completed steps
- prioritize weak-step Daily questions while preserving deterministic fallback selection
- show a short Daily reason when a review item influenced the question
- cover review-priority selection and reason display with tests

## Test plan
- npm run typecheck
- npm run lint
- npm run test
- npm run build