### PR TITLE
feat: Base NookとStepの相互リンクを追加

### DIFF
--- a/apps/web/src/content/base-nook/__tests__/stepLinks.test.ts
+++ b/apps/web/src/content/base-nook/__tests__/stepLinks.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { fundamentalsSteps } from '../../fundamentals/steps'
+import { getRelatedBaseNookTopics, getStepsRelatedToBaseNook } from '../stepLinks'
+
+describe('Base Nook step links', () => {
+  it('Step の relatedBaseNook から topic 情報を解決する', () => {
+    const step = fundamentalsSteps.find((item) => item.id === 'events')
+
+    expect(step).toBeDefined()
+    expect(getRelatedBaseNookTopics(step!)).toEqual([
+      {
+        id: 'jsx',
+        title: 'JSXって何？',
+        summary: 'ReactでHTMLのようにUIを書く構文',
+      },
+      {
+        id: 'dom',
+        title: 'DOMって何？',
+        summary: 'ブラウザがHTMLを理解する仕組み',
+      },
+      {
+        id: 'props-vs-state',
+        title: 'propsとstateの違い',
+        summary: 'データの流れ、それぞれの役割',
+      },
+    ])
+  })
+
+  it('Base Nook topic から関連Stepを order 順に逆引きする', () => {
+    const steps = getStepsRelatedToBaseNook('props-vs-state')
+
+    expect(steps.map((step) => step.id)).toEqual(['usestate-basic', 'events'])
+    expect(steps[0]).toMatchObject({
+      order: 1,
+      title: 'useState基礎',
+      courseTitle: 'React基礎',
+    })
+  })
+})

--- a/apps/web/src/content/base-nook/stepLinks.ts
+++ b/apps/web/src/content/base-nook/stepLinks.ts
@@ -1,0 +1,66 @@
+import { advancedSteps } from '../advanced/steps'
+import { apiPracticeSteps } from '../api-practice/steps'
+import { findCourseByStepId, findStepById } from '../courseData'
+import { fundamentalsSteps, type LearningStepContent } from '../fundamentals/steps'
+import { intermediateSteps } from '../intermediate/steps'
+import { reactModernSteps } from '../react-modern/steps'
+import { reactPatternsSteps } from '../react-patterns/steps'
+import { typescriptSteps } from '../typescript/steps'
+import { typescriptReactSteps } from '../typescript-react/steps'
+import { BASE_NOOK_TOPICS } from './topics'
+
+export interface RelatedBaseNookTopic {
+  id: string
+  title: string
+  summary: string
+}
+
+export interface RelatedStepLink {
+  id: string
+  order: number
+  title: string
+  description: string
+  courseTitle: string
+}
+
+const allLearningSteps: readonly LearningStepContent[] = [
+  ...fundamentalsSteps,
+  ...intermediateSteps,
+  ...advancedSteps,
+  ...apiPracticeSteps,
+  ...typescriptSteps,
+  ...typescriptReactSteps,
+  ...reactModernSteps,
+  ...reactPatternsSteps,
+]
+
+export function getRelatedBaseNookTopics(step: Pick<LearningStepContent, 'relatedBaseNook'>): RelatedBaseNookTopic[] {
+  if (!step.relatedBaseNook?.length) return []
+
+  return step.relatedBaseNook
+    .map((topicId) => BASE_NOOK_TOPICS.find((topic) => topic.id === topicId))
+    .filter((topic): topic is NonNullable<typeof topic> => topic != null)
+    .map((topic) => ({
+      id: topic.id,
+      title: topic.title,
+      summary: topic.summary,
+    }))
+}
+
+export function getStepsRelatedToBaseNook(topicId: string): RelatedStepLink[] {
+  return allLearningSteps
+    .filter((step) => step.relatedBaseNook?.includes(topicId))
+    .map((step) => {
+      const stepMeta = findStepById(step.id)
+      const course = findCourseByStepId(step.id)
+
+      return {
+        id: step.id,
+        order: step.order,
+        title: stepMeta?.title ?? step.title,
+        description: stepMeta?.description ?? step.summary,
+        courseTitle: course?.title ?? 'カリキュラム',
+      }
+    })
+    .sort((a, b) => a.order - b.order)
+}

