### PR TITLE
fix: 復習キューの遷移先と表示重複を修正

### DIFF
--- a/apps/web/src/content/daily/types.ts
+++ b/apps/web/src/content/daily/types.ts
@@ -9,6 +9,12 @@ export interface DailyQuestion {
   choices?: string[]
 }
 
+export interface DailyReviewTarget {
+  stepId: string
+  mode: 'practice' | 'test' | 'challenge' | 'daily'
+  questionId?: string | null
+}
+
 export interface TodayChallengeResult {
   question: DailyQuestion | null
   alreadyCompleted: boolean
@@ -16,6 +22,7 @@ export interface TodayChallengeResult {
   pointsEarned: number
   dateStr: string
   reviewReason?: string | null
+  reviewTarget?: DailyReviewTarget | null
 }
 
 export interface SubmitResult {

--- a/apps/web/src/features/dashboard/components/ReviewQueueCard.tsx
+++ b/apps/web/src/features/dashboard/components/ReviewQueueCard.tsx
@@ -14,9 +14,17 @@ function formatCount(count: number) {
   return count > 99 ? '99+' : String(count)
 }
 
+function getReviewPath(item: ReviewItem | null) {
+  if (!item) return '/curriculum'
+
+  const mode = item.mode === 'daily' ? 'practice' : item.mode
+  return `/step/${item.step_id}?mode=${mode}`
+}
+
 export function ReviewQueueCard({ count, firstItem, isLoading = false, error = null }: ReviewQueueCardProps) {
   const firstStep = firstItem ? findStepById(firstItem.step_id) : undefined
   const hasOpenItems = count > 0
+  const reviewPath = getReviewPath(firstItem)
 
   return (
     <section className="rounded-2xl border border-amber-200 bg-white p-5 shadow-sm">
@@ -45,7 +53,7 @@ export function ReviewQueueCard({ count, firstItem, isLoading = false, error = n
         </div>
 
         <Link
-          to={hasOpenItems ? '/daily' : '/curriculum'}
+          to={hasOpenItems ? reviewPath : '/curriculum'}
           className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-amber-500 px-4 py-2.5 text-sm font-semibold text-white transition hover:bg-amber-600"
         >
           {hasOpenItems ? '復習へ進む' : '学習を進める'}

--- a/apps/web/src/pages/DailyChallengePage.tsx
+++ b/apps/web/src/pages/DailyChallengePage.tsx
@@ -50,7 +50,13 @@ export function DailyChallengePage() {
     if (!user || !challenge?.question) {
       throw new Error('問題が読み込まれていません')
     }
-    const result = await submitDailyAnswer(user.id, challenge.question, answer, challenge.dateStr)
+    const result = await submitDailyAnswer(
+      user.id,
+      challenge.question,
+      answer,
+      challenge.dateStr,
+      challenge.reviewTarget,
+    )
     // 回答後に状態を更新
     setChallenge((prev) =>
       prev

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -76,9 +76,10 @@ export function DashboardPage() {
   }, [userId])
 
   const recommendedAction = useMemo(
-    () => getRecommendedAction({ progress: allStepProgress, reviewCount, enableReviewQueue: true }),
-    [allStepProgress, reviewCount],
+    () => getRecommendedAction({ progress: allStepProgress }),
+    [allStepProgress],
   )
+  const shouldShowReviewQueue = isLoadingReview || Boolean(reviewError) || reviewCount > 0
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50">
@@ -92,12 +93,14 @@ export function DashboardPage() {
           <section className="space-y-6 lg:col-span-8">
             <WelcomeBanner displayName={greetingName} />
             <TodayActionCard action={recommendedAction} />
-            <ReviewQueueCard
-              count={reviewCount}
-              firstItem={firstReviewItem}
-              isLoading={isLoadingReview}
-              error={reviewError}
-            />
+            {shouldShowReviewQueue ? (
+              <ReviewQueueCard
+                count={reviewCount}
+                firstItem={firstReviewItem}
+                isLoading={isLoadingReview}
+                error={reviewError}
+              />
+            ) : null}
             {completedStepsCount === 0 && firstImplementedStep ? (
               <OnboardingCard startTo={`/step/${firstImplementedStep.id}`} />
             ) : null}

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Link, Navigate, useNavigate, useParams } from 'react-router-dom'
+import { Link, Navigate, useNavigate, useParams, useSearchParams } from 'react-router-dom'
 import { BookOpen, Check, ChevronRight, Code2, PenLine, Trophy } from 'lucide-react'
 import { ErrorBanner } from '../components/ErrorBanner'
 import { ErrorBoundary } from '../components/ErrorBoundary'
@@ -71,13 +71,21 @@ const NEXT_ACTION_REASON: Record<LearningMode, string> = {
   challenge: '今の実装力を土台に、次のステップへ進みましょう。',
 }
 
+const LEARNING_MODES: readonly LearningMode[] = ['read', 'practice', 'test', 'challenge']
+
+function parseLearningMode(value: string | null): LearningMode | null {
+  return LEARNING_MODES.includes(value as LearningMode) ? (value as LearningMode) : null
+}
+
 export function StepPage() {
   const { stepId = '' } = useParams()
+  const [searchParams] = useSearchParams()
+  const requestedMode = parseLearningMode(searchParams.get('mode'))
   const { user } = useAuth()
   const { completedStepIds, isLoadingStats } = useLearningContext()
   const navigate = useNavigate()
   const handleSignOut = useSignOut()
-  const [activeMode, setActiveMode] = useState<LearningMode>('read')
+  const [activeMode, setActiveMode] = useState<LearningMode>(requestedMode ?? 'read')
   const [pulseModes, setPulseModes] = useState<Record<LearningMode, boolean>>({
     read: false,
     practice: false,
@@ -118,6 +126,10 @@ export function StepPage() {
     [],
   )
   useDocumentTitle(step?.title ?? 'ステップ')
+
+  useEffect(() => {
+    setActiveMode(requestedMode ?? 'read')
+  }, [requestedMode, stepId])
 
   useEffect(() => {
     if (!previousModeStatusRef.current) {

--- a/apps/web/src/pages/__tests__/DashboardPage.test.tsx
+++ b/apps/web/src/pages/__tests__/DashboardPage.test.tsx
@@ -127,7 +127,7 @@ describe('DashboardPage', () => {
     expect(await screen.findByText('学習コース')).toBeTruthy()
     expect(screen.getByText('今日のおすすめ')).toBeTruthy()
     expect(screen.getByText('Step 2 の Practice から再開')).toBeTruthy()
-    expect(await screen.findByText('復習待ち 0 件')).toBeTruthy()
+    expect(screen.queryByText('復習待ち 0 件')).toBeNull()
     expect(screen.getByText('React')).toBeTruthy()
     expect(screen.getByText('TypeScript')).toBeTruthy()
     expect(screen.getByText('スキルアップ')).toBeTruthy()
@@ -160,7 +160,7 @@ describe('DashboardPage', () => {
     expect(screen.getByRole('link', { name: '始める' }).getAttribute('href')).toBe('/step/usestate-basic')
   })
 
-  it('復習待ちがある場合は復習カードと今日のおすすめで復習を優先する', async () => {
+  it('復習待ちがある場合は復習カードを表示し、今日のおすすめは通常学習を表示する', async () => {
     testState.getOpenCountMock.mockResolvedValue(2)
     testState.listOpenMock.mockResolvedValue([
       {
@@ -184,8 +184,8 @@ describe('DashboardPage', () => {
     )
 
     expect(await screen.findByText('復習待ち 2 件')).toBeTruthy()
-    expect(screen.getByText('昨日間違えた問題を復習')).toBeTruthy()
+    expect(screen.getByText('Step 2 の Practice から再開')).toBeTruthy()
     expect(screen.getByText(/最優先: Step 2/)).toBeTruthy()
-    expect(screen.getAllByRole('link', { name: '復習へ進む' }).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByRole('link', { name: '復習へ進む' }).getAttribute('href')).toBe('/step/events?mode=practice')
   })
 })

--- a/apps/web/src/pages/__tests__/StepPage.test.tsx
+++ b/apps/web/src/pages/__tests__/StepPage.test.tsx
@@ -150,6 +150,29 @@ describe('StepPage', () => {
     expect(screen.getByRole('tab', { name: 'Practice' }).className).toContain('min-h-11')
   })
 
+  it('mode クエリがある場合は指定された学習モードを初期表示する', () => {
+    useChallengeSubmissionMock.mockReturnValue(vi.fn())
+    useRecentChallengeSubmissionsMock.mockReturnValue({
+      submissions: [],
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+    })
+    mockLearningStep()
+
+    render(
+      <MemoryRouter initialEntries={['/step/usestate-basic?mode=test']}>
+        <Routes>
+          <Route path="/step/:stepId" element={<StepPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('tab', { name: 'Test' }).getAttribute('aria-current')).toBe('step')
+    expect(screen.getByText('test mode')).toBeTruthy()
+    expect(screen.getByRole('tab', { name: 'Read' }).getAttribute('aria-current')).toBeNull()
+  })
+
   it('Challenge タブで提出履歴を主要導線上に表示する', async () => {
     const user = userEvent.setup()
 

--- a/apps/web/src/services/__tests__/dailyChallengeService.test.ts
+++ b/apps/web/src/services/__tests__/dailyChallengeService.test.ts
@@ -182,6 +182,7 @@ describe('getTodayChallenge', () => {
     expect(result.question).toBeDefined()
     expect(result.question?.stepId).toBe('usestate-basic')
     expect(result.reviewReason).toBeNull()
+    expect(result.reviewTarget).toBeNull()
   })
 
   it('完了済みの場合は alreadyCompleted: true を返す', async () => {
@@ -208,6 +209,7 @@ describe('getTodayChallenge', () => {
     expect(result.question).toBeNull()
     expect(result.pointsEarned).toBe(20)
     expect(result.reviewReason).toBeNull()
+    expect(result.reviewTarget).toBeNull()
   })
 
   it('完了済みステップがない場合は question: null を返す', async () => {
@@ -248,6 +250,11 @@ describe('getTodayChallenge', () => {
 
     expect(result.question?.stepId).toBe('events')
     expect(result.reviewReason).toContain('Practice')
+    expect(result.reviewTarget).toEqual({
+      stepId: 'events',
+      mode: 'practice',
+      questionId: 'practice-q1',
+    })
   })
 })
 
@@ -302,6 +309,28 @@ describe('submitDailyAnswer', () => {
       questionId: 'usestate-basic-daily-0',
     })
     expect(mockAwardPoints).toHaveBeenCalledWith(20, 'デイリーチャレンジ正解')
+  })
+
+  it('弱点優先のDaily正解時は元の復習itemも resolved にする', async () => {
+    const result = await submitDailyAnswer(userId, question, 'setCount', dateStr, {
+      stepId: 'events',
+      mode: 'practice',
+      questionId: 'practice-q1',
+    })
+
+    expect(result.isCorrect).toBe(true)
+    expect(mockResolveReviewItem).toHaveBeenCalledWith({
+      userId,
+      stepId: 'usestate-basic',
+      mode: 'daily',
+      questionId: 'usestate-basic-daily-0',
+    })
+    expect(mockResolveReviewItem).toHaveBeenCalledWith({
+      userId,
+      stepId: 'events',
+      mode: 'practice',
+      questionId: 'practice-q1',
+    })
   })
 
   it('不正解の場合は isCorrect: false と 0pt を返す', async () => {

--- a/apps/web/src/services/dailyChallengeService.ts
+++ b/apps/web/src/services/dailyChallengeService.ts
@@ -12,6 +12,7 @@ import {
 } from './reviewService'
 import { DAILY_QUESTIONS } from '../content/daily/questions'
 import type {
+  DailyReviewTarget,
   DailyQuestion,
   TodayChallengeResult,
   SubmitResult,
@@ -66,6 +67,21 @@ function getReviewReason(
   }
 
   return `${REVIEW_MODE_LABELS[reviewCandidate.mode]}で復習待ちになったStepから出題しています。`
+}
+
+function getReviewTarget(
+  reviewCandidate: DailyReviewCandidate | null | undefined,
+  question: DailyQuestion | undefined,
+): DailyReviewTarget | null {
+  if (!reviewCandidate || !question || reviewCandidate.step_id !== question.stepId) {
+    return null
+  }
+
+  return {
+    stepId: reviewCandidate.step_id,
+    mode: reviewCandidate.mode,
+    questionId: reviewCandidate.question_id,
+  }
 }
 
 /** 完了済みステップのプールから日付に基づいて問題を選択する（復習候補があれば優先） */
@@ -129,6 +145,7 @@ export async function getTodayChallenge(
       pointsEarned: history.points_earned,
       dateStr,
       reviewReason: null,
+      reviewTarget: null,
     }
   }
 
@@ -148,6 +165,7 @@ export async function getTodayChallenge(
     pointsEarned: 0,
     dateStr,
     reviewReason: getReviewReason(reviewCandidate, question),
+    reviewTarget: getReviewTarget(reviewCandidate, question),
   }
 }
 
@@ -181,6 +199,7 @@ export async function submitDailyAnswer(
   question: DailyQuestion,
   userAnswer: string,
   dateStr: string,
+  reviewTarget?: DailyReviewTarget | null,
 ): Promise<SubmitResult> {
   assertUuid(userId, 'userId')
   assertMaxLength(userAnswer, MAX_ANSWER_LENGTH, 'userAnswer')
@@ -213,6 +232,19 @@ export async function submitDailyAnswer(
         mode: 'daily',
         questionId: question.id,
       })
+      if (
+        reviewTarget &&
+        (reviewTarget.stepId !== question.stepId ||
+          reviewTarget.mode !== 'daily' ||
+          reviewTarget.questionId !== question.id)
+      ) {
+        await resolveReviewItem({
+          userId,
+          stepId: reviewTarget.stepId,
+          mode: reviewTarget.mode,
+          questionId: reviewTarget.questionId ?? null,
+        })
+      }
     } catch {
       // 復習キュー同期の失敗でDaily回答完了を止めない。
     }


### PR DESCRIPTION
## 概要
- Dashboard の「今日のおすすめ」から復習優先表示を外し、通常学習の導線に戻しました
- 復習キューは復習待ちがある場合のみ表示するようにしました
- 復習キューの「復習へ進む」を Daily 固定ではなく、最優先の該当 Step / Mode へ遷移するようにしました
- Step ページで `?mode=practice|test|challenge` を読み取り、該当タブを初期表示するようにしました
- Daily 弱点出題で正解した場合、元の復習 item も resolved にするようにしました

## 確認
- `npm run typecheck`
- `npm run lint`
- `npm run test`
- `npm run build`