### PR TITLE
docs: 教材とSupabaseの運用手順を追加

### DIFF
--- a/docs/content-guidelines.md
+++ b/docs/content-guidelines.md
@@ -1,0 +1,214 @@
+# Coden コンテンツ追加・レビュー基準
+
+**目的**: Coden の学習コンテンツを追加・修正するときに、到達目標、難易度、4モードのつながり、Base Nook との接続を一定品質で保つ。
+
+このドキュメントは公開しても問題ない運用基準として扱う。個別ユーザー情報、未公開の事業判断、APIキー、認証情報、個人メモは書かない。
+
+---
+
+## 1. 対象
+
+主な対象ファイル:
+
+- `apps/web/src/content/courseData.ts`
+- `apps/web/src/content/*/steps/*.ts`
+- `apps/web/src/content/*/steps/index.ts`
+- `apps/web/src/content/stepLearningGoals.ts`
+- `apps/web/src/content/base-nook/topics.ts`
+- `apps/web/src/content/base-nook/stepLinks.ts`
+- `apps/web/src/content/__tests__/stepWalkthrough.test.ts`
+
+対象コンテンツ:
+
+- Step の Read / Practice / Test / Challenge
+- Step メタ情報: `learningGoal`, `prerequisites`, `commonMistakes`, `relatedBaseNook`
+- Base Nook トピックと Step の相互リンク
+- Daily / Code Doctor / Mini Projects / Code Reading など、Step と関連する補助教材
+
+---
+
+## 2. Step 追加時の必須項目
+
+新しい Step を追加するときは、最低限以下をそろえる。
+
+| 項目 | 基準 |
+|---|---|
+| `id` | URLやDBに残るため、短く安定した kebab-case にする |
+| `order` | `courseData.ts` と content 側で一致させる |
+| `title` / `summary` | 学習者が内容をすぐ想像できる文言にする |
+| `learningGoal` | そのStep後に「何ができるようになるか」を1文で書く |
+| `readMarkdown` | 100文字以上。概念だけでなく、なぜ必要かを説明する |
+| `practiceQuestions` | 1問以上。各問に `prompt`, `answer`, `hint` を持たせる |
+| `testTask` | Readで学んだ内容を短く確認する。`expectedKeywords` を設定する |
+| `challengeTask` | 実装寄りの課題を1パターン以上用意する |
+
+`prerequisites`, `commonMistakes`, `relatedBaseNook` は段階適用のため optional だが、主要Stepでは付与を推奨する。
+
+---
+
+## 3. 学習メタ情報の書き方
+
+### 3.1 learningGoal
+
+良い `learningGoal` は、学習者が「このStepで何を得るか」を具体的に判断できる。
+
+良い例:
+
+```ts
+learningGoal: '配列データをmapでJSXに変換し、安定したkeyを付けてリストUIを描画できるようになる。'
+```
+
+避ける例:
+
+```ts
+learningGoal: 'リストについて理解する。'
+```
+
+チェック観点:
+
+- 「理解する」だけで終わらず、説明・実装・判断などの行動が見える
+- 1文で読み切れる
+- Step の Read / Practice / Test / Challenge と対応している
+- 前後Stepの難易度と飛びすぎていない
+
+### 3.2 prerequisites
+
+`prerequisites` は、このStepに入る前に確認しておく概念を書く。
+
+基準:
+
+- 2〜4項目を目安にする
+- 「Reactが完璧に分かること」のような広すぎる条件にしない
+- Base Nook で補える概念がある場合は `relatedBaseNook` と合わせる
+- 未習得でも進められる軽い前提は、ロック条件ではなく学習補助として書く
+
+### 3.3 commonMistakes
+
+`commonMistakes` は、初学者がつまずきやすい点を責めない表現で書く。
+
+良い例:
+
+```ts
+commonMistakes: [
+  'mapの戻り値を書き忘れて、何も表示されない',
+  'keyに配列indexを安易に使い、並び替えや削除で表示がずれる',
+]
+```
+
+避ける表現:
+
+- 「基本を理解していない」
+- 「間違った書き方」
+- 「ちゃんと考えていない」
+
+チェック観点:
+
+- 現象と確認ポイントが分かる
+- Practice / Test の不正解時補足に使っても自然
+- 1項目が長すぎない
+
+### 3.4 relatedBaseNook
+
+`relatedBaseNook` は、Step の補習に役立つ Base Nook topic ID を指定する。
+
+基準:
+
+- topic ID は `BASE_NOOK_TOPICS` に存在するものだけを使う
+- 主学習の代替ではなく、前提概念の補助として使う
+- 関連が弱い topic を増やしすぎない
+- 追加・変更時は `apps/web/src/content/base-nook/__tests__/stepLinks.test.ts` と `stepWalkthrough.test.ts` の観点を確認する
+
+---
+
+## 4. 4モードの対応基準
+
+Coden の Step は Read → Practice → Test → Challenge の順で、理解から実装へ進む。
+
+| モード | 役割 | レビュー観点 |
+|---|---|---|
+| Read | 概念理解 | なぜ必要か、どう使うか、落とし穴が説明されている |
+| Practice | 小さな確認 | Readの内容を直接使う。答えが暗記だけになりすぎない |
+| Test | 短い判定 | 1つの要点を確認する。`expectedKeywords` が過不足ない |
+| Challenge | 実装練習 | 実務に近い文脈で、複数要件を満たす課題にする |
+
+レビュー時は、各モードが別々の教材になっていないかを見る。Readで説明していない概念をTestやChallengeで突然要求しない。
+
+---
+
+## 5. 難易度設計
+
+難易度は前後Stepとコース内の位置で判断する。
+
+| レベル | 目安 |
+|---|---|
+| beginner | 1つの概念を小さく試す。構文・用語の説明を省略しない |
+| intermediate | 複数の概念を組み合わせる。状態管理やAPIなど、実装の流れを扱う |
+| advanced | 設計判断を含める。失敗時・境界条件・実務文脈を扱う |
+
+急に難しくなる兆候:
+
+- ReadにないAPIや型をChallengeで要求している
+- starterCode の TODO が多すぎる
+- `expectedKeywords` が多すぎて、何を見たい判定か分からない
+- 1つのStepで複数の新概念を初登場させている
+
+---
+
+## 6. レビュー前チェックリスト
+
+コンテンツPRを出す前に確認する。
+
+- [ ] `courseData.ts` と content 側の `id` / `order` が一致している
+- [ ] `learningGoal` が定義されている
+- [ ] 主要Stepでは `prerequisites` / `commonMistakes` / `relatedBaseNook` が定義されている
+- [ ] Readで説明した内容がPractice / Test / Challengeに反映されている
+- [ ] Practiceの `choices` がある場合、`answer` が choices に含まれている
+- [ ] Test / Challenge の `expectedKeywords` が判定目的に合っている
+- [ ] モバイルパズルがある場合、空欄とトークンが過不足ない
+- [ ] Base Nook topic ID が存在する
+- [ ] `cmd /c npm run typecheck`
+- [ ] `cmd /c npm run lint`
+- [ ] `cmd /c npm run test`
+- [ ] `cmd /c npm run build`
+
+---
+
+## 7. 既存コンテンツ修正時の注意
+
+既存Stepの `id` は、URL、進捗、復習、提出履歴と結びつく。基本的に変更しない。
+
+変更してよいもの:
+
+- 表現の改善
+- `learningGoal` などのメタ情報
+- 説明の補足
+- Practice / Test / Challenge の明らかな誤り修正
+- `expectedKeywords` の過不足修正
+
+慎重に扱うもの:
+
+- Step ID
+- `order`
+- Challenge の判定条件
+- Supabase に保存される値と対応する識別子
+
+---
+
+## 8. PR本文に書くこと
+
+コンテンツPRでは、最低限以下を書く。
+
+```md
+## Summary
+- 追加・修正したStep
+- learningGoal / prerequisites / commonMistakes / relatedBaseNook の追加範囲
+- Read / Practice / Test / Challenge の主な変更点
+
+## Test plan
+- cmd /c npm run typecheck
+- cmd /c npm run lint
+- cmd /c npm run test
+- cmd /c npm run build
+```
+
+スクリーンショット確認をユーザー側で行う場合は、その前提も明記する。