--- a/apps/web/src/features/learning/ReadMode.tsx
+++ b/apps/web/src/features/learning/ReadMode.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
-import { CheckCircle2, Lightbulb, Target } from 'lucide-react'
+import { Link } from 'react-router-dom'
+import { BookOpen, CheckCircle2, ChevronRight, Lightbulb, Target } from 'lucide-react'
 import { Button } from '../../components/Button'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -10,6 +11,7 @@ import 'prismjs/components/prism-typescript'
 import 'prismjs/components/prism-tsx'
 import 'prismjs/themes/prism-okaidia.css'
 import { COPY_FEEDBACK_DURATION_MS } from '../../shared/constants'
+import type { RelatedBaseNookTopic } from '../../content/base-nook/stepLinks'
 
 interface ReadModeProps {
   markdown: string
@@ -17,6 +19,7 @@ interface ReadModeProps {
   isCompleted: boolean
   learningGoal?: string | undefined
   prerequisites?: string[] | undefined
+  relatedBaseNookTopics?: readonly RelatedBaseNookTopic[] | undefined
 }
 
 function CopyButton({ text }: { text: string }) {
@@ -56,13 +59,21 @@ function CopyButton({ text }: { text: string }) {
   )
 }
 
-export function ReadMode({ markdown, onComplete, isCompleted, learningGoal, prerequisites }: ReadModeProps) {
+export function ReadMode({
+  markdown,
+  onComplete,
+  isCompleted,
+  learningGoal,
+  prerequisites,
+  relatedBaseNookTopics,
+}: ReadModeProps) {
   useEffect(() => {
     Prism.highlightAll()
   }, [markdown])
 
   const hasPrerequisites = prerequisites != null && prerequisites.length > 0
-  const hasOverview = Boolean(learningGoal) || hasPrerequisites
+  const hasRelatedBaseNookTopics = relatedBaseNookTopics != null && relatedBaseNookTopics.length > 0
+  const hasOverview = Boolean(learningGoal) || hasPrerequisites || hasRelatedBaseNookTopics
 
   const completeButton = (
     <Button onClick={onComplete} disabled={isCompleted}>
@@ -99,6 +110,28 @@ export function ReadMode({ markdown, onComplete, isCompleted, learningGoal, prer
                     <li key={prerequisite}>{prerequisite}</li>
                   ))}
                 </ul>
+              </div>
+            </div>
+          ) : null}
+
+          {hasRelatedBaseNookTopics ? (
+            <div className="flex gap-3">
+              <BookOpen className="mt-0.5 size-5 shrink-0 text-primary-dark" aria-hidden="true" />
+              <div>
+                <h3 className="font-bold text-primary-dark">関連するBase Nook</h3>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {relatedBaseNookTopics.map((topic) => (
+                    <Link
+                      key={topic.id}
+                      to={`/base-nook/${topic.id}`}
+                      className="inline-flex min-h-10 items-center gap-1.5 rounded-lg border border-primary-mint/30 bg-white px-3 py-2 text-sm font-semibold text-primary-dark transition hover:border-primary-mint hover:bg-primary-mint/10 focus:outline-none focus:ring-2 focus:ring-primary-mint/30"
+                      title={topic.summary}
+                    >
+                      {topic.title}
+                      <ChevronRight className="size-4" aria-hidden="true" />
+                    </Link>
+                  ))}
+                </div>
               </div>
             </div>
           ) : null}

--- a/apps/web/src/features/learning/__tests__/ReadMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/ReadMode.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ReadMode } from '../ReadMode'
 
