### PR TITLE
feat: learning_eventsの記録基盤を追加

### DIFF
--- a/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
@@ -6,6 +6,7 @@ import type { ChallengeTask } from '../../../content/fundamentals/steps'
 
 const recordWrongAnswer = vi.fn()
 const resolveReviewItem = vi.fn()
+const trackLearningEvent = vi.fn()
 
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
@@ -16,6 +17,10 @@ vi.mock('@/contexts/AuthContext', () => ({
 vi.mock('@/services/reviewService', () => ({
   recordWrongAnswer: (...args: unknown[]) => recordWrongAnswer(...args),
   resolveReviewItem: (...args: unknown[]) => resolveReviewItem(...args),
+}))
+
+vi.mock('@/services/eventService', () => ({
+  trackLearningEvent: (...args: unknown[]) => trackLearningEvent(...args),
 }))
 
 vi.mock('@/components/CodeEditor', () => ({
@@ -77,6 +82,7 @@ describe('ChallengeMode', () => {
   beforeEach(() => {
     recordWrongAnswer.mockReset()
     resolveReviewItem.mockReset()
+    trackLearningEvent.mockReset()
     recordWrongAnswer.mockResolvedValue(undefined)
     resolveReviewItem.mockResolvedValue(undefined)
   })
@@ -95,6 +101,18 @@ describe('ChallengeMode', () => {
     await user.click(screen.getByRole('button', { name: '判定する' }))
 
     expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(trackLearningEvent).toHaveBeenCalledWith({
+      userId: '00000000-0000-0000-0000-000000000001',
+      eventType: 'challenge_submitted',
+      stepId: 'step-a',
+      mode: 'challenge',
+      courseId: null,
+      payload: {
+        isCorrect: true,
+        itemCount: 1,
+        questionIds: ['pattern-1'],
+      },
+    })
     expect(onSubmitResult).toHaveBeenCalledWith({
       code: 'const [count, setCount] = useState(0); <button onClick={() => setCount(count + 1)} />',
       isPassed: true,
@@ -132,6 +150,18 @@ describe('ChallengeMode', () => {
 
     // Assert
     expect(screen.getByRole('status').textContent).toContain('要件を満たしていません。')
+    expect(trackLearningEvent).toHaveBeenCalledWith({
+      userId: '00000000-0000-0000-0000-000000000001',
+      eventType: 'challenge_submitted',
+      stepId: 'step-a',
+      mode: 'challenge',
+      courseId: null,
+      payload: {
+        isCorrect: false,
+        itemCount: 1,
+        questionIds: ['pattern-1'],
+      },
+    })
     expect(recordWrongAnswer).toHaveBeenCalledWith({
       userId: '00000000-0000-0000-0000-000000000001',
       stepId: 'step-a',

--- a/apps/web/src/features/learning/__tests__/PracticeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/PracticeMode.test.tsx
@@ -6,6 +6,7 @@ import type { PracticeQuestion } from '../../../content/fundamentals/steps'
 
 const recordWrongAnswer = vi.fn()
 const resolveReviewItem = vi.fn()
+const trackLearningEvent = vi.fn()
 
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
@@ -16,6 +17,10 @@ vi.mock('@/contexts/AuthContext', () => ({
 vi.mock('../../../services/reviewService', () => ({
   recordWrongAnswer: (...args: unknown[]) => recordWrongAnswer(...args),
   resolveReviewItem: (...args: unknown[]) => resolveReviewItem(...args),
+}))
+
+vi.mock('../../../services/eventService', () => ({
+  trackLearningEvent: (...args: unknown[]) => trackLearningEvent(...args),
 }))
 
 const firstQuestions: PracticeQuestion[] = [
@@ -57,6 +62,7 @@ describe('PracticeMode', () => {
   beforeEach(() => {
     recordWrongAnswer.mockReset()
     resolveReviewItem.mockReset()
+    trackLearningEvent.mockReset()
     recordWrongAnswer.mockResolvedValue(undefined)
     resolveReviewItem.mockResolvedValue(undefined)
   })
@@ -81,6 +87,18 @@ describe('PracticeMode', () => {
     await user.click(screen.getByRole('button', { name: '判定する' }))
 
     expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(trackLearningEvent).toHaveBeenCalledWith({
+      userId: '00000000-0000-0000-0000-000000000001',
+      eventType: 'practice_answer_submitted',
+      stepId: 'step-choice',
+      mode: 'practice',
+      courseId: null,
+      payload: {
+        isCorrect: true,
+        itemCount: 1,
+        questionIds: ['q-choice'],
+      },
+    })
     expect(screen.getByRole('status').textContent).toContain('Practiceを完了しました')
   })
 
@@ -93,6 +111,18 @@ describe('PracticeMode', () => {
     await user.click(screen.getByRole('button', { name: '判定する' }))
 
     expect(onComplete).not.toHaveBeenCalled()
+    expect(trackLearningEvent).toHaveBeenCalledWith({
+      userId: '00000000-0000-0000-0000-000000000001',
+      eventType: 'practice_answer_submitted',
+      stepId: 'step-choice',
+      mode: 'practice',
+      courseId: null,
+      payload: {
+        isCorrect: false,
+        itemCount: 1,
+        questionIds: ['q-choice'],
+      },
+    })
     expect(screen.getByRole('status').textContent).toContain('まだ不正解の問題があります')
   })
 

--- a/apps/web/src/features/learning/__tests__/TestMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/TestMode.test.tsx
@@ -8,6 +8,7 @@ import { previewByStepId } from '../testModePreview'
 
 const recordWrongAnswer = vi.fn()
 const resolveReviewItem = vi.fn()
+const trackLearningEvent = vi.fn()
 
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
@@ -35,6 +36,10 @@ vi.mock('../../../services/reviewService', () => ({
   resolveReviewItem: (...args: unknown[]) => resolveReviewItem(...args),
 }))
 
+vi.mock('../../../services/eventService', () => ({
+  trackLearningEvent: (...args: unknown[]) => trackLearningEvent(...args),
+}))
+
 const firstTask: TestTask = {
   instruction: '最初の問題',
   starterCode: 'const [count, setCount] = useState(0)\n____',
@@ -57,6 +62,7 @@ describe('TestMode', () => {
   beforeEach(() => {
     recordWrongAnswer.mockReset()
     resolveReviewItem.mockReset()
+    trackLearningEvent.mockReset()
     recordWrongAnswer.mockResolvedValue(undefined)
     resolveReviewItem.mockResolvedValue(undefined)
   })
@@ -71,6 +77,18 @@ describe('TestMode', () => {
     await user.click(screen.getByRole('button', { name: '判定する' }))
 
     expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(trackLearningEvent).toHaveBeenCalledWith({
+      userId: '00000000-0000-0000-0000-000000000001',
+      eventType: 'test_submitted',
+      stepId: 'step-a',
+      mode: 'test',
+      courseId: null,
+      payload: {
+        isCorrect: true,
+        itemCount: 1,
+        questionIds: ['test'],
+      },
+    })
     expect(resolveReviewItem).toHaveBeenCalledWith({
       userId: '00000000-0000-0000-0000-000000000001',
       stepId: 'step-a',

--- a/apps/web/src/features/learning/hooks/__tests__/useLearningStep.test.ts
+++ b/apps/web/src/features/learning/hooks/__tests__/useLearningStep.test.ts
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
-import { renderHook } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { useLearningStep } from '../useLearningStep'
 
 // コンテキストフックをモック
@@ -22,6 +22,10 @@ vi.mock('@/services/progressService', () => ({
   upsertProgress: vi.fn(),
 }))
 
+vi.mock('@/services/eventService', () => ({
+  trackLearningEvent: vi.fn(),
+}))
+
 vi.mock('@/services/statsService', () => ({
   recordStudyActivity: vi.fn(),
 }))
@@ -33,12 +37,15 @@ vi.mock('@/services/pointService', () => ({
 import { useAuth } from '@/contexts/AuthContext'
 import { useLearningContext } from '@/contexts/LearningContext'
 import { useAchievementContext } from '@/contexts/AchievementContext'
-import { getStepProgress } from '@/services/progressService'
+import { getStepProgress, upsertProgress } from '@/services/progressService'
+import { trackLearningEvent } from '@/services/eventService'
 
 const mockUseAuth = vi.mocked(useAuth)
 const mockUseLearningContext = vi.mocked(useLearningContext)
 const mockUseAchievementContext = vi.mocked(useAchievementContext)
 const mockGetStepProgress = vi.mocked(getStepProgress)
+const mockUpsertProgress = vi.mocked(upsertProgress)
+const mockTrackLearningEvent = vi.mocked(trackLearningEvent)
 
 const mockUser = { id: 'test-user', email: 'test@example.com', user_metadata: {} }
 
@@ -67,6 +74,7 @@ beforeEach(() => {
   } as unknown as ReturnType<typeof useAchievementContext>)
 
   mockGetStepProgress.mockResolvedValue(null)
+  mockUpsertProgress.mockResolvedValue(undefined)
 })
 
 describe('useLearningStep', () => {
@@ -99,5 +107,40 @@ describe('useLearningStep', () => {
     const { result } = renderHook(() => useLearningStep('api-error-loading'))
 
     expect(result.current.isUnavailableStep).toBe(false)
+  })
+
+  it('handleModeComplete は進捗保存後に mode_completed イベントを記録する', async () => {
+    const { result } = renderHook(() => useLearningStep('usestate-basic'))
+
+    await waitFor(() => {
+      expect(mockGetStepProgress).toHaveBeenCalledWith('test-user', 'usestate-basic')
+    })
+
+    mockGetStepProgress.mockResolvedValueOnce({
+      user_id: 'test-user',
+      step_id: 'usestate-basic',
+      read_done: true,
+      practice_done: false,
+      test_done: false,
+      challenge_done: false,
+      updated_at: '2026-06-05T00:00:00.000Z',
+      completed_at: null,
+    })
+
+    await act(async () => {
+      await result.current.handleModeComplete('read')
+    })
+
+    expect(mockUpsertProgress).toHaveBeenCalledWith('test-user', 'usestate-basic', { read_done: true })
+    expect(mockTrackLearningEvent).toHaveBeenCalledWith({
+      userId: 'test-user',
+      eventType: 'mode_completed',
+      stepId: 'usestate-basic',
+      mode: 'read',
+      courseId: 'react-fundamentals',
+      payload: {
+        stepCompleted: false,
+      },
+    })
   })
 })

--- a/apps/web/src/features/learning/hooks/useJudgmentAction.ts
+++ b/apps/web/src/features/learning/hooks/useJudgmentAction.ts
@@ -1,5 +1,7 @@
 import { useCallback, useState } from 'react'
+import { findCourseByStepId } from '@/content/courseData'
 import { useAuth } from '@/contexts/AuthContext'
+import { trackLearningEvent, type LearningEventType } from '@/services/eventService'
 import { recordWrongAnswer, resolveReviewItem, type ReviewMode } from '@/services/reviewService'
 import { useStepReset } from './useStepReset'
 
@@ -8,6 +10,12 @@ export type ReviewPayload = {
   expected?: string | null
   userInput?: string | null
 }
+
+const SUBMITTED_EVENT_BY_MODE = {
+  practice: 'practice_answer_submitted',
+  test: 'test_submitted',
+  challenge: 'challenge_submitted',
+} as const satisfies Partial<Record<ReviewMode, LearningEventType>>
 
 /** 判定結果に応じてレビューリスト操作と onComplete 呼び出しを行うフック */
 export function useJudgmentAction(stepId: string, mode: ReviewMode, onComplete: () => void) {
@@ -22,6 +30,22 @@ export function useJudgmentAction(stepId: string, mode: ReviewMode, onComplete: 
       const items = Array.isArray(payloads) ? payloads : [payloads]
 
       if (userId) {
+        const submittedEventType = SUBMITTED_EVENT_BY_MODE[mode as keyof typeof SUBMITTED_EVENT_BY_MODE]
+        if (submittedEventType) {
+          trackLearningEvent({
+            userId,
+            eventType: submittedEventType,
+            stepId,
+            mode: mode as keyof typeof SUBMITTED_EVENT_BY_MODE,
+            courseId: findCourseByStepId(stepId)?.id ?? null,
+            payload: {
+              isCorrect,
+              itemCount: items.length,
+              questionIds: items.map((item) => item.questionId ?? null),
+            },
+          })
+        }
+
         try {
           if (isCorrect) {
             await Promise.all(

--- a/apps/web/src/features/learning/hooks/useStepProgress.ts
+++ b/apps/web/src/features/learning/hooks/useStepProgress.ts
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { findCourseByStepId } from '@/content/courseData'
 import type { LearningMode, LearningStepContent } from '@/content/fundamentals/steps'
 import { useAuth } from '@/contexts/AuthContext'
 import { useLearningContext } from '@/contexts/LearningContext'
 import { useAchievementContext } from '@/contexts/AchievementContext'
+import { trackLearningEvent } from '@/services/eventService'
 import { awardPoints } from '@/services/pointService'
 import { POINTS_PER_MODE_COMPLETE } from '@/shared/constants'
 import { getStepProgress, updateModeCompletion, upsertProgress } from '@/services/progressService'
@@ -104,6 +106,17 @@ export function useStepProgress(stepId: string, step: LearningStepContent | unde
           latestProgress?.practice_done &&
           latestProgress?.test_done &&
           latestProgress?.challenge_done
+        trackLearningEvent({
+          userId: user.id,
+          eventType: 'mode_completed',
+          stepId: step.id,
+          mode,
+          courseId: findCourseByStepId(step.id)?.id ?? null,
+          payload: {
+            stepCompleted: Boolean(isNowStepCompleted && !wasStepCompleted),
+          },
+        })
+
         if (isNowStepCompleted && !wasStepCompleted) {
           await recordStudyActivity()
         }

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -22,6 +22,7 @@ import { useLearningStep } from '../features/learning/hooks/useLearningStep'
 import { useRecentChallengeSubmissions } from '../features/learning/hooks/useRecentChallengeSubmissions'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useSignOut } from '../hooks/useSignOut'
+import { trackLearningEvent } from '../services/eventService'
 import { PULSE_ANIMATION_MS } from '../shared/constants'
 import { getDisplayName } from '../shared/utils/getDisplayName'
 
@@ -96,6 +97,8 @@ export function StepPage() {
   const challengeCompleteRef = useRef<HTMLDivElement | null>(null)
   const previousModeStatusRef = useRef<Record<LearningMode, boolean> | null>(null)
   const pulseTimeoutsRef = useRef<number[]>([])
+  const trackedStepStartedRef = useRef<string | null>(null)
+  const trackedModeStartedRef = useRef<Set<string>>(new Set())
   const saveChallengeSubmission = useChallengeSubmission(stepId)
   const recentChallengeSubmissions = useRecentChallengeSubmissions(stepId)
   const handleChallengeSubmitResult = useCallback(
@@ -198,6 +201,38 @@ export function StepPage() {
   const isCourseLocked = !isLoadingStats && stepCourse
     ? getCourseLockStatus(stepCourse, completedStepIds).locked
     : false
+
+  useEffect(() => {
+    if (!user?.id || !step || isUnavailableStep || isCourseLocked) return
+
+    const courseId = stepCourse?.id ?? null
+    const stepKey = `${user.id}:${step.id}`
+
+    if (trackedStepStartedRef.current !== stepKey) {
+      trackLearningEvent({
+        userId: user.id,
+        eventType: 'step_started',
+        stepId: step.id,
+        courseId,
+        payload: {
+          order: step.order,
+        },
+      })
+      trackedStepStartedRef.current = stepKey
+    }
+
+    const modeKey = `${stepKey}:${activeMode}`
+    if (!trackedModeStartedRef.current.has(modeKey)) {
+      trackLearningEvent({
+        userId: user.id,
+        eventType: 'mode_started',
+        stepId: step.id,
+        mode: activeMode,
+        courseId,
+      })
+      trackedModeStartedRef.current.add(modeKey)
+    }
+  }, [activeMode, isCourseLocked, isUnavailableStep, step, stepCourse?.id, user?.id])
 
   if (isUnavailableStep || isCourseLocked) {
     return <Navigate to="/" replace />

--- a/apps/web/src/pages/__tests__/StepPage.test.tsx
+++ b/apps/web/src/pages/__tests__/StepPage.test.tsx
@@ -8,6 +8,7 @@ const useChallengeSubmissionMock = vi.fn()
 const useRecentChallengeSubmissionsMock = vi.fn()
 const useLearningStepMock = vi.fn()
 const readModeMock = vi.fn()
+const trackLearningEvent = vi.fn()
 
 vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => ({
@@ -68,6 +69,10 @@ vi.mock('@/features/learning/hooks/useLearningStep', () => ({
   useLearningStep: (...args: unknown[]) => useLearningStepMock(...args),
 }))
 
+vi.mock('@/services/eventService', () => ({
+  trackLearningEvent: (...args: unknown[]) => trackLearningEvent(...args),
+}))
+
 function mockLearningStep(
   modeStatus = {
     read: false,
@@ -120,6 +125,7 @@ describe('StepPage', () => {
   beforeEach(() => {
     vi.restoreAllMocks()
     readModeMock.mockClear()
+    trackLearningEvent.mockClear()
   })
 
   afterEach(() => {
@@ -151,12 +157,35 @@ describe('StepPage', () => {
     expect(screen.getByRole('navigation', { name: 'パンくずリスト' }).textContent).toContain('カリキュラム')
     expect(screen.getByText('Step 1 / 40')).toBeTruthy()
     expect(screen.getAllByText('React基礎').length).toBeGreaterThan(0)
+    expect(trackLearningEvent).toHaveBeenCalledWith({
+      userId: 'user-1',
+      eventType: 'step_started',
+      stepId: 'usestate-basic',
+      courseId: 'react-fundamentals',
+      payload: {
+        order: 1,
+      },
+    })
+    expect(trackLearningEvent).toHaveBeenCalledWith({
+      userId: 'user-1',
+      eventType: 'mode_started',
+      stepId: 'usestate-basic',
+      mode: 'read',
+      courseId: 'react-fundamentals',
+    })
 
     await user.click(screen.getByRole('tab', { name: 'Practice' }))
 
     expect(screen.getByRole('tab', { name: 'Practice' }).getAttribute('aria-current')).toBe('step')
     expect(screen.getByRole('tab', { name: 'Read' }).getAttribute('aria-current')).toBeNull()
     expect(screen.getByRole('tab', { name: 'Practice' }).className).toContain('min-h-11')
+    expect(trackLearningEvent).toHaveBeenCalledWith({
+      userId: 'user-1',
+      eventType: 'mode_started',
+      stepId: 'usestate-basic',
+      mode: 'practice',
+      courseId: 'react-fundamentals',
+    })
   })
 
   it('ReadMode に Step メタ情報を渡す', () => {

--- a/apps/web/src/services/__tests__/eventService.test.ts
+++ b/apps/web/src/services/__tests__/eventService.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { supabase } from '../../lib/supabaseClient'
+import { insertLearningEvent, trackLearningEvent } from '../eventService'
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}))
+
+const mockFrom = vi.mocked(supabase.from)
+
+describe('eventService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('learning_events に学習イベントを保存する', async () => {
+    const insert = vi.fn().mockResolvedValue({ error: null })
+    mockFrom.mockReturnValueOnce({ insert } as unknown as ReturnType<typeof supabase.from>)
+
+    await insertLearningEvent({
+      userId: '00000000-0000-0000-0000-000000000001',
+      eventType: 'mode_started',
+      stepId: 'usestate-basic',
+      mode: 'read',
+      courseId: 'react-fundamentals',
+      payload: { order: 1 },
+    })
+
+    expect(mockFrom).toHaveBeenCalledWith('learning_events')
+    expect(insert).toHaveBeenCalledWith({
+      user_id: '00000000-0000-0000-0000-000000000001',
+      event_type: 'mode_started',
+      step_id: 'usestate-basic',
+      mode: 'read',
+      course_id: 'react-fundamentals',
+      payload: { order: 1 },
+    })
+  })
+
+  it('Supabase エラーをアプリ共通エラーに変換する', async () => {
+    const insert = vi.fn().mockResolvedValue({
+      error: { code: '42501', message: 'new row violates row-level security policy' },
+    })
+    mockFrom.mockReturnValueOnce({ insert } as unknown as ReturnType<typeof supabase.from>)
+
+    await expect(
+      insertLearningEvent({
+        userId: '00000000-0000-0000-0000-000000000001',
+        eventType: 'step_started',
+      }),
+    ).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: '学習イベントの記録に失敗しました',
+    })
+  })
+
+  it('trackLearningEvent は失敗しても呼び出し元をブロックしない', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const insert = vi.fn().mockResolvedValue({
+      error: { code: '42501', message: 'new row violates row-level security policy' },
+    })
+    mockFrom.mockReturnValueOnce({ insert } as unknown as ReturnType<typeof supabase.from>)
+
+    expect(() => {
+      trackLearningEvent({
+        userId: '00000000-0000-0000-0000-000000000001',
+        eventType: 'step_started',
+      })
+    }).not.toThrow()
+
+    await vi.waitFor(() => {
+      expect(consoleError).toHaveBeenCalledWith('Learning event tracking failed:', expect.any(Error))
+    })
+
+    consoleError.mockRestore()
+  })
+})

--- a/apps/web/src/services/eventService.ts
+++ b/apps/web/src/services/eventService.ts
@@ -1,0 +1,52 @@
+import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+import type { Json, TablesInsert } from '../shared/types/database.types'
+
+export type LearningEventType =
+  | 'step_started'
+  | 'mode_started'
+  | 'mode_completed'
+  | 'practice_answer_submitted'
+  | 'test_submitted'
+  | 'challenge_submitted'
+  | 'daily_completed'
+  | 'review_item_created'
+  | 'review_item_resolved'
+  | 'mini_project_started'
+  | 'mini_project_completed'
+  | 'feedback_created'
+  | 'base_nook_opened'
+
+export type LearningEventMode = 'read' | 'practice' | 'test' | 'challenge' | 'daily' | 'base_nook' | 'mini_project'
+
+export interface TrackLearningEventInput {
+  userId: string
+  eventType: LearningEventType
+  stepId?: string | null
+  mode?: LearningEventMode | null
+  courseId?: string | null
+  payload?: Json | null
+}
+
+export async function insertLearningEvent(input: TrackLearningEventInput): Promise<void> {
+  const row: TablesInsert<'learning_events'> = {
+    user_id: input.userId,
+    event_type: input.eventType,
+    step_id: input.stepId ?? null,
+    mode: input.mode ?? null,
+    course_id: input.courseId ?? null,
+    payload: input.payload ?? null,
+  }
+
+  const { error } = await supabase.from('learning_events').insert(row)
+
+  if (error) {
+    throw fromSupabaseError(error, '学習イベントの記録に失敗しました')
+  }
+}
+
+export function trackLearningEvent(input: TrackLearningEventInput): void {
+  void insertLearningEvent(input).catch((error) => {
+    console.error('Learning event tracking failed:', error)
+  })
+}

--- a/apps/web/src/shared/types/database.types.ts
+++ b/apps/web/src/shared/types/database.types.ts
@@ -92,6 +92,39 @@ export type Database = {
         }
         Relationships: []
       }
+      learning_events: {
+        Row: {
+          course_id: string | null
+          created_at: string
+          event_type: string
+          id: number
+          mode: string | null
+          payload: Json | null
+          step_id: string | null
+          user_id: string
+        }
+        Insert: {
+          course_id?: string | null
+          created_at?: string
+          event_type: string
+          id?: number
+          mode?: string | null
+          payload?: Json | null
+          step_id?: string | null
+          user_id: string
+        }
+        Update: {
+          course_id?: string | null
+          created_at?: string
+          event_type?: string
+          id?: number
+          mode?: string | null
+          payload?: Json | null
+          step_id?: string | null
+          user_id?: string
+        }
+        Relationships: []
+      }
       learning_stats: {
         Row: {
           current_streak: number

--- a/apps/web/supabase/sql/022_learning_events.sql
+++ b/apps/web/supabase/sql/022_learning_events.sql
@@ -1,0 +1,62 @@
+-- v5roadmap05 M2: learning_events event log foundation
+-- Run this in Supabase SQL Editor (または supabase db push)
+-- 目的:
+--   学習導線の遷移率・離脱率・誤答率を admin が集計できるよう、
+--   Read / Practice / Test / Challenge の主要行動をイベントとして保存する。
+
+create table if not exists public.learning_events (
+  id bigint generated always as identity primary key,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  event_type text not null,
+  step_id text,
+  mode text,
+  course_id text,
+  payload jsonb,
+  created_at timestamptz not null default now(),
+  constraint learning_events_event_type_check check (
+    event_type in (
+      'step_started',
+      'mode_started',
+      'mode_completed',
+      'practice_answer_submitted',
+      'test_submitted',
+      'challenge_submitted',
+      'daily_completed',
+      'review_item_created',
+      'review_item_resolved',
+      'mini_project_started',
+      'mini_project_completed',
+      'feedback_created',
+      'base_nook_opened'
+    )
+  ),
+  constraint learning_events_mode_check check (
+    mode is null or mode in ('read', 'practice', 'test', 'challenge', 'daily', 'base_nook', 'mini_project')
+  )
+);
+
+alter table public.learning_events enable row level security;
+
+drop policy if exists insert_own_learning_events on public.learning_events;
+create policy insert_own_learning_events on public.learning_events
+  for insert
+  with check (auth.uid() = user_id);
+
+drop policy if exists admin_select_learning_events on public.learning_events;
+create policy admin_select_learning_events on public.learning_events
+  for select
+  using (public.is_admin());
+
+create index if not exists learning_events_event_type_created_at_idx
+  on public.learning_events (event_type, created_at desc);
+
+create index if not exists learning_events_step_id_event_type_idx
+  on public.learning_events (step_id, event_type)
+  where step_id is not null;
+
+create index if not exists learning_events_user_id_created_at_idx
+  on public.learning_events (user_id, created_at desc);
+
+create index if not exists learning_events_course_id_created_at_idx
+  on public.learning_events (course_id, created_at desc)
+  where course_id is not null;

--- a/docs/supabase-ops.md
+++ b/docs/supabase-ops.md
@@ -45,7 +45,7 @@ NNN_short_description.sql
 - RLS対象テーブルを作る場合、同じファイル内に RLS 有効化と policy を含める
 - RPCを追加する場合、権限、`security definer`、`search_path`、admin判定の有無を明記する
 
-2026-06-05 時点の最新は `021_admin_select_review_items.sql`。次の新規SQLは `022_*.sql` から始める。
+2026-06-05 時点の最新は `022_learning_events.sql`。次の新規SQLは `023_*.sql` から始める。
 
 ---
 
@@ -74,6 +74,7 @@ NNN_short_description.sql
 | 019 | `019_feedback_images.sql` | feedback画像 |
 | 020 | `020_review_items.sql` | 復習キュー |
 | 021 | `021_admin_select_review_items.sql` | review_items admin横断SELECT |
+| 022 | `022_learning_events.sql` | 学習イベントログ |
 
 READMEのSQL一覧よりこの表を優先する。READMEを更新するタイミングでは、この表と差分が出ないようにする。
 


### PR DESCRIPTION
## Summary
- learning_events テーブル/RLS/index を追加
- fire-and-forget の eventService を追加し、学習イベント記録をUI非ブロッキングに実装
- step_started / mode_started / mode_completed / practice_answer_submitted / test_submitted / challenge_submitted を主要導線へ差し込み
- database.types.ts と docs/supabase-ops.md を 022_learning_events.sql に合わせて更新
- イベント記録サービスと差し込み箇所のテストを追加

## Test plan
- cmd /c npm run typecheck
- cmd /c npm run lint
- cmd /c npm run test
- cmd /c npm run build

## Supabase
- SQL手動適用: 未適用
- 追加SQL: apps/web/supabase/sql/022_learning_events.sql
- RLS: INSERT は自分の user_id のみ、SELECT は admin のみ