--- a/docs/supabase-ops.md
+++ b/docs/supabase-ops.md
@@ -1,0 +1,265 @@
+# Coden Supabase 運用手順
+
+**目的**: Supabase SQL の追加・適用・型生成・RLS確認を、Coden v1.0 以降も再現できる形でそろえる。
+
+このドキュメントは公開しても問題ない運用手順として扱う。APIキー、パスワード、接続文字列、個人アカウントの認証情報、実ユーザーの個人情報は書かない。
+
+---
+
+## 1. 対象ファイル
+
+| 種別 | パス |
+|---|---|
+| SQL | `apps/web/supabase/sql/*.sql` |
+| ローカル用SQL例 | `apps/web/supabase/sql/local/*.example` |
+| 生成型 | `apps/web/src/shared/types/database.types.ts` |
+| Supabase client | `apps/web/src/lib/supabaseClient.ts` |
+| DB利用サービス | `apps/web/src/services/*.ts` |
+
+`apps/web/supabase/sql/local/*.sql` は実パスワードを含む可能性があるためGit管理外。`.example` だけを管理する。
+
+---
+
+## 2. SQLファイル命名ルール
+
+SQLファイルは `apps/web/supabase/sql/` に番号順で置く。
+
+形式:
+
+```text
+NNN_short_description.sql
+```
+
+例:
+
+```text
+022_learning_events.sql
+```
+
+ルール:
+
+- `NNN` は3桁の連番にする
+- 既存の最大番号の次を使う
+- ファイル名は snake_case にする
+- 1ファイル1目的を基本にする
+- RLS対象テーブルを作る場合、同じファイル内に RLS 有効化と policy を含める
+- RPCを追加する場合、権限、`security definer`、`search_path`、admin判定の有無を明記する
+
+2026-06-05 時点の最新は `021_admin_select_review_items.sql`。次の新規SQLは `022_*.sql` から始める。
+
+---
+
+## 3. 現在のSQL一覧
+
+| # | ファイル | 主な内容 |
+|---|---|---|
+| 001 | `001_schema_and_rls.sql` | 初期スキーマ / RLS |
+| 002 | `002_seed_test_users.sql` | テストユーザー |
+| 003 | `003_gamification.sql` | ポイント / 実績 |
+| 004 | `004_award_points_rpc.sql` | ポイント付与RPC |
+| 005 | `005_seed_test_progress.sql` | テスト用進捗 |
+| 006 | `006_daily_challenge.sql` | Daily Challenge |
+| 007 | `007_code_doctor.sql` | Code Doctor |
+| 008 | `008_mini_projects.sql` | Mini Projects |
+| 009 | `009_code_reading.sql` | Code Reading |
+| 010 | `010_record_study_activity_rpc.sql` | 学習活動記録RPC |
+| 011 | `011_base_nook.sql` | Base Nook |
+| 012 | `012_base_nook_timestamp_trigger.sql` | Base Nook timestamp trigger |
+| 013 | `013_admin_and_feedback.sql` | admin / feedback |
+| 014 | `014_admin_stats_rpc.sql` | admin stats RPC |
+| 015 | `015_admin_ops_rpc.sql` | admin ops RPC |
+| 016 | `016_admin_user_basic_rpc.sql` | admin user basic RPC |
+| 017 | `017_fix_profile_rls.sql` | profiles RLS修正 |
+| 018 | `018_auto_create_profile_trigger.sql` | profile自動作成trigger |
+| 019 | `019_feedback_images.sql` | feedback画像 |
+| 020 | `020_review_items.sql` | 復習キュー |
+| 021 | `021_admin_select_review_items.sql` | review_items admin横断SELECT |
+
+READMEのSQL一覧よりこの表を優先する。READMEを更新するタイミングでは、この表と差分が出ないようにする。
+
+---
+
+## 4. SQL追加時の実装手順
+
+1. 最新のSQL番号を確認する。
+   ```powershell
+   rg --files apps/web/supabase/sql
+   ```
+
+2. 次番号でSQLファイルを作る。
+   ```text
+   apps/web/supabase/sql/022_example.sql
+   ```
+
+3. テーブル作成時は以下を確認する。
+   - primary key がある
+   - `user_id` を持つユーザーデータは `auth.users(id)` と対応している
+   - 必要な `created_at` / `updated_at` がある
+   - 検索・集計で使う列に index がある
+   - RLSを有効化している
+   - own行 policy と admin policy の両方が必要か判断している
+
+4. RPC作成時は以下を確認する。
+   - `security definer` が本当に必要か
+   - `set search_path = public` を設定しているか
+   - admin限定RPCは `public.is_admin()` で制限しているか
+   - 戻り値の型がフロントエンドで扱いやすいか
+
+5. SQLを適用する。
+   - 本番適用はSupabase SQL Editorで手動実行する
+   - 複数ファイルを一度に流す場合も、番号順に実行する
+   - 失敗した場合は途中から再実行できるよう、`create policy` などは必要に応じて `drop policy if exists` を使う
+
+6. 型を生成する。
+   ```powershell
+   cmd /c npm --workspace @coden/web run types:supabase
+   ```
+
+7. 生成された `apps/web/src/shared/types/database.types.ts` を確認する。
+
+8. サービス層やテストを更新する。
+
+9. 共通チェックを通す。
+   ```powershell
+   cmd /c npm run typecheck
+   cmd /c npm run lint
+   cmd /c npm run test
+   cmd /c npm run build
+   ```
+
+---
+
+## 5. 本番適用手順
+
+本番DBへのSQL適用は、ユーザーまたは管理者がSupabase SQL Editorで手動実行する。
+
+手順:
+
+1. PR上でSQLファイルの内容を確認する
+2. 適用対象が本番プロジェクトであることを確認する
+3. SQL Editorに対象SQLを貼り付ける
+4. 番号順に実行する
+5. エラーがないことを確認する
+6. テーブル / policy / RPC が作成されたことを確認する
+7. 必要なら `types:supabase` を実行し、型差分をPRに含める
+
+注意:
+
+- 本番適用後にSQLファイルを変更しない。修正が必要な場合は次番号のSQLを追加する
+- 手動適用済みかどうかはPR本文や作業メモで明記する
+- secret、service role key、ユーザーパスワードはPR本文・docs・SQLコメントに書かない
+
+---
+
+## 6. ローカル適用手順
+
+ローカルSupabaseを使う場合は、SQLを番号順に適用する。
+
+プロジェクトでローカルSupabase CLI運用を行う場合の基本方針:
+
+- 本番と同じSQLファイルを使う
+- local専用seedは `apps/web/supabase/sql/local/` に置く
+- 実パスワード入りの `.sql` はGit管理しない
+- 共有したい形だけ `.example` にする
+
+ローカルseed例:
+
+```text
+apps/web/supabase/sql/local/seed_admin_user.sql.example
+```
+
+---
+
+## 7. RLS確認観点
+
+RLSは「自分」「他人」「admin」の3視点で確認する。
+
+| 視点 | 確認すること |
+|---|---|
+| 自分 | 自分の行をSELECT/INSERT/UPDATE/DELETEできるか |
+| 他人 | 他人の行を読めない、変更できないか |
+| admin | 管理画面や集計に必要な横断SELECT/RPCが通るか |
+| anonymous | 認証なしで不要なデータが読めないか |
+
+review_items のように管理画面の集計に使うテーブルでは、own行policyだけでは足りない場合がある。admin横断集計が必要なときは、以下のようなadmin SELECT policyを追加する。
+
+```sql
+create policy admin_select_example on public.example_table
+  for select using (public.is_admin());
+```
+
+---
+
+## 8. 型生成とフロントエンド更新
+
+型生成コマンド:
+
+```powershell
+cmd /c npm --workspace @coden/web run types:supabase
+```
+
+生成先:
+
+```text
+apps/web/src/shared/types/database.types.ts
+```
+
+型生成後の確認:
+
+- 新しいテーブルが `Database['public']['Tables']` にある
+- `Tables<'table_name'>` / `TablesInsert<'table_name'>` / `TablesUpdate<'table_name'>` が使える
+- RPCを追加した場合、`Database['public']['Functions']` に反映されている
+- 既存サービスの型エラーが出ていない
+
+---
+
+## 9. PR本文に書くこと
+
+Supabase関連PRでは、最低限以下を書く。
+
+```md
+## Summary
+- 追加したSQL / テーブル / RPC / policy
+- フロントエンド側の利用箇所
+- 型生成の有無
+
+## Test plan
+- cmd /c npm run typecheck
+- cmd /c npm run lint
+- cmd /c npm run test
+- cmd /c npm run build
+
+## Supabase
+- SQL手動適用: 未適用 / 適用済み
+- 適用対象: local / production
+- RLS確認: 自分 / 他人 / admin
+```
+
+SQLの手動適用をユーザーが行う場合は、PR本文に「DB適用は手動」と明記する。
+
+---
+
+## 10. よくある事故と予防
+
+| 事故 | 予防 |
+|---|---|
+| SQL番号が重複する | `rg --files apps/web/supabase/sql` で最新番号を確認する |
+| own行policyだけでadmin集計が欠ける | admin画面で横断SELECTが必要か確認する |
+| 本番適用後に同じSQLを修正する | 次番号の修正SQLを追加する |
+| 型生成を忘れる | SQL追加PRのTest planに `types:supabase` の有無を書く |
+| secretをdocsに書く | `.env.local` や local seed の実ファイルにだけ置き、Git管理しない |
+| RLSが広すぎる | anonymous / 他人視点のSELECTを必ず確認する |
+
+---
+
+## 11. 変更時の更新ルール
+
+以下の場合は、このドキュメントを更新する。
+
+- 新しいSQL番号が追加された
+- SQL適用方法が変わった
+- 型生成コマンドが変わった
+- RLS確認観点が増えた
+- admin集計に必要なpolicyが追加された
+
+SQL追加PRでは、必要に応じて「`docs/supabase-ops.md` の更新が必要か」を確認する。


### PR DESCRIPTION
## Summary
- コンテンツ追加・レビュー基準を docs/content-guidelines.md として追加
- Supabase SQL適用・型生成・RLS確認手順を docs/supabase-ops.md として追加
- 2026-06-05時点のSQL連番を 021 まで整理し、次回SQLは 022 からと明記

## Test plan
- git diff --check
- pre-commit: cmd /c npm run typecheck
- pre-commit: cmd /c npm run lint
- pre-push: cmd /c npm run build
- pre-push: cmd /c npm run test

※ build は既存の chunk size warning のみ