### PR TITLE
feat: React基礎ステップに学習メタ情報を追加

### DIFF
--- a/apps/web/src/content/__tests__/stepWalkthrough.test.ts
+++ b/apps/web/src/content/__tests__/stepWalkthrough.test.ts
@@ -39,6 +39,7 @@ import { typescriptReactSteps, getTypescriptReactStep } from '../typescript-reac
 import { reactModernSteps, getReactModernStep } from '../react-modern/steps'
 import { reactPatternsSteps, getReactPatternsStep } from '../react-patterns/steps'
 import type { LearningStepContent } from '../fundamentals/steps'
+import { BASE_NOOK_TOPICS } from '../base-nook/topics'
 
 // 全コンテンツを order 順に結合
 const allContentSteps: LearningStepContent[] = [
@@ -54,6 +55,8 @@ const allContentSteps: LearningStepContent[] = [
 
 // courseData の全ステップ（order 昇順）
 const allCourseSteps = getAllSteps().sort((a, b) => a.order - b.order)
+const reactFundamentalsStepIds = ['usestate-basic', 'events', 'conditional', 'lists']
+const baseNookTopicIds = new Set(BASE_NOOK_TOPICS.map((topic) => topic.id))
 
 // ─────────────────────────────────────────
 // 1. courseData 整合性
@@ -172,6 +175,33 @@ describe('4モードコンテンツ品質検証', () => {
       })
     })
   }
+})
+
+// ─────────────────────────────────────────
+// 3.5. Step メタ情報
+// ─────────────────────────────────────────
+describe('Step メタ情報', () => {
+  it('React基礎4ステップに学習メタ情報が付与されている', () => {
+    const reactFundamentalsSteps = fundamentalsSteps.filter((step) => reactFundamentalsStepIds.includes(step.id))
+
+    expect(reactFundamentalsSteps).toHaveLength(4)
+    for (const step of reactFundamentalsSteps) {
+      expect(step.learningGoal, `${step.id}: learningGoal が空`).toBeTruthy()
+      expect(step.prerequisites?.length, `${step.id}: prerequisites が空`).toBeGreaterThan(0)
+      expect(step.commonMistakes?.length, `${step.id}: commonMistakes が空`).toBeGreaterThan(0)
+      expect(step.relatedBaseNook?.length, `${step.id}: relatedBaseNook が空`).toBeGreaterThan(0)
+    }
+  })
+
+  it('React基礎4ステップの relatedBaseNook は存在する Base Nook topic を参照する', () => {
+    const reactFundamentalsSteps = fundamentalsSteps.filter((step) => reactFundamentalsStepIds.includes(step.id))
+
+    for (const step of reactFundamentalsSteps) {
+      for (const topicId of step.relatedBaseNook ?? []) {
+        expect(baseNookTopicIds.has(topicId), `${step.id}: ${topicId} が Base Nook に存在しない`).toBe(true)
+      }
+    }
+  })
 })
 
 // ─────────────────────────────────────────