@@ -32,5 +33,27 @@ describe('ReadMode', () => {
     expect(screen.queryByText('このStepのゴール')).toBeNull()
     expect(screen.queryByText('前提')).toBeNull()
     expect(screen.getByRole('heading', { name: '本文' })).toBeTruthy()
+  })
+
+  it('関連する Base Nook topic へのリンクを表示する', () => {
+    render(
+      <MemoryRouter>
+        <ReadMode
+          markdown="# 本文"
+          onComplete={vi.fn()}
+          isCompleted={false}
+          relatedBaseNookTopics={[
+            {
+              id: 'props-vs-state',
+              title: 'propsとstateの違い',
+              summary: 'データの流れ、それぞれの役割',
+            },
+          ]}
+        />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('関連するBase Nook')).toBeTruthy()
+    expect(screen.getByRole('link', { name: /propsとstateの違い/ }).getAttribute('href')).toBe('/base-nook/props-vs-state')
   })
 })

--- a/apps/web/src/pages/BaseNookTopicPage.tsx
+++ b/apps/web/src/pages/BaseNookTopicPage.tsx
@@ -1,6 +1,6 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useParams, Link } from 'react-router-dom'
-import { ArrowLeft, BookOpen } from 'lucide-react'
+import { ArrowLeft, BookOpen, ChevronRight, GraduationCap } from 'lucide-react'
 import { useAuth } from '../contexts/AuthContext'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useGreetingName } from '../hooks/useGreetingName'
@@ -11,6 +11,7 @@ import {
   selectQuestions,
 } from '../services/baseNookService'
 import { BASE_NOOK_TOPICS } from '../content/base-nook/topics'
+import { getStepsRelatedToBaseNook } from '../content/base-nook/stepLinks'
 import { ArticleView } from '../features/base-nook/components/ArticleView'
 import { QuizView } from '../features/base-nook/components/QuizView'
 import { AppHeader } from '../features/dashboard/components/AppHeader'
@@ -79,6 +80,7 @@ export function BaseNookTopicPage() {
   }, [solvedIds, topic])
 
   const allCleared = topic ? solvedIds.size >= topic.questions.length : false
