### PR TITLE
fix: review_itemsの管理者閲覧ポリシーを追加

### DIFF
--- a/apps/web/supabase/sql/021_admin_select_review_items.sql
+++ b/apps/web/supabase/sql/021_admin_select_review_items.sql
@@ -1,0 +1,6 @@
+-- 021_admin_select_review_items.sql
+-- 品質ダッシュボード向け: 管理者が全ユーザーの review_items を横断集計できるようにする。
+
+drop policy if exists admin_select_review_items on public.review_items;
+create policy admin_select_review_items on public.review_items
+  for select using (public.is_admin());


### PR DESCRIPTION
## Summary
- review_items に管理者向け SELECT ポリシーを追加する 021 マイグレーションを作成
- 品質ダッシュボードの復習待ち/Step Insights が全ユーザー分を横断集計できるようにする
- DB適用は dqiya さんが手動で実施する前提

## Test plan
- cmd /c npm run typecheck: pass
- cmd /c npm run lint: pass
- pre-push: npm run test pass
- pre-push: npm run build pass（既存の Vite chunk size warning のみ）