### PR TITLE
feat: Step Insightsをイベントログ集計に対応

### DIFF
--- a/apps/web/src/features/admin/components/AdminLayout.tsx
+++ b/apps/web/src/features/admin/components/AdminLayout.tsx
@@ -17,6 +17,7 @@ interface AdminLink {
 const ADMIN_LINKS: readonly AdminLink[] = [
   { to: '/admin', label: 'ダッシュボード', exact: true },
   { to: '/admin/quality', label: '品質ダッシュボード' },
+  { to: '/admin/step-insights', label: 'Step Insights' },
   { to: '/admin/feedback', label: 'フィードバック' },
   { to: '/admin/users', label: 'ユーザー' },
   { to: '/admin/stats', label: '統計' },

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -62,6 +62,11 @@ const AdminQualityDashboardPage = lazy(() =>
     default: m.AdminQualityDashboardPage,
   })),
 )
+const AdminStepInsightsPage = lazy(() =>
+  import('./pages/admin/AdminStepInsightsPage').then((m) => ({
+    default: m.AdminStepInsightsPage,
+  })),
+)
 const AdminOpsPage = lazy(() =>
   import('./pages/admin/AdminOpsPage').then((m) => ({ default: m.AdminOpsPage })),
 )
@@ -275,6 +280,18 @@ const router = createBrowserRouter([
         <AdminGuard>
           <Suspense fallback={<PageLoading />}>
             <AdminQualityDashboardPage />
+          </Suspense>
+        </AdminGuard>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/admin/step-insights',
+    element: (
+      <ProtectedRoute>
+        <AdminGuard>
+          <Suspense fallback={<PageLoading />}>
+            <AdminStepInsightsPage />
           </Suspense>
         </AdminGuard>
       </ProtectedRoute>

--- a/apps/web/src/pages/admin/AdminDashboardPage.tsx
+++ b/apps/web/src/pages/admin/AdminDashboardPage.tsx
@@ -26,6 +26,13 @@ const SECTIONS: SectionCard[] = [
     accent: 'bg-teal-100 text-teal-700',
   },
   {
+    to: '/admin/step-insights',
+    title: 'Step Insights',
+    description: 'ステップ別の遷移率・離脱率・誤答率を確認する',
+    icon: BarChart3,
+    accent: 'bg-rose-100 text-rose-700',
+  },
+  {
     to: '/admin/feedback',
     title: 'フィードバック',
     description: 'ユーザーから届いた不具合報告・要望・レビューを確認する',

--- a/apps/web/src/pages/admin/AdminStepInsightsPage.tsx
+++ b/apps/web/src/pages/admin/AdminStepInsightsPage.tsx
@@ -1,0 +1,309 @@
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { AlertCircle, BarChart3, ExternalLink, Loader2, Search, TrendingDown } from 'lucide-react'
+import { AdminLayout } from '../../features/admin/components/AdminLayout'
+import { useDocumentTitle } from '../../hooks/useDocumentTitle'
+import {
+  getAdminStepInsights,
+  type AdminQualityStepInsightSignal,
+  type AdminStepInsight,
+  type AdminStepInsights,
+} from '../../services/adminQualityService'
+
+const STEP_SIGNAL_LABELS: Record<AdminQualityStepInsightSignal, string> = {
+  healthy: '順調',
+  watch: '要観察',
+  attention: '要対応',
+  insufficient: 'データ不足',
+}
+
+const STEP_SIGNAL_STYLES: Record<AdminQualityStepInsightSignal, string> = {
+  healthy: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+  watch: 'border-amber-200 bg-amber-50 text-amber-700',
+  attention: 'border-rose-200 bg-rose-50 text-rose-700',
+  insufficient: 'border-slate-200 bg-slate-50 text-slate-600',
+}
+
+function formatPercent(rate: number | null): string {
+  if (rate === null) return 'データ不足'
+  return `${(rate * 100).toFixed(1)}%`
+}
+
+function formatDateTime(value: string): string {
+  return new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  }).format(new Date(value))
+}
+
+export function AdminStepInsightsPage() {
+  useDocumentTitle('Step Insights - 管理画面')
+
+  const [insights, setInsights] = useState<AdminStepInsights | null>(null)
+  const [selectedStepId, setSelectedStepId] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let isMounted = true
+    async function load() {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const data = await getAdminStepInsights()
+        if (!isMounted) return
+        setInsights(data)
+        setSelectedStepId(data.rows.find((row) => row.signal !== 'insufficient')?.stepId ?? data.rows[0]?.stepId ?? null)
+      } catch (e) {
+        if (!isMounted) return
+        setError(e instanceof Error ? e.message : 'Step Insightsの取得に失敗しました')
+      } finally {
+        if (isMounted) setIsLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  const selectedStep = useMemo(
+    () => insights?.rows.find((row) => row.stepId === selectedStepId) ?? null,
+    [insights, selectedStepId],
+  )
+
+  return (
+    <AdminLayout>
+      <div className="mb-6 flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Step Insights</h1>
+          <p className="mt-1 text-sm text-slate-500">
+            learning_events からステップ別の遷移率・離脱率・誤答率を確認します。
+          </p>
+        </div>
+        {insights && (
+          <div className="text-xs text-slate-500">
+            生成日時 <span className="font-mono text-slate-700">{formatDateTime(insights.generatedAt)}</span>
+          </div>
+        )}
+      </div>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-24">
+          <Loader2 className="h-8 w-8 animate-spin text-slate-400" aria-label="読み込み中" />
+        </div>
+      ) : error ? (
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-2xl border border-rose-200 bg-rose-50 p-5 text-sm text-rose-700"
+        >
+          <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+          <span>{error}</span>
+        </div>
+      ) : insights ? (
+        <div className="space-y-6">
+          <section className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <OverviewTile label="イベント数" value={`${insights.totalEvents.toLocaleString()}件`} />
+            <OverviewTile label="観測Step" value={`${insights.observedSteps.toLocaleString()}件`} />
+            <OverviewTile label="要対応Step" value={`${insights.attentionSteps.toLocaleString()}件`} />
+          </section>
+
+          <Section title="ステップ別品質" icon={<BarChart3 className="h-4 w-4" aria-hidden="true" />}>
+            <StepInsightsTable rows={insights.rows} selectedStepId={selectedStepId} onSelect={setSelectedStepId} />
+          </Section>
+
+          {selectedStep && (
+            <Section title="ドリルダウン" icon={<Search className="h-4 w-4" aria-hidden="true" />}>
+              <StepDetailPanel row={selectedStep} />
+            </Section>
+          )}
+        </div>
+      ) : null}
+    </AdminLayout>
+  )
+}
+
+function Section({
+  title,
+  icon,
+  children,
+}: {
+  title: string
+  icon: ReactNode
+  children: ReactNode
+}) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+        <span className="text-slate-500">{icon}</span>
+        <h2>{title}</h2>
+      </div>
+      {children}
+    </section>
+  )
+}
+
+function OverviewTile({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+      <p className="text-xs font-semibold text-slate-500">{label}</p>
+      <p className="mt-1 font-mono text-2xl font-semibold text-slate-900">{value}</p>
+    </div>
+  )
+}
+
+function StepInsightsTable({
+  rows,
+  selectedStepId,
+  onSelect,
+}: {
+  rows: AdminStepInsight[]
+  selectedStepId: string | null
+  onSelect: (stepId: string) => void
+}) {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-2xl border border-slate-200 bg-white p-5 text-sm text-slate-500 shadow-sm">
+        Step Insights のデータがありません
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <table className="min-w-full divide-y divide-slate-100 text-sm">
+        <thead className="bg-slate-50 text-left text-xs font-semibold text-slate-500">
+          <tr>
+            <th scope="col" className="px-4 py-3">Step</th>
+            <th scope="col" className="px-4 py-3">状態</th>
+            <th scope="col" className="px-4 py-3">開始</th>
+            <th scope="col" className="px-4 py-3">遷移率</th>
+            <th scope="col" className="px-4 py-3">離脱率</th>
+            <th scope="col" className="px-4 py-3">Practice / Test</th>
+            <th scope="col" className="px-4 py-3">Challenge</th>
+            <th scope="col" className="px-4 py-3">Feedback</th>
+            <th scope="col" className="px-4 py-3">詳細</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {rows.map((row) => (
+            <tr key={row.stepId} className={selectedStepId === row.stepId ? 'bg-teal-50/40' : undefined}>
+              <td className="px-4 py-3">
+                <p className="font-semibold text-slate-800">
+                  Step {row.order}「{row.title}」
+                </p>
+                <p className="mt-0.5 font-mono text-xs text-slate-400">{row.stepId}</p>
+                {row.courseTitle ? <p className="mt-1 text-xs text-slate-500">{row.courseTitle}</p> : null}
+              </td>
+              <td className="px-4 py-3">
+                <span
+                  className={`inline-flex rounded-full border px-2 py-0.5 text-xs font-semibold ${STEP_SIGNAL_STYLES[row.signal]}`}
+                >
+                  {STEP_SIGNAL_LABELS[row.signal]}
+                </span>
+              </td>
+              <td className="px-4 py-3 font-mono text-slate-700">{row.startedUsers}人</td>
+              <td className="px-4 py-3 font-mono text-xs leading-5 text-slate-700">
+                <p>R→P {formatPercent(row.readToPracticeRate)}</p>
+                <p>P→T {formatPercent(row.practiceToTestRate)}</p>
+                <p>T→C {formatPercent(row.testToChallengeRate)}</p>
+              </td>
+              <td className="px-4 py-3 font-mono text-slate-700">{formatPercent(row.dropoffRate)}</td>
+              <td className="px-4 py-3 font-mono text-xs leading-5 text-slate-700">
+                <p>Practice誤答 {formatPercent(row.practiceIncorrectRate)}</p>
+                <p>Test失敗 {formatPercent(row.testFailureRate)}</p>
+              </td>
+              <td className="px-4 py-3 font-mono text-xs leading-5 text-slate-700">
+                <p>{row.challengeSubmissions}件</p>
+                <p>合格 {formatPercent(row.challengePassRate)}</p>
+              </td>
+              <td className="px-4 py-3 font-mono text-xs leading-5 text-slate-700">
+                <p>{row.relatedFeedbackCount}件</p>
+                <p>新規 {row.newFeedbackCount}件</p>
+              </td>
+              <td className="px-4 py-3">
+                <button
+                  type="button"
+                  onClick={() => onSelect(row.stepId)}
+                  className="rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 transition hover:border-primary-mint hover:text-slate-900"
+                  aria-pressed={selectedStepId === row.stepId}
+                >
+                  詳細
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function StepDetailPanel({ row }: { row: AdminStepInsight }) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-lg font-bold text-slate-900">
+              Step {row.order}「{row.title}」
+            </h3>
+            <span
+              className={`inline-flex rounded-full border px-2 py-0.5 text-xs font-semibold ${STEP_SIGNAL_STYLES[row.signal]}`}
+            >
+              {STEP_SIGNAL_LABELS[row.signal]}
+            </span>
+          </div>
+          <p className="mt-1 font-mono text-xs text-slate-400">{row.stepId}</p>
+          {row.courseTitle ? <p className="mt-1 text-sm text-slate-500">{row.courseTitle}</p> : null}
+        </div>
+        <Link
+          to={`/step/${row.stepId}`}
+          className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-600 transition hover:border-primary-mint hover:text-slate-900"
+        >
+          Stepを開く
+          <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+        </Link>
+      </div>
+
+      <div className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+        <DetailMetric label="Read開始 / 完了" value={`${row.readStartedUsers} / ${row.readCompletedUsers}人`} />
+        <DetailMetric
+          label="Practice開始 / 完了"
+          value={`${row.practiceStartedUsers} / ${row.practiceCompletedUsers}人`}
+        />
+        <DetailMetric label="Test開始 / 完了" value={`${row.testStartedUsers} / ${row.testCompletedUsers}人`} />
+        <DetailMetric
+          label="Challenge開始 / 完了"
+          value={`${row.challengeStartedUsers} / ${row.challengeCompletedUsers}人`}
+        />
+      </div>
+
+      <div className="mt-5 grid grid-cols-1 gap-3 lg:grid-cols-3">
+        <DetailMetric label="完了率" value={formatPercent(row.completionRate)} />
+        <DetailMetric label="イベント数" value={`${row.eventCount.toLocaleString()}件`} />
+        <DetailMetric label="関連フィードバック" value={`${row.relatedFeedbackCount.toLocaleString()}件`} />
+      </div>
+
+      <div className="mt-5 flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-800">
+        <TrendingDown className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+        <div>
+          <p className="font-semibold">主なボトルネック</p>
+          <p className="mt-1">{row.bottleneck}</p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function DetailMetric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-slate-100 bg-slate-50 p-3">
+      <p className="text-xs font-semibold text-slate-500">{label}</p>
+      <p className="mt-1 font-mono text-lg font-semibold text-slate-900">{value}</p>
+    </div>
+  )
+}

--- a/apps/web/src/pages/admin/__tests__/AdminStepInsightsPage.test.tsx
+++ b/apps/web/src/pages/admin/__tests__/AdminStepInsightsPage.test.tsx
@@ -1,0 +1,153 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import type { AdminStepInsights } from '../../../services/adminQualityService'
+
+const getAdminStepInsightsMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../../../services/adminQualityService', async () => {
+  const actual = await vi.importActual<typeof import('../../../services/adminQualityService')>(
+    '../../../services/adminQualityService',
+  )
+  return {
+    ...actual,
+    getAdminStepInsights: (...args: unknown[]) => getAdminStepInsightsMock(...args),
+  }
+})
+
+vi.mock('../../../features/admin/components/AdminLayout', () => ({
+  AdminLayout: ({ children }: { children: ReactNode }) => <div data-testid="admin-layout">{children}</div>,
+}))
+
+vi.mock('../../../hooks/useDocumentTitle', () => ({
+  useDocumentTitle: () => undefined,
+}))
+
+import { AdminStepInsightsPage } from '../AdminStepInsightsPage'
+
+const SAMPLE_INSIGHTS: AdminStepInsights = {
+  generatedAt: '2026-06-05T12:00:00.000Z',
+  totalEvents: 14,
+  observedSteps: 2,
+  attentionSteps: 1,
+  rows: [
+    {
+      stepId: 'usestate-basic',
+      courseId: 'react-basics',
+      courseTitle: 'React 基礎',
+      order: 1,
+      title: 'useState基礎',
+      eventCount: 14,
+      startedUsers: 2,
+      readStartedUsers: 2,
+      practiceStartedUsers: 2,
+      testStartedUsers: 1,
+      challengeStartedUsers: 1,
+      readCompletedUsers: 2,
+      practiceCompletedUsers: 1,
+      testCompletedUsers: 1,
+      challengeCompletedUsers: 1,
+      completionRate: 0.5,
+      readToPracticeRate: 1,
+      practiceToTestRate: 0.5,
+      testToChallengeRate: 1,
+      dropoffRate: 0.5,
+      practiceSubmissions: 2,
+      practiceIncorrectRate: 0.5,
+      testSubmissions: 2,
+      testFailureRate: 0.5,
+      challengeSubmissions: 1,
+      challengePassRate: 1,
+      relatedFeedbackCount: 1,
+      newFeedbackCount: 1,
+      bottleneck: '離脱率 50.0%',
+      signal: 'watch',
+    },
+    {
+      stepId: 'events',
+      courseId: 'react-basics',
+      courseTitle: 'React 基礎',
+      order: 2,
+      title: 'イベント処理',
+      eventCount: 9,
+      startedUsers: 3,
+      readStartedUsers: 3,
+      practiceStartedUsers: 2,
+      testStartedUsers: 1,
+      challengeStartedUsers: 0,
+      readCompletedUsers: 2,
+      practiceCompletedUsers: 1,
+      testCompletedUsers: 0,
+      challengeCompletedUsers: 0,
+      completionRate: 0,
+      readToPracticeRate: 2 / 3,
+      practiceToTestRate: 0.5,
+      testToChallengeRate: 0,
+      dropoffRate: 1,
+      practiceSubmissions: 4,
+      practiceIncorrectRate: 0.75,
+      testSubmissions: 3,
+      testFailureRate: 1,
+      challengeSubmissions: 0,
+      challengePassRate: null,
+      relatedFeedbackCount: 3,
+      newFeedbackCount: 2,
+      bottleneck: '離脱率 100.0%',
+      signal: 'attention',
+    },
+  ],
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AdminStepInsightsPage />
+    </MemoryRouter>,
+  )
+}
+
+describe('AdminStepInsightsPage', () => {
+  beforeEach(() => {
+    getAdminStepInsightsMock.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('Step Insightsの集計値とドリルダウンを表示する', async () => {
+    getAdminStepInsightsMock.mockResolvedValue(SAMPLE_INSIGHTS)
+    renderPage()
+
+    expect(await screen.findByRole('heading', { name: 'Step Insights' })).toBeTruthy()
+    expect(screen.getAllByText('イベント数').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('14件').length).toBeGreaterThan(0)
+    expect(screen.getByText('要対応Step')).toBeTruthy()
+    expect(screen.getAllByText('Step 1「useState基礎」').length).toBeGreaterThan(0)
+    expect(screen.getByText('Step 2「イベント処理」')).toBeTruthy()
+    expect(screen.getByText('要対応')).toBeTruthy()
+    expect(screen.getByText('Practice誤答 75.0%')).toBeTruthy()
+    expect(screen.getByText('離脱率 50.0%')).toBeTruthy()
+
+    const eventsRow = screen.getByText('Step 2「イベント処理」').closest('tr')
+    expect(eventsRow).not.toBeNull()
+    fireEvent.click(within(eventsRow as HTMLElement).getByRole('button', { name: '詳細' }))
+
+    expect(await screen.findByRole('heading', { name: 'Step 2「イベント処理」' })).toBeTruthy()
+    expect(screen.getByText('離脱率 100.0%')).toBeTruthy()
+    expect(screen.getAllByText('3件').length).toBeGreaterThan(0)
+
+    await waitFor(() => {
+      expect(getAdminStepInsightsMock).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('取得エラーを alert で表示する', async () => {
+    getAdminStepInsightsMock.mockRejectedValue(new Error('admin only'))
+    renderPage()
+
+    const alert = await screen.findByRole('alert')
+    expect(within(alert).getByText('admin only')).toBeTruthy()
+  })
+})

--- a/apps/web/src/services/__tests__/adminQualityService.test.ts
+++ b/apps/web/src/services/__tests__/adminQualityService.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { getAdminQualityDashboard } from '../adminQualityService'
+import { getAdminQualityDashboard, getAdminStepInsights } from '../adminQualityService'
 
 type TableName =
   | 'profiles'
@@ -9,6 +9,7 @@ type TableName =
   | 'mini_project_progress'
   | 'user_feedback'
   | 'review_items'
+  | 'learning_events'
 
 const tableState: Record<TableName, { data: unknown[]; count: number | null; error: unknown }> = {
   profiles: { data: [], count: 0, error: null },
@@ -18,6 +19,7 @@ const tableState: Record<TableName, { data: unknown[]; count: number | null; err
   mini_project_progress: { data: [], count: null, error: null },
   user_feedback: { data: [], count: null, error: null },
   review_items: { data: [], count: null, error: null },
+  learning_events: { data: [], count: null, error: null },
 }
 
 const from = vi.fn((table: TableName) => ({
@@ -176,6 +178,181 @@ describe('getAdminQualityDashboard', () => {
     await expect(getAdminQualityDashboard()).rejects.toMatchObject({
       name: 'AppError',
       userMessage: '品質KPIのステップ進捗取得に失敗しました',
+    })
+  })
+})
+
+describe('getAdminStepInsights', () => {
+  beforeEach(resetState)
+
+  it('learning_events からステップ別の遷移率・誤答率・離脱率を集計する', async () => {
+    tableState.learning_events.data = [
+      {
+        user_id: 'u1',
+        event_type: 'step_started',
+        step_id: 'usestate-basic',
+        mode: null,
+        payload: null,
+        created_at: '2026-06-05T00:00:00Z',
+      },
+      {
+        user_id: 'u1',
+        event_type: 'mode_started',
+        step_id: 'usestate-basic',
+        mode: 'read',
+        payload: null,
+        created_at: '2026-06-05T00:01:00Z',
+      },
+      {
+        user_id: 'u1',
+        event_type: 'mode_started',
+        step_id: 'usestate-basic',
+        mode: 'practice',
+        payload: null,
+        created_at: '2026-06-05T00:02:00Z',
+      },
+      {
+        user_id: 'u1',
+        event_type: 'mode_started',
+        step_id: 'usestate-basic',
+        mode: 'test',
+        payload: null,
+        created_at: '2026-06-05T00:03:00Z',
+      },
+      {
+        user_id: 'u1',
+        event_type: 'mode_started',
+        step_id: 'usestate-basic',
+        mode: 'challenge',
+        payload: null,
+        created_at: '2026-06-05T00:04:00Z',
+      },
+      {
+        user_id: 'u1',
+        event_type: 'mode_completed',
+        step_id: 'usestate-basic',
+        mode: 'challenge',
+        payload: null,
+        created_at: '2026-06-05T00:05:00Z',
+      },
+      {
+        user_id: 'u1',
+        event_type: 'practice_answer_submitted',
+        step_id: 'usestate-basic',
+        mode: 'practice',
+        payload: { isCorrect: true },
+        created_at: '2026-06-05T00:06:00Z',
+      },
+      {
+        user_id: 'u1',
+        event_type: 'test_submitted',
+        step_id: 'usestate-basic',
+        mode: 'test',
+        payload: { isCorrect: true },
+        created_at: '2026-06-05T00:07:00Z',
+      },
+      {
+        user_id: 'u1',
+        event_type: 'challenge_submitted',
+        step_id: 'usestate-basic',
+        mode: 'challenge',
+        payload: { isCorrect: true },
+        created_at: '2026-06-05T00:08:00Z',
+      },
+      {
+        user_id: 'u2',
+        event_type: 'step_started',
+        step_id: 'usestate-basic',
+        mode: null,
+        payload: null,
+        created_at: '2026-06-05T01:00:00Z',
+      },
+      {
+        user_id: 'u2',
+        event_type: 'mode_started',
+        step_id: 'usestate-basic',
+        mode: 'read',
+        payload: null,
+        created_at: '2026-06-05T01:01:00Z',
+      },
+      {
+        user_id: 'u2',
+        event_type: 'mode_started',
+        step_id: 'usestate-basic',
+        mode: 'practice',
+        payload: null,
+        created_at: '2026-06-05T01:02:00Z',
+      },
+      {
+        user_id: 'u2',
+        event_type: 'practice_answer_submitted',
+        step_id: 'usestate-basic',
+        mode: 'practice',
+        payload: { isCorrect: false },
+        created_at: '2026-06-05T01:03:00Z',
+      },
+      {
+        user_id: 'u2',
+        event_type: 'test_submitted',
+        step_id: 'usestate-basic',
+        mode: 'test',
+        payload: { isCorrect: false },
+        created_at: '2026-06-05T01:04:00Z',
+      },
+    ]
+    tableState.user_feedback.data = [
+      {
+        status: 'new',
+        created_at: '2026-06-05T02:00:00Z',
+        page_url: 'http://localhost:5173/step/usestate-basic?mode=practice',
+      },
+      {
+        status: 'resolved',
+        created_at: '2026-06-05T03:00:00Z',
+        page_url: 'http://localhost:5173/step/events',
+      },
+    ]
+
+    const insights = await getAdminStepInsights()
+    const row = insights.rows.find((item) => item.stepId === 'usestate-basic')
+
+    expect(from).toHaveBeenCalledWith('learning_events')
+    expect(insights.totalEvents).toBe(14)
+    expect(insights.observedSteps).toBeGreaterThan(0)
+    expect(row).toEqual(
+      expect.objectContaining({
+        stepId: 'usestate-basic',
+        startedUsers: 2,
+        readStartedUsers: 2,
+        practiceStartedUsers: 2,
+        testStartedUsers: 1,
+        challengeStartedUsers: 1,
+        challengeCompletedUsers: 1,
+        completionRate: 0.5,
+        readToPracticeRate: 1,
+        practiceToTestRate: 0.5,
+        testToChallengeRate: 1,
+        dropoffRate: 0.5,
+        practiceSubmissions: 2,
+        practiceIncorrectRate: 0.5,
+        testSubmissions: 2,
+        testFailureRate: 0.5,
+        challengeSubmissions: 1,
+        challengePassRate: 1,
+        relatedFeedbackCount: 1,
+        newFeedbackCount: 1,
+        bottleneck: '離脱率 50.0%',
+        signal: 'watch',
+      }),
+    )
+  })
+
+  it('イベントログ取得エラーを AppError に変換する', async () => {
+    tableState.learning_events.error = { code: 'DB_ERROR', message: 'forbidden' }
+
+    await expect(getAdminStepInsights()).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: 'Step Insightsのイベントログ取得に失敗しました',
     })
   })
 })

--- a/apps/web/src/services/adminQualityService.ts
+++ b/apps/web/src/services/adminQualityService.ts
@@ -1,7 +1,7 @@
-import { getAllSteps } from '../content/courseData'
+import { findCourseByStepId, getAllSteps } from '../content/courseData'
 import { supabase } from '../lib/supabaseClient'
 import { fromSupabaseError } from '../shared/errors'
-import type { Tables } from '../shared/types/database.types'
+import type { Json, Tables } from '../shared/types/database.types'
 
 type StepProgressRow = Pick<
   Tables<'step_progress'>,
@@ -23,7 +23,12 @@ type MiniProjectProgressRow = Pick<
   'project_id' | 'status' | 'completed_at'
 >
 type UserFeedbackRow = Pick<Tables<'user_feedback'>, 'status' | 'created_at'>
+type StepFeedbackRow = Pick<Tables<'user_feedback'>, 'status' | 'created_at' | 'page_url'>
 type ReviewItemRow = Pick<Tables<'review_items'>, 'status' | 'step_id'>
+type LearningEventRow = Pick<
+  Tables<'learning_events'>,
+  'user_id' | 'event_type' | 'step_id' | 'mode' | 'payload' | 'created_at'
+>
 
 export type AdminQualityMetricStatus = 'formal' | 'provisional' | 'future'
 
@@ -72,6 +77,47 @@ export interface AdminQualityStepInsight {
   signal: AdminQualityStepInsightSignal
 }
 
+export interface AdminStepInsight {
+  stepId: string
+  courseId: string | null
+  courseTitle: string | null
+  order: number
+  title: string
+  eventCount: number
+  startedUsers: number
+  readStartedUsers: number
+  practiceStartedUsers: number
+  testStartedUsers: number
+  challengeStartedUsers: number
+  readCompletedUsers: number
+  practiceCompletedUsers: number
+  testCompletedUsers: number
+  challengeCompletedUsers: number
+  completionRate: number | null
+  readToPracticeRate: number | null
+  practiceToTestRate: number | null
+  testToChallengeRate: number | null
+  dropoffRate: number | null
+  practiceSubmissions: number
+  practiceIncorrectRate: number | null
+  testSubmissions: number
+  testFailureRate: number | null
+  challengeSubmissions: number
+  challengePassRate: number | null
+  relatedFeedbackCount: number
+  newFeedbackCount: number
+  bottleneck: string
+  signal: AdminQualityStepInsightSignal
+}
+
+export interface AdminStepInsights {
+  generatedAt: string
+  totalEvents: number
+  observedSteps: number
+  attentionSteps: number
+  rows: AdminStepInsight[]
+}
+
 export interface AdminQualityMiniProjectStatus {
   total: number
   completed: number
@@ -105,6 +151,30 @@ interface StepAggregate {
   challengePassed: number
   openReviewItems: number
 }
+
+type LearningMode = 'read' | 'practice' | 'test' | 'challenge'
+
+interface StepEventAggregate {
+  stepId: string
+  courseId: string | null
+  courseTitle: string | null
+  order: number
+  title: string
+  eventCount: number
+  startedUsers: Set<string>
+  modeStartedUsers: Record<LearningMode, Set<string>>
+  modeCompletedUsers: Record<LearningMode, Set<string>>
+  practiceSubmissions: number
+  practiceIncorrect: number
+  testSubmissions: number
+  testFailures: number
+  challengeSubmissions: number
+  challengePassed: number
+  relatedFeedbackCount: number
+  newFeedbackCount: number
+}
+
+const STEP_INSIGHT_MODES: readonly LearningMode[] = ['read', 'practice', 'test', 'challenge']
 
 function isStepCompleted(row: StepProgressRow): boolean {
   return Boolean(
@@ -249,6 +319,247 @@ function getLowestTransition(
   if (measurable.length === 0) return null
   const [lowest] = measurable.sort((a, b) => a.rate - b.rate)
   return lowest ?? null
+}
+
+function createModeUserSets(): Record<LearningMode, Set<string>> {
+  return {
+    read: new Set<string>(),
+    practice: new Set<string>(),
+    test: new Set<string>(),
+    challenge: new Set<string>(),
+  }
+}
+
+function isStepFeedback(row: StepFeedbackRow, stepId: string): boolean {
+  return Boolean(row.page_url?.includes(`/step/${stepId}`))
+}
+
+function getPayloadBoolean(payload: Json | null, key: string): boolean | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null
+  const value = payload[key]
+  return typeof value === 'boolean' ? value : null
+}
+
+function isLearningMode(value: string | null): value is LearningMode {
+  return STEP_INSIGHT_MODES.includes(value as LearningMode)
+}
+
+function buildStepEventAggregates(
+  events: LearningEventRow[],
+  feedbackRows: StepFeedbackRow[],
+): StepEventAggregate[] {
+  const implementedSteps = getAllSteps().filter((step) => step.isImplemented)
+  const aggregates = new Map<string, StepEventAggregate>()
+
+  for (const step of implementedSteps) {
+    const course = findCourseByStepId(step.id)
+    aggregates.set(step.id, {
+      stepId: step.id,
+      courseId: course?.id ?? null,
+      courseTitle: course?.title ?? null,
+      order: step.order,
+      title: step.title,
+      eventCount: 0,
+      startedUsers: new Set<string>(),
+      modeStartedUsers: createModeUserSets(),
+      modeCompletedUsers: createModeUserSets(),
+      practiceSubmissions: 0,
+      practiceIncorrect: 0,
+      testSubmissions: 0,
+      testFailures: 0,
+      challengeSubmissions: 0,
+      challengePassed: 0,
+      relatedFeedbackCount: 0,
+      newFeedbackCount: 0,
+    })
+  }
+
+  for (const row of events) {
+    if (!row.step_id) continue
+    const aggregate = aggregates.get(row.step_id)
+    if (!aggregate) continue
+
+    aggregate.eventCount += 1
+    aggregate.startedUsers.add(row.user_id)
+
+    if (row.event_type === 'mode_started' && isLearningMode(row.mode)) {
+      aggregate.modeStartedUsers[row.mode].add(row.user_id)
+    }
+
+    if (row.event_type === 'mode_completed' && isLearningMode(row.mode)) {
+      aggregate.modeCompletedUsers[row.mode].add(row.user_id)
+    }
+
+    if (row.event_type === 'practice_answer_submitted') {
+      aggregate.practiceSubmissions += 1
+      if (getPayloadBoolean(row.payload, 'isCorrect') === false) {
+        aggregate.practiceIncorrect += 1
+      }
+    }
+
+    if (row.event_type === 'test_submitted') {
+      aggregate.testSubmissions += 1
+      if (getPayloadBoolean(row.payload, 'isCorrect') === false) {
+        aggregate.testFailures += 1
+      }
+    }
+
+    if (row.event_type === 'challenge_submitted') {
+      aggregate.challengeSubmissions += 1
+      if (getPayloadBoolean(row.payload, 'isCorrect') === true) {
+        aggregate.challengePassed += 1
+      }
+    }
+  }
+
+  for (const row of feedbackRows) {
+    for (const aggregate of aggregates.values()) {
+      if (!isStepFeedback(row, aggregate.stepId)) continue
+      aggregate.relatedFeedbackCount += 1
+      if (row.status === 'new') {
+        aggregate.newFeedbackCount += 1
+      }
+    }
+  }
+
+  return [...aggregates.values()]
+}
+
+function selectBottleneck(indicators: readonly { label: string; score: number | null }[]): string {
+  const measurable = indicators.filter((item): item is { label: string; score: number } => item.score !== null)
+  if (measurable.length === 0) return 'データ不足'
+  const [worst] = measurable.sort((a, b) => b.score - a.score)
+  return worst ? `${worst.label} ${formatPercent(worst.score)}` : 'データ不足'
+}
+
+function getStepInsightSignal(row: {
+  eventCount: number
+  dropoffRate: number | null
+  practiceIncorrectRate: number | null
+  practiceSubmissions: number
+  testFailureRate: number | null
+  testSubmissions: number
+  challengePassRate: number | null
+  challengeSubmissions: number
+  relatedFeedbackCount: number
+}): AdminQualityStepInsightSignal {
+  if (row.eventCount === 0 && row.relatedFeedbackCount === 0) return 'insufficient'
+
+  const hasAttentionSignal =
+    (row.dropoffRate !== null && row.dropoffRate >= 0.6) ||
+    (row.practiceIncorrectRate !== null && row.practiceSubmissions >= 3 && row.practiceIncorrectRate >= 0.5) ||
+    (row.testFailureRate !== null && row.testSubmissions >= 3 && row.testFailureRate >= 0.5) ||
+    (row.challengePassRate !== null && row.challengeSubmissions >= 3 && row.challengePassRate < 0.4) ||
+    row.relatedFeedbackCount >= 3
+
+  if (hasAttentionSignal) return 'attention'
+
+  const hasWatchSignal =
+    (row.dropoffRate !== null && row.dropoffRate >= 0.3) ||
+    (row.practiceIncorrectRate !== null && row.practiceSubmissions > 0 && row.practiceIncorrectRate >= 0.3) ||
+    (row.testFailureRate !== null && row.testSubmissions > 0 && row.testFailureRate >= 0.3) ||
+    (row.challengePassRate !== null && row.challengeSubmissions > 0 && row.challengePassRate < 0.7) ||
+    row.relatedFeedbackCount > 0
+
+  return hasWatchSignal ? 'watch' : 'healthy'
+}
+
+function buildAdminStepInsightRows(aggregates: StepEventAggregate[]): AdminStepInsight[] {
+  return aggregates
+    .map((row) => {
+      const startedUsers = row.startedUsers.size
+      const readStartedUsers = row.modeStartedUsers.read.size
+      const practiceStartedUsers = row.modeStartedUsers.practice.size
+      const testStartedUsers = row.modeStartedUsers.test.size
+      const challengeStartedUsers = row.modeStartedUsers.challenge.size
+      const readCompletedUsers = row.modeCompletedUsers.read.size
+      const practiceCompletedUsers = row.modeCompletedUsers.practice.size
+      const testCompletedUsers = row.modeCompletedUsers.test.size
+      const challengeCompletedUsers = row.modeCompletedUsers.challenge.size
+      const completionRate = safeRate(challengeCompletedUsers, startedUsers)
+      const readToPracticeRate = safeRate(practiceStartedUsers, readStartedUsers)
+      const practiceToTestRate = safeRate(testStartedUsers, practiceStartedUsers)
+      const testToChallengeRate = safeRate(challengeStartedUsers, testStartedUsers)
+      const challengeReachRate = safeRate(challengeStartedUsers, startedUsers)
+      const dropoffRate = challengeReachRate === null ? null : 1 - challengeReachRate
+      const practiceIncorrectRate = safeRate(row.practiceIncorrect, row.practiceSubmissions)
+      const testFailureRate = safeRate(row.testFailures, row.testSubmissions)
+      const challengePassRate = safeRate(row.challengePassed, row.challengeSubmissions)
+      const bottleneck = selectBottleneck([
+        { label: '離脱率', score: dropoffRate },
+        { label: 'Practice誤答率', score: practiceIncorrectRate },
+        { label: 'Test失敗率', score: testFailureRate },
+        {
+          label: 'Challenge不合格率',
+          score: challengePassRate === null ? null : 1 - challengePassRate,
+        },
+        {
+          label: 'Read→Practice未遷移',
+          score: readToPracticeRate === null ? null : 1 - readToPracticeRate,
+        },
+        {
+          label: 'Practice→Test未遷移',
+          score: practiceToTestRate === null ? null : 1 - practiceToTestRate,
+        },
+        {
+          label: 'Test→Challenge未遷移',
+          score: testToChallengeRate === null ? null : 1 - testToChallengeRate,
+        },
+      ])
+      const signal = getStepInsightSignal({
+        eventCount: row.eventCount,
+        dropoffRate,
+        practiceIncorrectRate,
+        practiceSubmissions: row.practiceSubmissions,
+        testFailureRate,
+        testSubmissions: row.testSubmissions,
+        challengePassRate,
+        challengeSubmissions: row.challengeSubmissions,
+        relatedFeedbackCount: row.relatedFeedbackCount,
+      })
+
+      return {
+        stepId: row.stepId,
+        courseId: row.courseId,
+        courseTitle: row.courseTitle,
+        order: row.order,
+        title: row.title,
+        eventCount: row.eventCount,
+        startedUsers,
+        readStartedUsers,
+        practiceStartedUsers,
+        testStartedUsers,
+        challengeStartedUsers,
+        readCompletedUsers,
+        practiceCompletedUsers,
+        testCompletedUsers,
+        challengeCompletedUsers,
+        completionRate,
+        readToPracticeRate,
+        practiceToTestRate,
+        testToChallengeRate,
+        dropoffRate,
+        practiceSubmissions: row.practiceSubmissions,
+        practiceIncorrectRate,
+        testSubmissions: row.testSubmissions,
+        testFailureRate,
+        challengeSubmissions: row.challengeSubmissions,
+        challengePassRate,
+        relatedFeedbackCount: row.relatedFeedbackCount,
+        newFeedbackCount: row.newFeedbackCount,
+        bottleneck,
+        signal,
+      }
+    })
+    .sort((a, b) => {
+      const signalOrder: Record<AdminQualityStepInsightSignal, number> = {
+        attention: 0,
+        watch: 1,
+        healthy: 2,
+        insufficient: 3,
+      }
+      return signalOrder[a.signal] - signalOrder[b.signal] || a.order - b.order
+    })
 }
 
 function buildStepInsights(aggregates: StepAggregate[]): AdminQualityStepInsight[] {
@@ -486,5 +797,32 @@ export async function getAdminQualityDashboard(): Promise<AdminQualityDashboard>
       inProgress: miniProjectInProgress,
       notStarted: miniProjectNotStarted,
     },
+  }
+}
+
+export async function getAdminStepInsights(): Promise<AdminStepInsights> {
+  const [eventsRes, feedbackRes] = await Promise.all([
+    supabase
+      .from('learning_events')
+      .select('user_id, event_type, step_id, mode, payload, created_at'),
+    supabase.from('user_feedback').select('status, created_at, page_url'),
+  ])
+
+  if (eventsRes.error)
+    throw fromSupabaseError(eventsRes.error, 'Step Insightsのイベントログ取得に失敗しました')
+  if (feedbackRes.error)
+    throw fromSupabaseError(feedbackRes.error, 'Step Insightsのフィードバック取得に失敗しました')
+
+  const events = (eventsRes.data ?? []) as LearningEventRow[]
+  const feedbackRows = (feedbackRes.data ?? []) as StepFeedbackRow[]
+  const rows = buildAdminStepInsightRows(buildStepEventAggregates(events, feedbackRows))
+  const observedRows = rows.filter((row) => row.eventCount > 0 || row.relatedFeedbackCount > 0)
+
+  return {
+    generatedAt: new Date().toISOString(),
+    totalEvents: events.length,
+    observedSteps: observedRows.length,
+    attentionSteps: rows.filter((row) => row.signal === 'attention').length,
+    rows,
   }
 }


### PR DESCRIPTION
## Summary
- learning_events を使う Step Insights 集計を adminQualityService に追加
- /admin/step-insights に専用ページを追加し、ステップ別テーブルとドリルダウンを表示
- AdminLayout と管理トップに Step Insights 導線を追加
- ステップ別集計と表示のテストを追加

## Test plan
- cmd /c npm run typecheck
- cmd /c npm run lint
- cmd /c npm run test
- cmd /c npm run build

## Supabase
- 新規SQLなし
- 前提: apps/web/supabase/sql/022_learning_events.sql が適用済みであること