+  const relatedStepLinks = useMemo(() => (topic ? getStepsRelatedToBaseNook(topic.id) : []), [topic])
 
   if (!topic) {
     return (
@@ -131,6 +133,33 @@ export function BaseNookTopicPage() {
             <section className="mb-10 rounded-2xl border border-slate-200 bg-white p-4 shadow-sm sm:p-6 lg:p-8">
               <ArticleView markdown={topic.article} />
             </section>
+
+            {relatedStepLinks.length > 0 ? (
+              <section className="mb-10 rounded-2xl border border-amber-200 bg-amber-50/80 p-4 shadow-sm sm:p-5">
+                <div className="mb-3 flex items-center gap-2 text-amber-900">
+                  <GraduationCap size={20} aria-hidden="true" />
+                  <h2 className="text-lg font-bold">この基礎を使うStep</h2>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                  {relatedStepLinks.map((step) => (
+                    <Link
+                      key={step.id}
+                      to={`/step/${step.id}`}
+                      className="group rounded-xl border border-amber-200 bg-white p-4 text-left transition hover:border-amber-300 hover:shadow-sm focus:outline-none focus:ring-2 focus:ring-amber-300/50"
+                    >
+                      <div className="mb-1 flex items-center justify-between gap-3">
+                        <span className="text-xs font-semibold text-amber-700">
+                          Step {step.order} / {step.courseTitle}
+                        </span>
+                        <ChevronRight className="size-4 shrink-0 text-amber-500 transition group-hover:translate-x-0.5" aria-hidden="true" />
+                      </div>
+                      <h3 className="font-bold text-text-dark group-hover:text-amber-800">{step.title}</h3>
+                      <p className="mt-1 text-sm leading-relaxed text-slate-600">{step.description}</p>
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            ) : null}
 
             {/* クイズパート */}
             <section>

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -4,6 +4,7 @@ import { BookOpen, Check, ChevronRight, Code2, PenLine, Trophy } from 'lucide-re
 import { ErrorBanner } from '../components/ErrorBanner'
 import { ErrorBoundary } from '../components/ErrorBoundary'
 import { LearningSidebar } from '../components/LearningSidebar'
+import { getRelatedBaseNookTopics } from '../content/base-nook/stepLinks'
 import { TOTAL_STEP_COUNT, findCategoryByStepId, findCourseByStepId } from '../content/courseData'
 import { PageSpinner } from '../components/Spinner'
 import type { LearningMode } from '../content/fundamentals/steps'
@@ -126,6 +127,7 @@ export function StepPage() {
     [],
   )
   useDocumentTitle(step?.title ?? 'ステップ')
+  const relatedBaseNookTopics = useMemo(() => (step ? getRelatedBaseNookTopics(step) : []), [step])
 
   useEffect(() => {
     setActiveMode(requestedMode ?? 'read')
@@ -322,6 +324,7 @@ export function StepPage() {
                 isCompleted={modeStatus.read}
                 learningGoal={step.learningGoal}
                 prerequisites={step.prerequisites}
+                relatedBaseNookTopics={relatedBaseNookTopics}
               />
             ) : null}
 

--- a/apps/web/src/pages/__tests__/BaseNookTopicPage.test.tsx
+++ b/apps/web/src/pages/__tests__/BaseNookTopicPage.test.tsx
@@ -85,6 +85,14 @@ describe('BaseNookTopicPage', () => {
     expect(screen.getByText('Quiz')).toBeTruthy()
   })
 
+  it('関連するStepがある topic では Step への導線を表示すること', async () => {
+    renderWithRoute('props-vs-state')
+
+    expect(await screen.findByText('この基礎を使うStep')).toBeTruthy()
+    expect(screen.getByRole('link', { name: /useState基礎/ }).getAttribute('href')).toBe('/step/usestate-basic')
+    expect(screen.getByRole('link', { name: /イベント処理/ }).getAttribute('href')).toBe('/step/events')
+  })
+
   it('エラー時にエラーメッセージが role="alert" で表示されること', async () => {
     getTopicProgressMock.mockRejectedValue(new Error('進捗の取得に失敗しました'))
     renderWithRoute('javascript')

--- a/apps/web/src/pages/__tests__/StepPage.test.tsx
+++ b/apps/web/src/pages/__tests__/StepPage.test.tsx
@@ -177,6 +177,7 @@ describe('StepPage', () => {
       {
         learningGoal: 'stateで画面を更新できるようになる',
         prerequisites: ['Reactコンポーネントの基本', 'クリックイベントの基本'],
+        relatedBaseNook: ['props-vs-state'],
       },
     )
 
@@ -192,6 +193,13 @@ describe('StepPage', () => {
       expect.objectContaining({
         learningGoal: 'stateで画面を更新できるようになる',
         prerequisites: ['Reactコンポーネントの基本', 'クリックイベントの基本'],
+        relatedBaseNookTopics: [
+          {
+            id: 'props-vs-state',
+            title: 'propsとstateの違い',
+            summary: 'データの流れ、それぞれの役割',
+          },
+        ],
       }),
     )
   })


### PR DESCRIPTION
## Summary
- Stepの relatedBaseNook から Base Nook topic 情報を解決するユーティリティを追加
- StepページのRead冒頭に関連Base Nookリンクを表示
- Base Nook topic詳細に、この基礎を使うStepへの逆リンクを表示
- 相互リンクのユーティリティ、ReadMode、StepPage、BaseNookTopicPageのテストを追加・更新

## Test plan
- cmd /c npm run typecheck: pass
- cmd /c npm run lint: pass
- cmd /c npm run test: pass
- cmd /c npm run build: pass（既存のVite chunk size warningのみ）