### PR TITLE
feat: Step Insightsを品質ダッシュボードに追加

### DIFF
--- a/apps/web/src/pages/admin/AdminQualityDashboardPage.tsx
+++ b/apps/web/src/pages/admin/AdminQualityDashboardPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react'
-import { AlertCircle, CheckCircle2, Clock3, Loader2, ShieldCheck, TrendingUp } from 'lucide-react'
+import { AlertCircle, BarChart3, CheckCircle2, Clock3, Loader2, ShieldCheck, TrendingUp } from 'lucide-react'
 import { AdminLayout } from '../../features/admin/components/AdminLayout'
 import { useDocumentTitle } from '../../hooks/useDocumentTitle'
 import {
@@ -7,6 +7,8 @@ import {
   type AdminQualityDashboard,
   type AdminQualityMetric,
   type AdminQualityMetricStatus,
+  type AdminQualityStepInsight,
+  type AdminQualityStepInsightSignal,
   type AdminQualityStepPriority,
 } from '../../services/adminQualityService'
 
@@ -20,6 +22,20 @@ const STATUS_STYLES: Record<AdminQualityMetricStatus, string> = {
   formal: 'border-emerald-200 bg-emerald-50 text-emerald-700',
   provisional: 'border-amber-200 bg-amber-50 text-amber-700',
   future: 'border-slate-200 bg-slate-50 text-slate-600',
+}
+
+const STEP_SIGNAL_LABELS: Record<AdminQualityStepInsightSignal, string> = {
+  healthy: '順調',
+  watch: '要観察',
+  attention: '要対応',
+  insufficient: 'データ不足',
+}
+
+const STEP_SIGNAL_STYLES: Record<AdminQualityStepInsightSignal, string> = {
+  healthy: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  watch: 'border-amber-200 bg-amber-50 text-amber-700',
+  attention: 'border-rose-200 bg-rose-50 text-rose-700',
+  insufficient: 'border-slate-200 bg-slate-50 text-slate-600',
 }
 
 function formatPercent(rate: number | null): string {
@@ -117,6 +133,10 @@ export function AdminQualityDashboardPage() {
             <ImprovementTable rows={dashboard.improvementSteps} />
           </Section>
 
+          <Section title="Step Insights" icon={<BarChart3 className="h-4 w-4" aria-hidden="true" />}>
+            <StepInsightsTable rows={dashboard.stepInsights} />
+          </Section>
+
           <Section title="Mini Project状況" icon={<CheckCircle2 className="h-4 w-4" aria-hidden="true" />}>
             <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
               <OverviewTile label="合計" value={`${dashboard.miniProjectStatus.total.toLocaleString()}件`} />
@@ -190,6 +210,69 @@ function MetricGrid({ metrics }: { metrics: AdminQualityMetric[] }) {
           <p className="mt-2 text-xs leading-5 text-slate-500">{metric.detail}</p>
         </article>
       ))}
+    </div>
+  )
+}
+
+function StepInsightsTable({ rows }: { rows: AdminQualityStepInsight[] }) {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-2xl border border-slate-200 bg-white p-5 text-sm text-slate-500 shadow-sm">
+        Step Insights のデータがありません
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <table className="min-w-full divide-y divide-slate-100 text-sm">
+        <thead className="bg-slate-50 text-left text-xs font-semibold text-slate-500">
+          <tr>
+            <th scope="col" className="px-4 py-3">Step</th>
+            <th scope="col" className="px-4 py-3">状態</th>
+            <th scope="col" className="px-4 py-3">着手</th>
+            <th scope="col" className="px-4 py-3">完了率</th>
+            <th scope="col" className="px-4 py-3">遷移</th>
+            <th scope="col" className="px-4 py-3">Challenge</th>
+            <th scope="col" className="px-4 py-3">ボトルネック</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {rows.map((row) => (
+            <tr key={row.stepId}>
+              <td className="px-4 py-3">
+                <p className="font-semibold text-slate-800">
+                  Step {row.order}「{row.title}」
+                </p>
+                <p className="mt-0.5 font-mono text-xs text-slate-400">{row.stepId}</p>
+              </td>
+              <td className="px-4 py-3">
+                <span
+                  className={`inline-flex rounded-full border px-2 py-0.5 text-xs font-semibold ${STEP_SIGNAL_STYLES[row.signal]}`}
+                >
+                  {STEP_SIGNAL_LABELS[row.signal]}
+                </span>
+              </td>
+              <td className="px-4 py-3 font-mono text-slate-700">{row.startedUsers}人</td>
+              <td className="px-4 py-3 font-mono text-slate-700">
+                {row.completedUsers} / {row.startedUsers} ({formatPercent(row.completionRate)})
+              </td>
+              <td className="px-4 py-3 font-mono text-xs leading-5 text-slate-700">
+                <p>R→P {formatPercent(row.readToPracticeRate)}</p>
+                <p>P→T {formatPercent(row.practiceToTestRate)}</p>
+                <p>T→C {formatPercent(row.testToChallengeRate)}</p>
+              </td>
+              <td className="px-4 py-3 font-mono text-slate-700">
+                {row.challengeSubmissions}件 / {formatPercent(row.challengePassRate)}
+              </td>
+              <td className="px-4 py-3 text-xs leading-5 text-slate-500">
+                <p>{row.bottleneck}</p>
+                {row.openReviewItems > 0 ? <p>復習待ち {row.openReviewItems}件</p> : null}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   )
 }

--- a/apps/web/src/pages/admin/__tests__/AdminQualityDashboardPage.test.tsx
+++ b/apps/web/src/pages/admin/__tests__/AdminQualityDashboardPage.test.tsx
@@ -79,6 +79,28 @@ const SAMPLE_DASHBOARD: AdminQualityDashboard = {
       reasons: ['完了率 0.0%', 'Challenge 合格率 0.0%', '復習待ち 1件', '着手 1人'],
     },
   ],
+  stepInsights: [
+    {
+      stepId: 'usestate-basic',
+      order: 1,
+      title: 'useState基礎',
+      startedUsers: 2,
+      readDoneUsers: 2,
+      practiceDoneUsers: 2,
+      testDoneUsers: 1,
+      challengeDoneUsers: 1,
+      completedUsers: 1,
+      completionRate: 0.5,
+      readToPracticeRate: 1,
+      practiceToTestRate: 0.5,
+      testToChallengeRate: 1,
+      challengeSubmissions: 1,
+      challengePassRate: 1,
+      openReviewItems: 0,
+      bottleneck: 'Practice → Test 50.0%',
+      signal: 'watch',
+    },
+  ],
   miniProjectStatus: {
     total: 2,
     completed: 1,
@@ -115,6 +137,10 @@ describe('AdminQualityDashboardPage', () => {
     expect(screen.getAllByText('M2以降').length).toBeGreaterThan(0)
     expect(screen.getByText('改善優先ステップ Top5')).toBeTruthy()
     expect(screen.getByText('Step 2「イベント処理」')).toBeTruthy()
+    expect(screen.getByText('Step Insights')).toBeTruthy()
+    expect(screen.getByText('Step 1「useState基礎」')).toBeTruthy()
+    expect(screen.getByText('要観察')).toBeTruthy()
+    expect(screen.getByText('Practice → Test 50.0%')).toBeTruthy()
     expect(screen.getByText('Read → Practice遷移率')).toBeTruthy()
 
     await waitFor(() => {

--- a/apps/web/src/services/__tests__/adminQualityService.test.ts
+++ b/apps/web/src/services/__tests__/adminQualityService.test.ts
@@ -140,6 +140,34 @@ describe('getAdminQualityDashboard', () => {
         openReviewItems: 1,
       }),
     )
+    expect(dashboard.stepInsights).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          stepId: 'usestate-basic',
+          startedUsers: 2,
+          readDoneUsers: 2,
+          practiceDoneUsers: 2,
+          testDoneUsers: 1,
+          challengeDoneUsers: 1,
+          completedUsers: 1,
+          completionRate: 0.5,
+          readToPracticeRate: 1,
+          practiceToTestRate: 0.5,
+          testToChallengeRate: 1,
+          signal: 'watch',
+          bottleneck: 'Practice → Test 50.0%',
+        }),
+        expect.objectContaining({
+          stepId: 'events',
+          startedUsers: 1,
+          completionRate: 0,
+          challengeSubmissions: 2,
+          challengePassRate: 0,
+          openReviewItems: 1,
+          signal: 'attention',
+        }),
+      ]),
+    )
   })
 
   it('クエリエラーを AppError に変換する', async () => {

--- a/apps/web/src/services/adminQualityService.ts
+++ b/apps/web/src/services/adminQualityService.ts
@@ -49,6 +49,29 @@ export interface AdminQualityStepPriority {
   reasons: string[]
 }
 
+export type AdminQualityStepInsightSignal = 'healthy' | 'watch' | 'attention' | 'insufficient'
+
+export interface AdminQualityStepInsight {
+  stepId: string
+  order: number
+  title: string
+  startedUsers: number
+  readDoneUsers: number
+  practiceDoneUsers: number
+  testDoneUsers: number
+  challengeDoneUsers: number
+  completedUsers: number
+  completionRate: number | null
+  readToPracticeRate: number | null
+  practiceToTestRate: number | null
+  testToChallengeRate: number | null
+  challengeSubmissions: number
+  challengePassRate: number | null
+  openReviewItems: number
+  bottleneck: string
+  signal: AdminQualityStepInsightSignal
+}
+
 export interface AdminQualityMiniProjectStatus {
   total: number
   completed: number
@@ -64,6 +87,7 @@ export interface AdminQualityDashboard {
   provisionalMetrics: AdminQualityMetric[]
   futureMetrics: AdminQualityMetric[]
   improvementSteps: AdminQualityStepPriority[]
+  stepInsights: AdminQualityStepInsight[]
   miniProjectStatus: AdminQualityMiniProjectStatus
 }
 
@@ -72,6 +96,10 @@ interface StepAggregate {
   order: number
   title: string
   startedUsers: Set<string>
+  readDoneUsers: Set<string>
+  practiceDoneUsers: Set<string>
+  testDoneUsers: Set<string>
+  challengeDoneUsers: Set<string>
   completedUsers: Set<string>
   challengeSubmissions: number
   challengePassed: number
@@ -130,6 +158,10 @@ function buildStepAggregates(
       order: step.order,
       title: step.title,
       startedUsers: new Set<string>(),
+      readDoneUsers: new Set<string>(),
+      practiceDoneUsers: new Set<string>(),
+      testDoneUsers: new Set<string>(),
+      challengeDoneUsers: new Set<string>(),
       completedUsers: new Set<string>(),
       challengeSubmissions: 0,
       challengePassed: 0,
@@ -141,6 +173,10 @@ function buildStepAggregates(
     const aggregate = aggregates.get(row.step_id)
     if (!aggregate) continue
     aggregate.startedUsers.add(row.user_id)
+    if (row.read_done) aggregate.readDoneUsers.add(row.user_id)
+    if (row.practice_done) aggregate.practiceDoneUsers.add(row.user_id)
+    if (row.test_done) aggregate.testDoneUsers.add(row.user_id)
+    if (row.challenge_done) aggregate.challengeDoneUsers.add(row.user_id)
     if (isStepCompleted(row)) {
       aggregate.completedUsers.add(row.user_id)
     }
@@ -204,6 +240,81 @@ function buildImprovementSteps(aggregates: StepAggregate[]): AdminQualityStepPri
     })
     .sort((a, b) => b.priorityScore - a.priorityScore || a.order - b.order)
     .slice(0, 5)
+}
+
+function getLowestTransition(
+  transitions: readonly { label: string; rate: number | null }[],
+): { label: string; rate: number | null } | null {
+  const measurable = transitions.filter((item): item is { label: string; rate: number } => item.rate !== null)
+  if (measurable.length === 0) return null
+  const [lowest] = measurable.sort((a, b) => a.rate - b.rate)
+  return lowest ?? null
+}
+
+function buildStepInsights(aggregates: StepAggregate[]): AdminQualityStepInsight[] {
+  return aggregates.map((row) => {
+    const startedUsers = row.startedUsers.size
+    const readDoneUsers = row.readDoneUsers.size
+    const practiceDoneUsers = row.practiceDoneUsers.size
+    const testDoneUsers = row.testDoneUsers.size
+    const challengeDoneUsers = row.challengeDoneUsers.size
+    const completedUsers = row.completedUsers.size
+    const completionRate = safeRate(completedUsers, startedUsers)
+    const readToPracticeRate = safeRate(practiceDoneUsers, readDoneUsers)
+    const practiceToTestRate = safeRate(testDoneUsers, practiceDoneUsers)
+    const testToChallengeRate = safeRate(challengeDoneUsers, testDoneUsers)
+    const challengePassRate = safeRate(row.challengePassed, row.challengeSubmissions)
+    const lowestTransition = getLowestTransition([
+      { label: 'Read → Practice', rate: readToPracticeRate },
+      { label: 'Practice → Test', rate: practiceToTestRate },
+      { label: 'Test → Challenge', rate: testToChallengeRate },
+    ])
+    const hasSevereDrop =
+      completionRate !== null && completionRate < 0.4 ||
+      lowestTransition?.rate != null && lowestTransition.rate < 0.45 ||
+      challengePassRate !== null && challengePassRate < 0.4 ||
+      row.openReviewItems >= 3
+    const hasWatchSignal =
+      completionRate !== null && completionRate < 0.7 ||
+      lowestTransition?.rate != null && lowestTransition.rate < 0.7 ||
+      challengePassRate !== null && challengePassRate < 0.7 ||
+      row.openReviewItems > 0
+    const signal: AdminQualityStepInsightSignal =
+      startedUsers === 0 && row.challengeSubmissions === 0 && row.openReviewItems === 0
+        ? 'insufficient'
+        : hasSevereDrop
+          ? 'attention'
+          : hasWatchSignal
+            ? 'watch'
+            : 'healthy'
+    const bottleneck =
+      startedUsers === 0
+        ? '着手データなし'
+        : lowestTransition
+          ? `${lowestTransition.label} ${formatPercent(lowestTransition.rate)}`
+          : '遷移データ不足'
+
+    return {
+      stepId: row.stepId,
+      order: row.order,
+      title: row.title,
+      startedUsers,
+      readDoneUsers,
+      practiceDoneUsers,
+      testDoneUsers,
+      challengeDoneUsers,
+      completedUsers,
+      completionRate,
+      readToPracticeRate,
+      practiceToTestRate,
+      testToChallengeRate,
+      challengeSubmissions: row.challengeSubmissions,
+      challengePassRate,
+      openReviewItems: row.openReviewItems,
+      bottleneck,
+      signal,
+    }
+  }).sort((a, b) => a.order - b.order)
 }
 
 export async function getAdminQualityDashboard(): Promise<AdminQualityDashboard> {
@@ -270,6 +381,7 @@ export async function getAdminQualityDashboard(): Promise<AdminQualityDashboard>
   )
   const aggregates = buildStepAggregates(progressRows, submissions, reviewItems)
   const improvementSteps = buildImprovementSteps(aggregates)
+  const stepInsights = buildStepInsights(aggregates)
   const openReviewItems = reviewItems.filter((row) => row.status === 'open').length
 
   return {
@@ -367,6 +479,7 @@ export async function getAdminQualityDashboard(): Promise<AdminQualityDashboard>
       ),
     ],
     improvementSteps,
+    stepInsights,
     miniProjectStatus: {
       total: miniProjectRows.length,
       completed: miniProjectCompleted,


### PR DESCRIPTION
## Summary
- 品質ダッシュボードに Step Insights セクションを追加
- step_progress から Read→Practice→Test→Challenge の遷移率と4モード完了率を集計
- challenge_submissions / review_items を合わせて Step ごとの状態シグナルとボトルネックを表示
- adminQualityService と AdminQualityDashboardPage のテストを更新

## Test plan
- cmd /c npm run typecheck: pass
- cmd /c npm run lint: pass
- cmd /c npm run test: pass
- cmd /c npm run build: pass（既存のVite chunk size warningのみ）