### PR TITLE
feat: 判定結果モデルを JudgeResult に拡張（v5roadmap04 M1）

### DIFF
--- a/apps/web/src/features/learning/ChallengeMode.tsx
+++ b/apps/web/src/features/learning/ChallengeMode.tsx
@@ -6,7 +6,7 @@ import { useIsMobile } from '../../hooks/useIsMobile'
 import type { ChallengePattern, ChallengeTask } from '../../content/fundamentals/steps'
 import { JudgmentResult } from './components/JudgmentResult'
 import { useJudgmentAction } from './hooks/useJudgmentAction'
-import { getMissingKeywords } from './utils/keywordMatcher'
+import { judgeKeywords } from '../../lib/judge'
 import { ChallengePuzzleMulti } from './ChallengePuzzle/ChallengePuzzleMulti'
 
 interface ChallengeModeProps {
@@ -41,17 +41,16 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
     setSubmissionError(null)
   }, [stepId, task])
 
-  const missingKeywords = useMemo(
-    () => getMissingKeywords(code, pattern.expectedKeywords),
+  const judgement = useMemo(
+    () => judgeKeywords(code, { requiredKeywords: pattern.expectedKeywords }),
     [code, pattern.expectedKeywords],
   )
-  const hasSatisfiedRequirements = missingKeywords.length === 0
+  const missingKeywords = judgement.missing
+  const hasSatisfiedRequirements = judgement.passed
   const isPassed = checked && hasSatisfiedRequirements
 
   async function handleCheck() {
-    const matchedKeywords = pattern.expectedKeywords.filter((keyword) =>
-      code.toLowerCase().includes(keyword.toLowerCase()),
-    )
+    const matchedKeywords = judgement.matched
 
     setChecked(true)
     setSubmissionError(null)

--- a/apps/web/src/features/learning/utils/keywordMatcher.ts
+++ b/apps/web/src/features/learning/utils/keywordMatcher.ts
@@ -1,15 +1,19 @@
+import { judgeKeywords } from '../../../lib/judge'
+
 /**
  * コード内に全ての expectedKeywords が含まれるか検証する（大文字小文字無視）
+ *
+ * 共通ユーティリティ {@link judgeKeywords} に委譲する。
  */
 export function checkAllKeywords(code: string, expectedKeywords: string[]): boolean {
-  const lower = code.toLowerCase()
-  return expectedKeywords.every((kw) => lower.includes(kw.toLowerCase()))
+  return judgeKeywords(code, { requiredKeywords: expectedKeywords }).passed
 }
 
 /**
  * コード内に含まれていない expectedKeywords を返す（大文字小文字無視）
+ *
+ * 共通ユーティリティ {@link judgeKeywords} に委譲する。
  */
 export function getMissingKeywords(code: string, expectedKeywords: string[]): string[] {
-  const lower = code.toLowerCase()
-  return expectedKeywords.filter((kw) => !lower.includes(kw.toLowerCase()))
+  return judgeKeywords(code, { requiredKeywords: expectedKeywords }).missing
 }

--- a/apps/web/src/lib/__tests__/judge.test.ts
+++ b/apps/web/src/lib/__tests__/judge.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { judgeKeywords } from '../judge'
+
+describe('judgeKeywords', () => {
+  it('必須キーワードをすべて含めば passed: true / score 100', () => {
+    const result = judgeKeywords('const [c, setC] = useState(0)', {
+      requiredKeywords: ['useState', 'setC'],
+    })
+    expect(result.passed).toBe(true)
+    expect(result.score).toBe(100)
+    expect(result.matched).toEqual(['useState', 'setC'])
+    expect(result.missing).toHaveLength(0)
+    expect(result.violations).toHaveLength(0)
+  })
+
+  it('一部のみ満たす場合は部分点 score と missing を返す（passed は false）', () => {
+    const result = judgeKeywords('const x = useState(0)', {
+      requiredKeywords: ['useState', 'onClick', 'return', 'props'],
+    })
+    expect(result.passed).toBe(false)
+    expect(result.score).toBe(25)
+    expect(result.matched).toEqual(['useState'])
+    expect(result.missing).toEqual(['onClick', 'return', 'props'])
+  })
+
+  it('ngKeywords を含むと violations に入り passed: false（必須は満たしていても）', () => {
+    const result = judgeKeywords('var x = 1; useState()', {
+      requiredKeywords: ['useState'],
+      ngKeywords: ['var '],
+    })
+    expect(result.matched).toEqual(['useState'])
+    expect(result.violations).toEqual(['var '])
+    expect(result.passed).toBe(false)
+    // 必須は満たすため score は満点だが passed は違反で false
+    expect(result.score).toBe(100)
+  })
+
+  it('大文字小文字を区別しない', () => {
+    const result = judgeKeywords('USESTATE()', { requiredKeywords: ['useState'] })
+    expect(result.passed).toBe(true)
+  })
+
+  it('requiredKeywords が空なら score 100 / passed: true', () => {
+    const result = judgeKeywords('anything', { requiredKeywords: [] })
+    expect(result.passed).toBe(true)
+    expect(result.score).toBe(100)
+  })
+
+  it('ngKeywords 未指定でも違反なしとして扱う', () => {
+    const result = judgeKeywords('useState', { requiredKeywords: ['useState'] })
+    expect(result.violations).toEqual([])
+    expect(result.passed).toBe(true)
+  })
+})

--- a/apps/web/src/lib/judge.ts
+++ b/apps/web/src/lib/judge.ts
@@ -1,0 +1,55 @@
+/**
+ * コード判定の共通ユーティリティ。
+ *
+ * Challenge / Code Doctor / Mini Project などの各判定モードが
+ * 共通の `JudgeResult` を返せるよう、キーワード判定ロジックを集約する。
+ *
+ * v5roadmap04 M1: 合否（boolean）から「スコア + 詳細」を返す構造へ拡張。
+ * `passed` の意味は従来通り（必須をすべて満たし、禁止に違反しない）を維持する。
+ */
+
+/** 判定結果モデル（合否 + 部分点 + 詳細） */
+export interface JudgeResult {
+  /** 合格したか（必須をすべて満たし、禁止に違反しない） */
+  passed: boolean
+  /** 部分点 0-100（満たした必須要件の割合） */
+  score: number
+  /** 満たした要件 */
+  matched: string[]
+  /** 不足している要件 */
+  missing: string[]
+  /** 禁止キーワード等の違反 */
+  violations: string[]
+}
+
+/** キーワード判定の入力 */
+export interface KeywordJudgeInput {
+  /** すべて含まれている必要があるキーワード */
+  requiredKeywords: string[]
+  /** 含まれていてはいけないキーワード（任意） */
+  ngKeywords?: string[]
+}
+
+/**
+ * キーワードベースでコードを判定する（大文字小文字を区別しない）。
+ *
+ * - `matched`: requiredKeywords のうちコードに含まれるもの
+ * - `missing`: requiredKeywords のうちコードに含まれないもの
+ * - `violations`: ngKeywords のうちコードに含まれるもの
+ * - `score`: matched / required の割合（0-100）。required が空なら 100
+ * - `passed`: missing が空 かつ violations が空
+ */
+export function judgeKeywords(code: string, input: KeywordJudgeInput): JudgeResult {
+  const lower = code.toLowerCase()
+  const required = input.requiredKeywords
+  const ngKeywords = input.ngKeywords ?? []
+
+  const matched = required.filter((kw) => lower.includes(kw.toLowerCase()))
+  const missing = required.filter((kw) => !lower.includes(kw.toLowerCase()))
+  const violations = ngKeywords.filter((kw) => lower.includes(kw.toLowerCase()))
+
+  const score = required.length === 0 ? 100 : Math.round((matched.length / required.length) * 100)
+  const passed = missing.length === 0 && violations.length === 0
+
+  return { passed, score, matched, missing, violations }
+}

--- a/apps/web/src/services/codeDoctorService.ts
+++ b/apps/web/src/services/codeDoctorService.ts
@@ -8,6 +8,7 @@ import {
 import { fromSupabaseError } from '../shared/errors'
 import { assertMaxLength, assertUuid } from '../shared/validation'
 import { awardPoints } from './pointService'
+import { judgeKeywords } from '../lib/judge'
 import type { CodeDoctorProblem, CodeDoctorProgress, SubmitDoctorResult } from '../content/code-doctor/types'
 
 // ─── 純粋関数 ────────────────────────────────────────────
@@ -32,18 +33,23 @@ export function getPointsForDifficulty(difficulty: CodeDoctorProblem['difficulty
  * コードが問題の合格条件を満たしているか判定する（純粋関数）
  * - requiredKeywords をすべて含む
  * - ngKeywords をどれも含まない
+ *
+ * 共通ユーティリティ {@link judgeKeywords} に委譲し、後方互換の戻り値へ射影する。
+ * `score` / `matched` など拡張フィールドが必要な場合は judgeKeywords を直接利用する。
  */
 export function judgeCode(
   code: string,
   problem: Pick<CodeDoctorProblem, 'requiredKeywords' | 'ngKeywords'>,
 ): { passed: boolean; missingKeywords: string[]; foundNgKeywords: string[] } {
-  const lower = code.toLowerCase()
-  const missingKeywords = problem.requiredKeywords.filter(
-    (kw) => !lower.includes(kw.toLowerCase()),
-  )
-  const foundNgKeywords = problem.ngKeywords.filter((kw) => lower.includes(kw.toLowerCase()))
-  const passed = missingKeywords.length === 0 && foundNgKeywords.length === 0
-  return { passed, missingKeywords, foundNgKeywords }
+  const result = judgeKeywords(code, {
+    requiredKeywords: problem.requiredKeywords,
+    ngKeywords: problem.ngKeywords,
+  })
+  return {
+    passed: result.passed,
+    missingKeywords: result.missing,
+    foundNgKeywords: result.violations,
+  }
 }
 
 // ─── DB 関数 ─────────────────────────────────────────────


### PR DESCRIPTION
## 概要

v5roadmap04「Challenge 実装力評価の進化」の **M1: 判定結果モデル拡張 + 共通ユーティリティ**。
キーワード判定を boolean から `JudgeResult`（score + matched/missing/violations）を返す構造へ**後方互換**で拡張し、分散していた判定ロジックを単一ユーティリティへ集約する。

これ自体は判定基準を変えない土台作り。部分点での合格判定・ngKeywords の Challenge 展開・複数正解パターンは M2 で扱う。

## 変更内容

| ファイル | 内容 |
|---|---|
| `lib/judge.ts`（新規） | `JudgeResult` 型 + `judgeKeywords`（単一の判定ロジック） |
| `lib/__tests__/judge.test.ts`（新規） | 部分点 / 違反 / 大小無視 / 空配列の各ケース |
| `services/codeDoctorService.ts` | `judgeCode` を judgeKeywords へ委譲（旧戻り値 `missingKeywords`/`foundNgKeywords` を温存） |
| `features/learning/utils/keywordMatcher.ts` | `checkAllKeywords`/`getMissingKeywords` を judgeKeywords へ委譲 |
| `features/learning/ChallengeMode.tsx` | judgeKeywords へ移行し matched/missing を1パス取得 |

## 設計判断

- 共通ユーティリティを `lib/judge.ts` に配置（依存方向ルール上 `services/`・`features/` 双方から参照できる最下層）。`keywordMatcher` は薄いラッパとして残し、既存呼び出し元（TestMode / CodePuzzle / ChallengeMode）を温存。
- `passed` の挙動は不変。`judgeCode` の旧フィールド名は射影層で温存し、既存テストを緑のまま維持。

## 検証

- typecheck: PASS
- lint: PASS
- test: PASS（**886件**、judge.test.ts 6件追加）
- build: PASS

回帰確認: Challenge / Code Doctor の既存判定テストはすべて緑のまま（passed 互換）。

## マージ判断

CI 4ゲート全通過・後方互換維持を確認済みのため dev へマージ可。Level 1（M2）の前提となる判定基盤。

🤖 Generated with [Claude Code](https://claude.com/claude-code)