### PR TITLE
feat: 品質ダッシュボード最小版を追加

### DIFF
--- a/apps/web/src/features/admin/components/AdminLayout.tsx
+++ b/apps/web/src/features/admin/components/AdminLayout.tsx
@@ -16,6 +16,7 @@ interface AdminLink {
 
 const ADMIN_LINKS: readonly AdminLink[] = [
   { to: '/admin', label: 'ダッシュボード', exact: true },
+  { to: '/admin/quality', label: '品質ダッシュボード' },
   { to: '/admin/feedback', label: 'フィードバック' },
   { to: '/admin/users', label: 'ユーザー' },
   { to: '/admin/stats', label: '統計' },

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -57,6 +57,11 @@ const AdminUserDetailPage = lazy(() =>
 const AdminStatsPage = lazy(() =>
   import('./pages/admin/AdminStatsPage').then((m) => ({ default: m.AdminStatsPage })),
 )
+const AdminQualityDashboardPage = lazy(() =>
+  import('./pages/admin/AdminQualityDashboardPage').then((m) => ({
+    default: m.AdminQualityDashboardPage,
+  })),
+)
 const AdminOpsPage = lazy(() =>
   import('./pages/admin/AdminOpsPage').then((m) => ({ default: m.AdminOpsPage })),
 )
@@ -258,6 +263,18 @@ const router = createBrowserRouter([
         <AdminGuard>
           <Suspense fallback={<PageLoading />}>
             <AdminUserDetailPage />
+          </Suspense>
+        </AdminGuard>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/admin/quality',
+    element: (
+      <ProtectedRoute>
+        <AdminGuard>
+          <Suspense fallback={<PageLoading />}>
+            <AdminQualityDashboardPage />
           </Suspense>
         </AdminGuard>
       </ProtectedRoute>

--- a/apps/web/src/pages/admin/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/admin/AdminDashboardPage.tsx
@@ -19,6 +19,13 @@ interface SectionCard {
 
 const SECTIONS: SectionCard[] = [
   {
+    to: '/admin/quality',
+    title: '品質ダッシュボード',
+    description: '学習品質KPIと改善優先ステップを確認する',
+    icon: BarChart3,
+    accent: 'bg-teal-100 text-teal-700',
+  },
+  {
     to: '/admin/feedback',
     title: 'フィードバック',
     description: 'ユーザーから届いた不具合報告・要望・レビューを確認する',

--- a/apps/web/src/pages/admin/AdminQualityDashboardPage.tsx
+++ b/apps/web/src/pages/admin/AdminQualityDashboardPage.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useState, type ReactNode } from 'react'
+import { AlertCircle, CheckCircle2, Clock3, Loader2, ShieldCheck, TrendingUp } from 'lucide-react'
+import { AdminLayout } from '../../features/admin/components/AdminLayout'
+import { useDocumentTitle } from '../../hooks/useDocumentTitle'
+import {
+  getAdminQualityDashboard,
+  type AdminQualityDashboard,
+  type AdminQualityMetric,
+  type AdminQualityMetricStatus,
+  type AdminQualityStepPriority,
+} from '../../services/adminQualityService'
+
+const STATUS_LABELS: Record<AdminQualityMetricStatus, string> = {
+  formal: '正式表示',
+  provisional: '暫定表示',
+  future: 'M2以降',
+}
+
+const STATUS_STYLES: Record<AdminQualityMetricStatus, string> = {
+  formal: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  provisional: 'border-amber-200 bg-amber-50 text-amber-700',
+  future: 'border-slate-200 bg-slate-50 text-slate-600',
+}
+
+function formatPercent(rate: number | null): string {
+  if (rate === null) return 'データ不足'
+  return `${(rate * 100).toFixed(1)}%`
+}
+
+function formatDateTime(value: string): string {
+  return new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(value))
+}
+
+export function AdminQualityDashboardPage() {
+  useDocumentTitle('品質ダッシュボード - 管理画面')
+
+  const [dashboard, setDashboard] = useState<AdminQualityDashboard | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+    async function load() {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const data = await getAdminQualityDashboard()
+        if (!isMounted) return
+        setDashboard(data)
+      } catch (e) {
+        if (!isMounted) return
+        setError(e instanceof Error ? e.message : '品質ダッシュボードの取得に失敗しました')
+      } finally {
+        if (isMounted) setIsLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  return (
+    <AdminLayout>
+      <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">品質ダッシュボード</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            既存データから学習品質KPIと改善優先ステップを確認します。
+          </p>
+        </div>
+        {dashboard && (
+          <div className="text-xs text-slate-500">
+            生成日時 <span className="font-mono text-slate-700">{formatDateTime(dashboard.generatedAt)}</span>
+          </div>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-24">
+          <Loader2 className="h-8 w-8 animate-spin text-slate-400" aria-label="読み込み中" />
+        </div>
+      ) : error ? (
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-2xl border border-rose-200 bg-rose-50 p-5 text-sm text-rose-700"
+        >
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>{error}</span>
+        </div>
+      ) : dashboard ? (
+        <div className="space-y-6">
+          <section className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <OverviewTile label="登録ユーザー" value={`${dashboard.totalUsers.toLocaleString()}人`} />
+            <OverviewTile label="着手ユーザー" value={`${dashboard.activeLearners.toLocaleString()}人`} />
+            <OverviewTile
+              label="改善候補"
+              value={`${dashboard.improvementSteps.length.toLocaleString()}件`}
+            />
+          </section>
+
+          <Section title="正式KPI" icon={<ShieldCheck className="h-4 w-4" aria-hidden="true" />}>
+            <MetricGrid metrics={dashboard.formalMetrics} />
+          </Section>
+
+          <Section title="暫定KPI" icon={<Clock3 className="h-4 w-4" aria-hidden="true" />}>
+            <MetricGrid metrics={dashboard.provisionalMetrics} />
+          </Section>
+
+          <Section title="改善優先ステップ Top5" icon={<TrendingUp className="h-4 w-4" aria-hidden="true" />}>
+            <ImprovementTable rows={dashboard.improvementSteps} />
+          </Section>
+
+          <Section title="Mini Project状況" icon={<CheckCircle2 className="h-4 w-4" aria-hidden="true" />}>
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+              <OverviewTile label="合計" value={`${dashboard.miniProjectStatus.total.toLocaleString()}件`} />
+              <OverviewTile label="完了" value={`${dashboard.miniProjectStatus.completed.toLocaleString()}件`} />
+              <OverviewTile
+                label="進行中"
+                value={`${dashboard.miniProjectStatus.inProgress.toLocaleString()}件`}
+              />
+              <OverviewTile
+                label="未着手"
+                value={`${dashboard.miniProjectStatus.notStarted.toLocaleString()}件`}
+              />
+            </div>
+          </Section>
+
+          <Section title="M2以降に正式化するKPI" icon={<Clock3 className="h-4 w-4" aria-hidden="true" />}>
+            <MetricGrid metrics={dashboard.futureMetrics} />
+          </Section>
+        </div>
+      ) : null}
+    </AdminLayout>
+  )
+}
+
+function Section({
+  title,
+  icon,
+  children,
+}: {
+  title: string
+  icon: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+        <span className="text-slate-500">{icon}</span>
+        <h2>{title}</h2>
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function OverviewTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+      <p className="text-xs font-semibold text-slate-500">{label}</p>
+      <p className="mt-1 font-mono text-2xl font-semibold text-slate-900">{value}</p>
+    </div>
+  )
+}
+
+function MetricGrid({ metrics }: { metrics: AdminQualityMetric[] }) {
+  if (metrics.length === 0) {
+    return <p className="text-sm text-slate-500">データがありません</p>
+  }
+  return (
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+      {metrics.map((metric) => (
+        <article key={metric.id} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="flex items-start justify-between gap-3">
+            <h3 className="text-sm font-semibold text-slate-700">{metric.label}</h3>
+            <span
+              className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold ${STATUS_STYLES[metric.status]}`}
+            >
+              {STATUS_LABELS[metric.status]}
+            </span>
+          </div>
+          <p className="mt-3 font-mono text-2xl font-semibold text-slate-900">{metric.value}</p>
+          <p className="mt-2 text-xs leading-5 text-slate-500">{metric.detail}</p>
+        </article>
+      ))}
+    </div>
+  )
+}
+
+function ImprovementTable({ rows }: { rows: AdminQualityStepPriority[] }) {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-2xl border border-slate-200 bg-white p-5 text-sm text-slate-500 shadow-sm">
+        改善優先ステップの候補はありません
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <table className="min-w-full divide-y divide-slate-100 text-sm">
+        <thead className="bg-slate-50 text-left text-xs font-semibold text-slate-500">
+          <tr>
+            <th scope="col" className="px-4 py-3">Step</th>
+            <th scope="col" className="px-4 py-3">優先度</th>
+            <th scope="col" className="px-4 py-3">完了率</th>
+            <th scope="col" className="px-4 py-3">Challenge</th>
+            <th scope="col" className="px-4 py-3">理由</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {rows.map((row) => (
+            <tr key={row.stepId}>
+              <td className="px-4 py-3">
+                <p className="font-semibold text-slate-800">
+                  Step {row.order}「{row.title}」
+                </p>
+                <p className="mt-0.5 font-mono text-xs text-slate-400">{row.stepId}</p>
+              </td>
+              <td className="px-4 py-3 font-mono text-slate-800">{row.priorityScore.toFixed(1)}</td>
+              <td className="px-4 py-3 font-mono text-slate-700">
+                {row.completedUsers} / {row.startedUsers} ({formatPercent(row.completionRate)})
+              </td>
+              <td className="px-4 py-3 font-mono text-slate-700">
+                {row.challengeSubmissions}件 / {formatPercent(row.challengePassRate)}
+              </td>
+              <td className="px-4 py-3 text-xs leading-5 text-slate-500">
+                {row.reasons.join(' / ')}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/apps/web/src/pages/admin/__tests__/AdminQualityDashboardPage.test.tsx
+++ b/apps/web/src/pages/admin/__tests__/AdminQualityDashboardPage.test.tsx
@@ -1,0 +1,132 @@
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import type { AdminQualityDashboard } from '../../../services/adminQualityService'
+
+const getAdminQualityDashboardMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../services/adminQualityService', async () => {
+  const actual = await vi.importActual<typeof import('../../../services/adminQualityService')>(
+    '../../../services/adminQualityService',
+  )
+  return {
+    ...actual,
+    getAdminQualityDashboard: (...args: unknown[]) => getAdminQualityDashboardMock(...args),
+  }
+})
+
+vi.mock('../../../features/admin/components/AdminLayout', () => ({
+  AdminLayout: ({ children }: { children: ReactNode }) => <div data-testid="admin-layout">{children}</div>,
+}))
+
+vi.mock('../../../hooks/useDocumentTitle', () => ({
+  useDocumentTitle: () => undefined,
+}))
+
+import { AdminQualityDashboardPage } from '../AdminQualityDashboardPage'
+
+const SAMPLE_DASHBOARD: AdminQualityDashboard = {
+  totalUsers: 3,
+  activeLearners: 2,
+  generatedAt: '2026-06-04T12:00:00.000Z',
+  formalMetrics: [
+    {
+      id: 'four-mode-completion-rate',
+      label: '4モード完了率',
+      value: '33.3%',
+      detail: '1 / 3 件のStep進捗が Read / Practice / Test / Challenge を完了',
+      status: 'formal',
+    },
+    {
+      id: 'challenge-pass-rate',
+      label: 'Challenge合格率',
+      value: '50.0%',
+      detail: '1 / 2 件の提出が合格',
+      status: 'formal',
+    },
+  ],
+  provisionalMetrics: [
+    {
+      id: 'first-step-started-rate',
+      label: '初回Step開始率',
+      value: '66.7%',
+      detail: '最初の実装済みStepに進捗行があるユーザー割合',
+      status: 'provisional',
+    },
+  ],
+  futureMetrics: [
+    {
+      id: 'read-to-practice-rate',
+      label: 'Read → Practice遷移率',
+      value: 'M2以降',
+      detail: 'learning_events 導入後に正式表示',
+      status: 'future',
+    },
+  ],
+  improvementSteps: [
+    {
+      stepId: 'events',
+      order: 2,
+      title: 'イベント処理',
+      startedUsers: 1,
+      completedUsers: 0,
+      completionRate: 0,
+      challengeSubmissions: 2,
+      challengePassRate: 0,
+      openReviewItems: 1,
+      priorityScore: 100,
+      reasons: ['完了率 0.0%', 'Challenge 合格率 0.0%', '復習待ち 1件', '着手 1人'],
+    },
+  ],
+  miniProjectStatus: {
+    total: 2,
+    completed: 1,
+    inProgress: 1,
+    notStarted: 0,
+  },
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminQualityDashboardPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('AdminQualityDashboardPage', () => {
+  beforeEach(() => {
+    getAdminQualityDashboardMock.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('品質KPIと改善優先ステップを表示する', async () => {
+    getAdminQualityDashboardMock.mockResolvedValue(SAMPLE_DASHBOARD)
+    renderPage()
+
+    expect(await screen.findByRole('heading', { name: '品質ダッシュボード' })).toBeTruthy()
+    expect(screen.getByText('4モード完了率')).toBeTruthy()
+    expect(screen.getAllByText('正式表示').length).toBeGreaterThan(0)
+    expect(screen.getByText('暫定表示')).toBeTruthy()
+    expect(screen.getAllByText('M2以降').length).toBeGreaterThan(0)
+    expect(screen.getByText('改善優先ステップ Top5')).toBeTruthy()
+    expect(screen.getByText('Step 2「イベント処理」')).toBeTruthy()
+    expect(screen.getByText('Read → Practice遷移率')).toBeTruthy()
+
+    await waitFor(() => {
+      expect(getAdminQualityDashboardMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('取得エラーを alert で表示する', async () => {
+    getAdminQualityDashboardMock.mockRejectedValue(new Error('admin only'))
+    renderPage()
+
+    const alert = await screen.findByRole('alert')
+    expect(within(alert).getByText('admin only')).toBeTruthy()
+  })
+})

--- a/apps/web/src/services/__tests__/adminQualityService.test.ts
+++ b/apps/web/src/services/__tests__/adminQualityService.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getAdminQualityDashboard } from '../adminQualityService'
+
+type TableName =
+  | 'profiles'
+  | 'step_progress'
+  | 'challenge_submissions'
+  | 'daily_challenge_history'
+  | 'mini_project_progress'
+  | 'user_feedback'
+  | 'review_items'
+
+const tableState: Record<TableName, { data: unknown[]; count: number | null; error: unknown }> = {
+  profiles: { data: [], count: 0, error: null },
+  step_progress: { data: [], count: null, error: null },
+  challenge_submissions: { data: [], count: null, error: null },
+  daily_challenge_history: { data: [], count: null, error: null },
+  mini_project_progress: { data: [], count: null, error: null },
+  user_feedback: { data: [], count: null, error: null },
+  review_items: { data: [], count: null, error: null },
+}
+
+const from = vi.fn((table: TableName) => ({
+  select: () =>
+    Promise.resolve({
+      data: tableState[table].data,
+      count: tableState[table].count,
+      error: tableState[table].error,
+    }),
+}))
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {
+    from: (...args: unknown[]) => from(...(args as [TableName])),
+  },
+}))
+
+function resetState() {
+  vi.clearAllMocks()
+  for (const table of Object.keys(tableState) as TableName[]) {
+    tableState[table] = { data: [], count: table === 'profiles' ? 0 : null, error: null }
+  }
+}
+
+describe('getAdminQualityDashboard', () => {
+  beforeEach(resetState)
+
+  it('既存テーブルから品質KPIと改善優先ステップを集計する', async () => {
+    tableState.profiles.count = 3
+    tableState.step_progress.data = [
+      {
+        user_id: 'u1',
+        step_id: 'usestate-basic',
+        read_done: true,
+        practice_done: true,
+        test_done: true,
+        challenge_done: true,
+        completed_at: '2026-06-01T00:00:00Z',
+      },
+      {
+        user_id: 'u2',
+        step_id: 'usestate-basic',
+        read_done: true,
+        practice_done: true,
+        test_done: false,
+        challenge_done: false,
+        completed_at: null,
+      },
+      {
+        user_id: 'u1',
+        step_id: 'events',
+        read_done: true,
+        practice_done: false,
+        test_done: false,
+        challenge_done: false,
+        completed_at: null,
+      },
+    ]
+    tableState.challenge_submissions.data = [
+      { step_id: 'usestate-basic', is_passed: true, submitted_at: '2026-06-01T00:00:00Z' },
+      { step_id: 'events', is_passed: false, submitted_at: '2026-06-01T00:00:00Z' },
+      { step_id: 'events', is_passed: false, submitted_at: '2026-06-02T00:00:00Z' },
+    ]
+    tableState.daily_challenge_history.data = [
+      { completed: true, challenge_date: '2026-06-01' },
+      { completed: false, challenge_date: '2026-06-02' },
+    ]
+    tableState.mini_project_progress.data = [
+      { project_id: 'todo-app', status: 'completed', completed_at: '2026-06-01T00:00:00Z' },
+      { project_id: 'counter-extended', status: 'in_progress', completed_at: null },
+    ]
+    tableState.user_feedback.data = [
+      { status: 'new', created_at: new Date().toISOString() },
+      { status: 'resolved', created_at: '2020-01-01T00:00:00Z' },
+    ]
+    tableState.review_items.data = [
+      { status: 'open', step_id: 'events' },
+      { status: 'resolved', step_id: 'usestate-basic' },
+    ]
+
+    const dashboard = await getAdminQualityDashboard()
+
+    expect(from).toHaveBeenCalledWith('profiles')
+    expect(from).toHaveBeenCalledWith('step_progress')
+    expect(from).toHaveBeenCalledWith('challenge_submissions')
+    expect(dashboard.totalUsers).toBe(3)
+    expect(dashboard.activeLearners).toBe(2)
+    expect(dashboard.formalMetrics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'four-mode-completion-rate',
+          label: '4モード完了率',
+          value: '33.3%',
+          status: 'formal',
+        }),
+        expect.objectContaining({
+          id: 'challenge-pass-rate',
+          value: '33.3%',
+        }),
+      ]),
+    )
+    expect(dashboard.provisionalMetrics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'first-step-started-rate',
+          value: '66.7%',
+        }),
+      ]),
+    )
+    expect(dashboard.miniProjectStatus).toEqual({
+      total: 2,
+      completed: 1,
+      inProgress: 1,
+      notStarted: 0,
+    })
+    expect(dashboard.improvementSteps[0]).toEqual(
+      expect.objectContaining({
+        stepId: 'events',
+        title: 'イベント処理',
+        openReviewItems: 1,
+      }),
+    )
+  })
+
+  it('クエリエラーを AppError に変換する', async () => {
+    tableState.step_progress.error = { code: 'DB_ERROR', message: 'forbidden' }
+
+    await expect(getAdminQualityDashboard()).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: '品質KPIのステップ進捗取得に失敗しました',
+    })
+  })
+})

--- a/apps/web/src/services/adminQualityService.ts
+++ b/apps/web/src/services/adminQualityService.ts
@@ -1,0 +1,377 @@
+import { getAllSteps } from '../content/courseData'
+import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+import type { Tables } from '../shared/types/database.types'
+
+type StepProgressRow = Pick<
+  Tables<'step_progress'>,
+  | 'user_id'
+  | 'step_id'
+  | 'read_done'
+  | 'practice_done'
+  | 'test_done'
+  | 'challenge_done'
+  | 'completed_at'
+>
+type ChallengeSubmissionRow = Pick<
+  Tables<'challenge_submissions'>,
+  'step_id' | 'is_passed' | 'submitted_at'
+>
+type DailyChallengeHistoryRow = Pick<Tables<'daily_challenge_history'>, 'completed' | 'challenge_date'>
+type MiniProjectProgressRow = Pick<
+  Tables<'mini_project_progress'>,
+  'project_id' | 'status' | 'completed_at'
+>
+type UserFeedbackRow = Pick<Tables<'user_feedback'>, 'status' | 'created_at'>
+type ReviewItemRow = Pick<Tables<'review_items'>, 'status' | 'step_id'>
+
+export type AdminQualityMetricStatus = 'formal' | 'provisional' | 'future'
+
+export interface AdminQualityMetric {
+  id: string
+  label: string
+  value: string
+  detail: string
+  status: AdminQualityMetricStatus
+}
+
+export interface AdminQualityStepPriority {
+  stepId: string
+  order: number
+  title: string
+  startedUsers: number
+  completedUsers: number
+  completionRate: number | null
+  challengeSubmissions: number
+  challengePassRate: number | null
+  openReviewItems: number
+  priorityScore: number
+  reasons: string[]
+}
+
+export interface AdminQualityMiniProjectStatus {
+  total: number
+  completed: number
+  inProgress: number
+  notStarted: number
+}
+
+export interface AdminQualityDashboard {
+  totalUsers: number
+  activeLearners: number
+  generatedAt: string
+  formalMetrics: AdminQualityMetric[]
+  provisionalMetrics: AdminQualityMetric[]
+  futureMetrics: AdminQualityMetric[]
+  improvementSteps: AdminQualityStepPriority[]
+  miniProjectStatus: AdminQualityMiniProjectStatus
+}
+
+interface StepAggregate {
+  stepId: string
+  order: number
+  title: string
+  startedUsers: Set<string>
+  completedUsers: Set<string>
+  challengeSubmissions: number
+  challengePassed: number
+  openReviewItems: number
+}
+
+function isStepCompleted(row: StepProgressRow): boolean {
+  return Boolean(
+    row.completed_at ||
+      (row.read_done && row.practice_done && row.test_done && row.challenge_done),
+  )
+}
+
+function safeRate(numerator: number, denominator: number): number | null {
+  if (denominator <= 0) return null
+  return numerator / denominator
+}
+
+function formatPercent(rate: number | null): string {
+  if (rate === null) return 'データ不足'
+  return `${(rate * 100).toFixed(1)}%`
+}
+
+function formatCount(value: number, unit = '件'): string {
+  return `${value.toLocaleString()}${unit}`
+}
+
+function isWithinLastDays(dateValue: string | null, days: number): boolean {
+  if (!dateValue) return false
+  const time = new Date(dateValue).getTime()
+  if (Number.isNaN(time)) return false
+  return Date.now() - time <= days * 24 * 60 * 60 * 1000
+}
+
+function createMetric(
+  id: string,
+  label: string,
+  value: string,
+  detail: string,
+  status: AdminQualityMetricStatus,
+): AdminQualityMetric {
+  return { id, label, value, detail, status }
+}
+
+function buildStepAggregates(
+  progressRows: StepProgressRow[],
+  submissions: ChallengeSubmissionRow[],
+  reviewItems: ReviewItemRow[],
+): StepAggregate[] {
+  const implementedSteps = getAllSteps().filter((step) => step.isImplemented)
+  const aggregates = new Map<string, StepAggregate>()
+
+  for (const step of implementedSteps) {
+    aggregates.set(step.id, {
+      stepId: step.id,
+      order: step.order,
+      title: step.title,
+      startedUsers: new Set<string>(),
+      completedUsers: new Set<string>(),
+      challengeSubmissions: 0,
+      challengePassed: 0,
+      openReviewItems: 0,
+    })
+  }
+
+  for (const row of progressRows) {
+    const aggregate = aggregates.get(row.step_id)
+    if (!aggregate) continue
+    aggregate.startedUsers.add(row.user_id)
+    if (isStepCompleted(row)) {
+      aggregate.completedUsers.add(row.user_id)
+    }
+  }
+
+  for (const row of submissions) {
+    const aggregate = aggregates.get(row.step_id)
+    if (!aggregate) continue
+    aggregate.challengeSubmissions += 1
+    if (row.is_passed) {
+      aggregate.challengePassed += 1
+    }
+  }
+
+  for (const row of reviewItems) {
+    const aggregate = aggregates.get(row.step_id)
+    if (!aggregate || row.status !== 'open') continue
+    aggregate.openReviewItems += 1
+  }
+
+  return [...aggregates.values()]
+}
+
+function buildImprovementSteps(aggregates: StepAggregate[]): AdminQualityStepPriority[] {
+  return aggregates
+    .filter((row) => row.startedUsers.size > 0 || row.challengeSubmissions > 0 || row.openReviewItems > 0)
+    .map((row) => {
+      const startedUsers = row.startedUsers.size
+      const completedUsers = row.completedUsers.size
+      const completionRate = safeRate(completedUsers, startedUsers)
+      const challengePassRate = safeRate(row.challengePassed, row.challengeSubmissions)
+      const completionGap = completionRate === null ? 0.4 : 1 - completionRate
+      const challengeGap = challengePassRate === null ? 0 : 1 - challengePassRate
+      const reviewWeight = Math.min(row.openReviewItems, 10) / 10
+      const priorityScore = Math.round((completionGap * 60 + challengeGap * 30 + reviewWeight * 10) * 10) / 10
+      const reasons = [
+        `完了率 ${formatPercent(completionRate)}`,
+        row.challengeSubmissions > 0
+          ? `Challenge 合格率 ${formatPercent(challengePassRate)}`
+          : 'Challenge 提出なし',
+      ]
+
+      if (row.openReviewItems > 0) {
+        reasons.push(`復習待ち ${row.openReviewItems.toLocaleString()}件`)
+      }
+      reasons.push(`着手 ${startedUsers.toLocaleString()}人`)
+
+      return {
+        stepId: row.stepId,
+        order: row.order,
+        title: row.title,
+        startedUsers,
+        completedUsers,
+        completionRate,
+        challengeSubmissions: row.challengeSubmissions,
+        challengePassRate,
+        openReviewItems: row.openReviewItems,
+        priorityScore,
+        reasons,
+      }
+    })
+    .sort((a, b) => b.priorityScore - a.priorityScore || a.order - b.order)
+    .slice(0, 5)
+}
+
+export async function getAdminQualityDashboard(): Promise<AdminQualityDashboard> {
+  const [
+    usersRes,
+    progressRes,
+    submissionsRes,
+    dailyRes,
+    miniProjectRes,
+    feedbackRes,
+    reviewItemsRes,
+  ] = await Promise.all([
+    supabase.from('profiles').select('*', { count: 'exact', head: true }),
+    supabase
+      .from('step_progress')
+      .select('user_id, step_id, read_done, practice_done, test_done, challenge_done, completed_at'),
+    supabase.from('challenge_submissions').select('step_id, is_passed, submitted_at'),
+    supabase.from('daily_challenge_history').select('completed, challenge_date'),
+    supabase.from('mini_project_progress').select('project_id, status, completed_at'),
+    supabase.from('user_feedback').select('status, created_at'),
+    supabase.from('review_items').select('status, step_id'),
+  ])
+
+  if (usersRes.error) throw fromSupabaseError(usersRes.error, '品質KPIのユーザー数取得に失敗しました')
+  if (progressRes.error)
+    throw fromSupabaseError(progressRes.error, '品質KPIのステップ進捗取得に失敗しました')
+  if (submissionsRes.error)
+    throw fromSupabaseError(submissionsRes.error, '品質KPIのChallenge提出取得に失敗しました')
+  if (dailyRes.error) throw fromSupabaseError(dailyRes.error, '品質KPIのDaily履歴取得に失敗しました')
+  if (miniProjectRes.error)
+    throw fromSupabaseError(miniProjectRes.error, '品質KPIのMini Project進捗取得に失敗しました')
+  if (feedbackRes.error)
+    throw fromSupabaseError(feedbackRes.error, '品質KPIのフィードバック取得に失敗しました')
+  if (reviewItemsRes.error)
+    throw fromSupabaseError(reviewItemsRes.error, '品質KPIの復習キュー取得に失敗しました')
+
+  const progressRows = (progressRes.data ?? []) as StepProgressRow[]
+  const submissions = (submissionsRes.data ?? []) as ChallengeSubmissionRow[]
+  const dailyRows = (dailyRes.data ?? []) as DailyChallengeHistoryRow[]
+  const miniProjectRows = (miniProjectRes.data ?? []) as MiniProjectProgressRow[]
+  const feedbackRows = (feedbackRes.data ?? []) as UserFeedbackRow[]
+  const reviewItems = (reviewItemsRes.data ?? []) as ReviewItemRow[]
+
+  const totalUsers = usersRes.count ?? 0
+  const activeLearners = new Set(progressRows.map((row) => row.user_id)).size
+  const completedStepRows = progressRows.filter(isStepCompleted).length
+  const fourModeCompletionRate = safeRate(completedStepRows, progressRows.length)
+  const challengePassed = submissions.filter((row) => row.is_passed).length
+  const challengePassRate = safeRate(challengePassed, submissions.length)
+  const dailyCompletedCount = dailyRows.filter((row) => row.completed).length
+  const miniProjectCompleted = miniProjectRows.filter((row) => row.status === 'completed').length
+  const miniProjectInProgress = miniProjectRows.filter((row) => row.status === 'in_progress').length
+  const miniProjectNotStarted = miniProjectRows.filter((row) => row.status === 'not_started').length
+  const recentFeedbackCount = feedbackRows.filter((row) => isWithinLastDays(row.created_at, 7)).length
+  const newFeedbackCount = feedbackRows.filter((row) => row.status === 'new').length
+  const firstStepId = getAllSteps().find((step) => step.isImplemented)?.id
+  const firstStepRows = firstStepId
+    ? progressRows.filter((row) => row.step_id === firstStepId)
+    : []
+  const firstStepStartedRate = safeRate(new Set(firstStepRows.map((row) => row.user_id)).size, totalUsers)
+  const firstStepCompletedRate = safeRate(
+    new Set(firstStepRows.filter(isStepCompleted).map((row) => row.user_id)).size,
+    totalUsers,
+  )
+  const aggregates = buildStepAggregates(progressRows, submissions, reviewItems)
+  const improvementSteps = buildImprovementSteps(aggregates)
+  const openReviewItems = reviewItems.filter((row) => row.status === 'open').length
+
+  return {
+    totalUsers,
+    activeLearners,
+    generatedAt: new Date().toISOString(),
+    formalMetrics: [
+      createMetric(
+        'four-mode-completion-rate',
+        '4モード完了率',
+        formatPercent(fourModeCompletionRate),
+        `${completedStepRows.toLocaleString()} / ${progressRows.length.toLocaleString()} 件のStep進捗が Read / Practice / Test / Challenge を完了`,
+        'formal',
+      ),
+      createMetric(
+        'challenge-pass-rate',
+        'Challenge合格率',
+        formatPercent(challengePassRate),
+        `${challengePassed.toLocaleString()} / ${submissions.length.toLocaleString()} 件の提出が合格`,
+        'formal',
+      ),
+      createMetric(
+        'daily-completed-count',
+        'Daily完了数',
+        formatCount(dailyCompletedCount),
+        'daily_challenge_history の completed=true 件数',
+        'formal',
+      ),
+      createMetric(
+        'mini-project-completed',
+        'Mini Project完了',
+        formatCount(miniProjectCompleted),
+        `${miniProjectRows.length.toLocaleString()}件中 ${miniProjectCompleted.toLocaleString()}件が completed`,
+        'formal',
+      ),
+      createMetric(
+        'recent-feedback',
+        '直近フィードバック',
+        formatCount(recentFeedbackCount),
+        `過去7日 ${recentFeedbackCount.toLocaleString()}件 / 新規 ${newFeedbackCount.toLocaleString()}件`,
+        'formal',
+      ),
+      createMetric(
+        'open-review-items',
+        '復習待ち',
+        formatCount(openReviewItems),
+        'review_items の status=open 件数',
+        'formal',
+      ),
+    ],
+    provisionalMetrics: [
+      createMetric(
+        'active-learner-rate',
+        '着手ユーザー率',
+        formatPercent(safeRate(activeLearners, totalUsers)),
+        `${activeLearners.toLocaleString()} / ${totalUsers.toLocaleString()} 人がStep進捗を保持`,
+        'provisional',
+      ),
+      createMetric(
+        'first-step-started-rate',
+        '初回Step開始率',
+        formatPercent(firstStepStartedRate),
+        '最初の実装済みStepに進捗行があるユーザー割合',
+        'provisional',
+      ),
+      createMetric(
+        'first-step-completed-rate',
+        '初回Step完了率',
+        formatPercent(firstStepCompletedRate),
+        '最初の実装済みStepを完了したユーザー割合',
+        'provisional',
+      ),
+    ],
+    futureMetrics: [
+      createMetric(
+        'read-to-practice-rate',
+        'Read → Practice遷移率',
+        'M2以降',
+        'learning_events 導入後に正式表示',
+        'future',
+      ),
+      createMetric(
+        'test-to-challenge-rate',
+        'Test → Challenge遷移率',
+        'M2以降',
+        'learning_events 導入後に正式表示',
+        'future',
+      ),
+      createMetric(
+        'review-resolution-time',
+        '復習解消までの時間',
+        'M2以降',
+        'review_items の履歴強化後に正式表示',
+        'future',
+      ),
+    ],
+    improvementSteps,
+    miniProjectStatus: {
+      total: miniProjectRows.length,
+      completed: miniProjectCompleted,
+      inProgress: miniProjectInProgress,
+      notStarted: miniProjectNotStarted,
+    },
+  }
+}


### PR DESCRIPTION
## 概要
- 既存データから4モード完了率、Challenge合格率、Daily完了数、Mini Project状況、直近フィードバック件数、復習待ち件数を集計する adminQualityService を追加
- 管理画面に品質ダッシュボードを追加し、正式KPI / 暫定KPI / M2以降KPIを区別して表示
- 改善優先ステップ Top5 を既存の進捗・提出・復習キューデータから近似表示
- Adminサイドナビと管理トップから品質ダッシュボードへ遷移できるように追加

## 確認
- npm run typecheck
- npm run lint
- npm run test
- npm run build
- pre-commit: lint / typecheck pass
- pre-push: test / build pass

## 補足
- build は既存の vendor-icons chunk size warning のみです
- ブラウザー確認は未実施です（ユーザー側で確認予定）