--- a/apps/web/src/content/fundamentals/steps.ts
+++ b/apps/web/src/content/fundamentals/steps.ts
@@ -48,6 +48,10 @@ export interface LearningStepContent {
   order: number
   title: string
   summary: string
+  learningGoal?: string
+  prerequisites?: string[]
+  commonMistakes?: string[]
+  relatedBaseNook?: string[]
   readMarkdown: string
   practiceQuestions: PracticeQuestion[]
   testTask: TestTask
@@ -60,6 +64,14 @@ export const fundamentalsSteps: LearningStepContent[] = [
     order: 1,
     title: 'useStateの基礎',
     summary: 'コンポーネントに「記憶」を持たせる useState フックの基本を学ぶ。',
+    learningGoal: 'useStateで画面の状態を保持し、ユーザー操作に応じて再レンダリングされる流れを説明・実装できるようになる。',
+    prerequisites: ['Reactコンポーネントが関数としてUIを返すこと', 'ボタンのクリックなど、ユーザー操作で画面が変わるイメージを持っていること'],
+    commonMistakes: [
+      '通常の変数を書き換えても画面が更新されると思い込む',
+      'stateを直接代入で変更し、setStateを使わない',
+      '更新後の値をすぐ同じ処理内で読もうとして、反映タイミングを誤解する',
+    ],
+    relatedBaseNook: ['component', 'props-vs-state'],
     readMarkdown: `# State: コンポーネントの記憶
 
 UIの一部はユーザーの操作に応じて変化する必要があります。画面上のカウンターやテキスト入力など、時間とともに変化するデータをReactでは **State（状態）** と呼びます。
@@ -227,6 +239,14 @@ return <button onClick={() => ____}>-1 ({count})</button>`,
     order: 2,
     title: 'イベントへの応答',
     summary: 'onClick や onChange などのイベントハンドラを設定し、ユーザー操作を処理する。',
+    learningGoal: 'onClickやonChangeに関数を渡し、ユーザー操作をきっかけにstateや表示を更新できるようになる。',
+    prerequisites: ['JSXでボタンやinputを描画できること', 'useStateで値を保持する基本を理解していること'],
+    commonMistakes: [
+      'イベントハンドラに関数の実行結果を渡して、描画時に処理が走ってしまう',
+      'inputのvalueとonChangeをつなげず、入力欄とstateがずれる',
+      'イベントオブジェクトから値を取り出す位置を間違える',
+    ],
+    relatedBaseNook: ['jsx', 'dom', 'props-vs-state'],
     readMarkdown: `# イベントへの応答
 
 Reactでは、クリックしたり、マウスを重ねたり、入力フォームのテキストが変更されたりといった「ユーザーアクション」に対する処理を簡単に追加できます。
@@ -394,6 +414,14 @@ export function NameInput() {
     order: 3,
     title: '条件付きレンダリング',
     summary: '条件によって表示するコンポーネントや要素を分岐させる。',
+    learningGoal: 'booleanやstateの値に応じて、必要なUIだけを表示・非表示に切り替えられるようになる。',
+    prerequisites: ['JSX内でJavaScript式を埋め込めること', 'stateやpropsの値を画面表示に使う基本を理解していること'],
+    commonMistakes: [
+      'JSXの中でif文をそのまま式として書こうとする',
+      '0や空文字が&&の左辺に来たとき、意図しない値が表示される',
+      '条件分岐が深くなり、どのUIが表示されるか読み取りづらくなる',
+    ],
+    relatedBaseNook: ['jsx', 'javascript'],
     readMarkdown: `# 条件付きレンダリング
 
 コンポーネントは、状態や与えられたプロパティ(Props)に応じて、表示する内容を変えたい場面がよくあります。ReactではJavaScriptの強力な構文を使って柔軟に条件付きレンダリングを記述できます。
@@ -517,6 +545,14 @@ function Notifications({ unreadCount }) {
     order: 4,
     title: 'リストのレンダリング',
     summary: '配列のデータを map() メソッドで JSX に変換し、リストを描画する。',
+    learningGoal: '配列データをmapでJSXに変換し、安定したkeyを付けてリストUIを描画できるようになる。',
+    prerequisites: ['JavaScriptの配列とmapの基本', 'JSXで複数の要素を表示する基本'],
+    commonMistakes: [
+      'mapの戻り値を書き忘れて、何も表示されない',
+      'keyに配列indexを安易に使い、並び替えや削除で表示がずれる',
+      'リスト内の各要素に一意なidが必要な理由を見落とす',
+    ],
+    relatedBaseNook: ['javascript', 'jsx'],
     readMarkdown: `# リストのレンダリング
 
 アプリを作っていると、データの配列をもとに「同じ構造のコンポーネント」をいくつも生成したい場面が多々あります（商品一覧、Todoリスト、など）。

--- a/apps/web/src/features/learning/ReadMode.tsx
+++ b/apps/web/src/features/learning/ReadMode.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { Lightbulb } from 'lucide-react'
+import { CheckCircle2, Lightbulb, Target } from 'lucide-react'
 import { Button } from '../../components/Button'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -15,6 +15,8 @@ interface ReadModeProps {
   markdown: string
   onComplete: () => void
   isCompleted: boolean
+  learningGoal?: string | undefined
+  prerequisites?: string[] | undefined
 }
 
 function CopyButton({ text }: { text: string }) {
@@ -54,10 +56,13 @@ function CopyButton({ text }: { text: string }) {
   )
 }
 
-export function ReadMode({ markdown, onComplete, isCompleted }: ReadModeProps) {
+export function ReadMode({ markdown, onComplete, isCompleted, learningGoal, prerequisites }: ReadModeProps) {
   useEffect(() => {
     Prism.highlightAll()
   }, [markdown])
+
+  const hasPrerequisites = prerequisites != null && prerequisites.length > 0
+  const hasOverview = Boolean(learningGoal) || hasPrerequisites
 
   const completeButton = (
     <Button onClick={onComplete} disabled={isCompleted}>
@@ -71,6 +76,34 @@ export function ReadMode({ markdown, onComplete, isCompleted }: ReadModeProps) {
         <h2 className="text-lg font-semibold">Read</h2>
         {completeButton}
       </div>
+
+      {hasOverview ? (
+        <aside className="space-y-3 rounded-xl border border-primary-mint/30 bg-primary-mint/10 p-4 text-sm text-text-dark">
+          {learningGoal ? (
+            <div className="flex gap-3">
+              <Target className="mt-0.5 size-5 shrink-0 text-primary-dark" aria-hidden="true" />
+              <div>
+                <h3 className="font-bold text-primary-dark">このStepのゴール</h3>
+                <p className="mt-1 leading-relaxed">{learningGoal}</p>
+              </div>
+            </div>
+          ) : null}
+
+          {hasPrerequisites ? (
+            <div className="flex gap-3">
+              <CheckCircle2 className="mt-0.5 size-5 shrink-0 text-primary-dark" aria-hidden="true" />
+              <div>
+                <h3 className="font-bold text-primary-dark">前提</h3>
+                <ul className="mt-1 list-disc space-y-1 pl-5 leading-relaxed">
+                  {prerequisites.map((prerequisite) => (
+                    <li key={prerequisite}>{prerequisite}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          ) : null}
+        </aside>
+      ) : null}
 
       <article className="prose prose-slate prose-sm max-w-none overflow-x-hidden rounded-2xl border border-slate-200 bg-white p-3 shadow-sm sm:prose-base sm:p-5">
         <ReactMarkdown

--- a/apps/web/src/features/learning/__tests__/ReadMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/ReadMode.test.tsx
@@ -1,0 +1,36 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ReadMode } from '../ReadMode'
+
+describe('ReadMode', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('learningGoal と prerequisites がある場合は Read 冒頭に表示する', () => {
+    render(
+      <ReadMode
+        markdown="# 本文"
+        onComplete={vi.fn()}
+        isCompleted={false}
+        learningGoal="stateで画面を更新できるようになる"
+        prerequisites={['Reactコンポーネントの基本', 'クリックイベントの基本']}
+      />,
+    )
+
+    expect(screen.getByText('このStepのゴール')).toBeTruthy()
+    expect(screen.getByText('stateで画面を更新できるようになる')).toBeTruthy()
+    expect(screen.getByText('前提')).toBeTruthy()
+    expect(screen.getByText('Reactコンポーネントの基本')).toBeTruthy()
+    expect(screen.getByText('クリックイベントの基本')).toBeTruthy()
+    expect(screen.getByRole('heading', { name: '本文' })).toBeTruthy()
+  })
+
+  it('Step メタ情報がない場合は概要表示を省略する', () => {
+    render(<ReadMode markdown="# 本文" onComplete={vi.fn()} isCompleted={false} />)
+
+    expect(screen.queryByText('このStepのゴール')).toBeNull()
+    expect(screen.queryByText('前提')).toBeNull()
+    expect(screen.getByRole('heading', { name: '本文' })).toBeTruthy()
+  })
+})

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -320,6 +320,8 @@ export function StepPage() {
                 markdown={step.readMarkdown}
                 onComplete={() => void handleModeComplete('read')}
                 isCompleted={modeStatus.read}
+                learningGoal={step.learningGoal}
+                prerequisites={step.prerequisites}
               />
             ) : null}
 

--- a/apps/web/src/pages/__tests__/StepPage.test.tsx
+++ b/apps/web/src/pages/__tests__/StepPage.test.tsx
@@ -7,6 +7,7 @@ import { StepPage } from '../StepPage'
 const useChallengeSubmissionMock = vi.fn()
 const useRecentChallengeSubmissionsMock = vi.fn()
 const useLearningStepMock = vi.fn()
+const readModeMock = vi.fn()
 
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
@@ -37,7 +38,10 @@ vi.mock('@/features/dashboard/components/AppHeader', () => ({
 }))
 
 vi.mock('@/features/learning/ReadMode', () => ({
-  ReadMode: () => <div>read mode</div>,
+  ReadMode: (props: unknown) => {
+    readModeMock(props)
+    return <div>read mode</div>
+  },
 }))
 
 vi.mock('@/features/learning/PracticeMode', () => ({
@@ -64,12 +68,15 @@ vi.mock('@/features/learning/hooks/useLearningStep', () => ({
   useLearningStep: (...args: unknown[]) => useLearningStepMock(...args),
 }))
 
-function mockLearningStep(modeStatus = {
-  read: false,
-  practice: false,
-  test: false,
-  challenge: false,
-}) {
+function mockLearningStep(
+  modeStatus = {
+    read: false,
+    practice: false,
+    test: false,
+    challenge: false,
+  },
+  stepOverrides: Record<string, unknown> = {},
+) {
   useLearningStepMock.mockReturnValue({
     step: {
       id: 'usestate-basic',
@@ -95,6 +102,7 @@ function mockLearningStep(modeStatus = {
         ],
       },
       order: 1,
+      ...stepOverrides,
     },
     isUnavailableStep: false,
     modeStatus,
@@ -111,6 +119,7 @@ function mockLearningStep(modeStatus = {
 describe('StepPage', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
+    readModeMock.mockClear()
   })
 
   afterEach(() => {
@@ -148,6 +157,43 @@ describe('StepPage', () => {
     expect(screen.getByRole('tab', { name: 'Practice' }).getAttribute('aria-current')).toBe('step')
     expect(screen.getByRole('tab', { name: 'Read' }).getAttribute('aria-current')).toBeNull()
     expect(screen.getByRole('tab', { name: 'Practice' }).className).toContain('min-h-11')
+  })
+
+  it('ReadMode に Step メタ情報を渡す', () => {
+    useChallengeSubmissionMock.mockReturnValue(vi.fn())
+    useRecentChallengeSubmissionsMock.mockReturnValue({
+      submissions: [],
+      isLoading: false,
+      error: null,
+      refresh: vi.fn(),
+    })
+    mockLearningStep(
+      {
+        read: false,
+        practice: false,
+        test: false,
+        challenge: false,
+      },
+      {
+        learningGoal: 'stateで画面を更新できるようになる',
+        prerequisites: ['Reactコンポーネントの基本', 'クリックイベントの基本'],
+      },
+    )
+
+    render(
+      <MemoryRouter initialEntries={['/step/usestate-basic']}>
+        <Routes>
+          <Route path="/step/:stepId" element={<StepPage />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    expect(readModeMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        learningGoal: 'stateで画面を更新できるようになる',
+        prerequisites: ['Reactコンポーネントの基本', 'クリックイベントの基本'],
+      }),
+    )
   })
 
   it('mode クエリがある場合は指定された学習モードを初期表示する', () => {


### PR DESCRIPTION
## Summary
- Stepコンテンツ型に learningGoal / prerequisites / commonMistakes / relatedBaseNook を optional で追加
- React基礎4ステップに学習メタ情報と Base Nook topic 参照を追加
- StepページのRead冒頭にゴールと前提を表示し、未付与ステップでは表示を省略
- ReadMode / StepPage / コンテンツ整合性テストを追加・更新

## Test plan
- cmd /c npm run typecheck: pass
- cmd /c npm run lint: pass
- cmd /c npm run test: pass
- cmd /c npm run build: pass（既存のVite chunk size warningのみ）