### PR TITLE
feat: Challenge 判定 Level 1 強化（禁止語・複数正解・部分点）（v5roadmap04 M2）

### DIFF
--- a/apps/web/src/content/fundamentals/steps.ts
+++ b/apps/web/src/content/fundamentals/steps.ts
@@ -36,7 +36,14 @@ export interface ChallengePattern {
   prompt: string
   requirements: string[]
   hints: string[]
+  /** 常に含まれている必要があるキーワード */
   expectedKeywords: string[]
+  /** 含まれていてはいけないキーワード（アンチパターン抑止。任意） */
+  ngKeywords?: string[]
+  /** 複数正解パターン（いずれかを満たせば可。任意） */
+  anyOf?: string[][]
+  /** 部分点での合格閾値（0-100。未指定なら全要件一致。任意） */
+  passThreshold?: number
   starterCode: string
   mobilePuzzle?: ChallengeMobilePuzzle
 }
@@ -670,6 +677,8 @@ export function List() {
           requirements: ['mapメソッドを使う', 'keyプロパティを指定する', 'todoのtitleを表示する'],
           hints: ['todos.map(todo => ...) とする', 'key={todo.id} のように一意な値を渡す'],
           expectedKeywords: ['map', 'key=', 'todo.id'],
+          // 配列インデックスを key にするアンチパターンを抑止する
+          ngKeywords: ['key={index}', 'key={i}'],
           starterCode: `export function TodoList() {\n  const todos = [\n    { id: 1, title: 'Reactを学ぶ' },\n    { id: 2, title: 'TypeScriptを学ぶ' },\n  ];\n\n  return (\n    <ul>\n      {/* TODO: todos を map し、それぞれ <li> タグとして描画してください。\n          <li> には必ず key に todo.id を指定し、中身に todo.title を表示してください。 \n      */}\n      \n    </ul>\n  );\n}`,
           mobilePuzzle: {
             type: 'multi',

--- a/apps/web/src/features/learning/ChallengeMode.tsx
+++ b/apps/web/src/features/learning/ChallengeMode.tsx
@@ -42,10 +42,17 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
   }, [stepId, task])
 
   const judgement = useMemo(
-    () => judgeKeywords(code, { requiredKeywords: pattern.expectedKeywords }),
-    [code, pattern.expectedKeywords],
+    () =>
+      judgeKeywords(code, {
+        requiredKeywords: pattern.expectedKeywords,
+        ngKeywords: pattern.ngKeywords,
+        anyOf: pattern.anyOf,
+        passThreshold: pattern.passThreshold,
+      }),
+    [code, pattern.expectedKeywords, pattern.ngKeywords, pattern.anyOf, pattern.passThreshold],
   )
   const missingKeywords = judgement.missing
+  const violations = judgement.violations
   const hasSatisfiedRequirements = judgement.passed
   const isPassed = checked && hasSatisfiedRequirements
 
@@ -123,12 +130,26 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
 
       {checked && !isPassed ? (
         <div className="rounded-lg border border-rose-200 bg-rose-50 p-4" role="alert">
-          <p className="text-sm font-semibold text-rose-800">以下の要件が未達成です:</p>
-          <ul className="mt-2 list-inside list-disc text-sm text-rose-700">
-            {missingKeywords.map((keyword) => (
-              <li key={keyword}>{keyword}</li>
-            ))}
-          </ul>
+          {missingKeywords.length > 0 && (
+            <>
+              <p className="text-sm font-semibold text-rose-800">以下の要件が未達成です:</p>
+              <ul className="mt-2 list-inside list-disc text-sm text-rose-700">
+                {missingKeywords.map((keyword) => (
+                  <li key={keyword}>{keyword}</li>
+                ))}
+              </ul>
+            </>
+          )}
+          {violations.length > 0 && (
+            <div className={missingKeywords.length > 0 ? 'mt-3' : ''}>
+              <p className="text-sm font-semibold text-amber-800">避けたい書き方が含まれています:</p>
+              <ul className="mt-2 list-inside list-disc text-sm text-amber-700">
+                {violations.map((keyword) => (
+                  <li key={keyword}>{keyword}</li>
+                ))}
+              </ul>
+            </div>
+          )}
           {pattern.hints.length > 0 && (
             <p className="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800">
               ヒント: {pattern.hints[0]}

--- a/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
@@ -174,6 +174,63 @@ describe('ChallengeMode', () => {
     expect(screen.getByText('onClick')).toBeTruthy()
   })
 
+  it('violations 表示: ngKeywords を含むと「避けたい書き方」と違反語が表示され不合格になること', async () => {
+    const user = userEvent.setup()
+    const onComplete = vi.fn()
+    const ngTask: ChallengeTask = {
+      patterns: [
+        {
+          id: 'ng-pattern',
+          prompt: 'index を key にしない',
+          requirements: ['mapを使う'],
+          hints: ['key={item.id}'],
+          expectedKeywords: ['map', 'key='],
+          ngKeywords: ['key={index}'],
+          starterCode: '',
+        },
+      ],
+    }
+
+    render(<ChallengeMode stepId="step-ng" task={ngTask} onComplete={onComplete} />)
+
+    const editor = await screen.findByLabelText('challenge-editor')
+    // 必須は満たすが ngKeyword を含む
+    fireEvent.change(editor, { target: { value: 'items.map((item, index) => <li key={index}>{item}</li>)' } })
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(screen.getByText('避けたい書き方が含まれています:')).toBeTruthy()
+    expect(screen.getByText('key={index}')).toBeTruthy()
+  })
+
+  it('anyOf: いずれかの正解パターンを満たせば合格すること', async () => {
+    const user = userEvent.setup()
+    const onComplete = vi.fn()
+    const anyOfTask: ChallengeTask = {
+      patterns: [
+        {
+          id: 'anyof-pattern',
+          prompt: 'カウントを増やす',
+          requirements: ['setCountを使う'],
+          hints: ['count + 1 でも prev => prev + 1 でも可'],
+          expectedKeywords: ['setCount'],
+          anyOf: [['count + 1'], ['prev => prev + 1']],
+          starterCode: '',
+        },
+      ],
+    }
+
+    render(<ChallengeMode stepId="step-anyof" task={anyOfTask} onComplete={onComplete} />)
+
+    const editor = await screen.findByLabelText('challenge-editor')
+    // 2つ目の正解パターンを使用
+    fireEvent.change(editor, { target: { value: 'setCount(prev => prev + 1)' } })
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(screen.getByRole('status').textContent).toContain('Challengeを完了しました')
+  })
+
   it('ヒント表示: 判定失敗時にヒントが表示されること', async () => {
     // Arrange
     const user = userEvent.setup()

--- a/apps/web/src/lib/__tests__/judge.test.ts
+++ b/apps/web/src/lib/__tests__/judge.test.ts
@@ -78,6 +78,14 @@ describe('judgeKeywords', () => {
       // anyOf は満たすが必須が無い
       expect(judgeKeywords('setX(count + 1)', input).passed).toBe(false)
     })
+
+    it('完全充足した短い候補を一致数の多い未充足候補より優先する', () => {
+      // ['a','b','c'] は一致2だが未充足、['x'] は一致1だが完全充足
+      const result = judgeKeywords('a b x', { anyOf: [['a', 'b', 'c'], ['x']] })
+      expect(result.passed).toBe(true)
+      expect(result.matched).toEqual(['x'])
+      expect(result.missing).toEqual([])
+    })
   })
 
   describe('passThreshold（部分点での合格）', () => {

--- a/apps/web/src/lib/__tests__/judge.test.ts
+++ b/apps/web/src/lib/__tests__/judge.test.ts
@@ -51,4 +51,63 @@ describe('judgeKeywords', () => {
     expect(result.violations).toEqual([])
     expect(result.passed).toBe(true)
   })
+
+  describe('anyOf（複数正解パターン）', () => {
+    it('いずれかの候補を満たせば passed: true', () => {
+      const input = { anyOf: [['count + 1'], ['c => c + 1']] }
+      expect(judgeKeywords('setCount(count + 1)', input).passed).toBe(true)
+      expect(judgeKeywords('setCount(c => c + 1)', input).passed).toBe(true)
+    })
+
+    it('どの候補も満たさなければ passed: false で最も近い候補の missing を返す', () => {
+      const result = judgeKeywords('setCount(0)', {
+        anyOf: [
+          ['count', '+ 1'],
+          ['prev', '=> prev'],
+        ],
+      })
+      expect(result.passed).toBe(false)
+      // 'count' のみ一致する最初の候補が採用される
+      expect(result.matched).toEqual(['count'])
+      expect(result.missing).toEqual(['+ 1'])
+    })
+
+    it('requiredKeywords と anyOf は AND される', () => {
+      const input = { requiredKeywords: ['setCount'], anyOf: [['count + 1'], ['c => c + 1']] }
+      expect(judgeKeywords('setCount(count + 1)', input).passed).toBe(true)
+      // anyOf は満たすが必須が無い
+      expect(judgeKeywords('setX(count + 1)', input).passed).toBe(false)
+    })
+  })
+
+  describe('passThreshold（部分点での合格）', () => {
+    it('閾値以上の score で passed: true（一部不足でも合格）', () => {
+      const result = judgeKeywords('useState onClick', {
+        requiredKeywords: ['useState', 'onClick', 'return', 'props'],
+        passThreshold: 50,
+      })
+      expect(result.score).toBe(50)
+      expect(result.passed).toBe(true)
+      expect(result.missing).toEqual(['return', 'props'])
+    })
+
+    it('閾値未満なら passed: false', () => {
+      const result = judgeKeywords('useState', {
+        requiredKeywords: ['useState', 'onClick', 'return', 'props'],
+        passThreshold: 50,
+      })
+      expect(result.score).toBe(25)
+      expect(result.passed).toBe(false)
+    })
+
+    it('閾値を満たしても violations があれば passed: false', () => {
+      const result = judgeKeywords('useState onClick var x', {
+        requiredKeywords: ['useState', 'onClick'],
+        ngKeywords: ['var '],
+        passThreshold: 50,
+      })
+      expect(result.score).toBe(100)
+      expect(result.passed).toBe(false)
+    })
+  })
 })

--- a/apps/web/src/lib/judge.ts
+++ b/apps/web/src/lib/judge.ts
@@ -56,7 +56,9 @@ export interface KeywordJudgeInput {
  * - `score`: matched / 有効必須 の割合（0-100）。有効必須が空なら 100
  * - `passed`: score >= passThreshold（既定 100）かつ violations が空
  *
- * `anyOf` 指定時は最も多く一致した候補を requiredKeywords に合成して評価する。
+ * `anyOf` 指定時は各候補を requiredKeywords に合成して個別に評価し、
+ * 合格 > 高スコア の順で最良の結果を返す（一致数だけで選ぶと、完全充足した
+ * 短い候補を一致数の多い未充足候補に取りこぼすため）。
  */
 export function judgeKeywords(code: string, input: KeywordJudgeInput): JudgeResult {
   const lower = code.toLowerCase()
@@ -64,23 +66,25 @@ export function judgeKeywords(code: string, input: KeywordJudgeInput): JudgeResu
 
   const violations = (input.ngKeywords ?? []).filter(includes)
   const baseRequired = input.requiredKeywords ?? []
+  const threshold = input.passThreshold ?? 100
 
-  // 複数正解パターン: 最も多く一致した候補を採用し、base と AND する
-  let effectiveRequired = baseRequired
-  if (input.anyOf && input.anyOf.length > 0) {
-    const bestAlt = input.anyOf.reduce((best, alt) =>
-      alt.filter(includes).length > best.filter(includes).length ? alt : best,
-    )
-    effectiveRequired = [...new Set([...baseRequired, ...bestAlt])]
+  // 評価対象の必須セット一覧（anyOf 指定時は各候補を base と合成）
+  const candidateSets =
+    input.anyOf && input.anyOf.length > 0
+      ? input.anyOf.map((alt) => [...new Set([...baseRequired, ...alt])])
+      : [baseRequired]
+
+  const evaluate = (required: string[]): JudgeResult => {
+    const matched = required.filter(includes)
+    const missing = required.filter((kw) => !includes(kw))
+    const score = required.length === 0 ? 100 : Math.round((matched.length / required.length) * 100)
+    const passed = score >= threshold && violations.length === 0
+    return { passed, score, matched, missing, violations }
   }
 
-  const matched = effectiveRequired.filter(includes)
-  const missing = effectiveRequired.filter((kw) => !includes(kw))
-
-  const score =
-    effectiveRequired.length === 0 ? 100 : Math.round((matched.length / effectiveRequired.length) * 100)
-  const threshold = input.passThreshold ?? 100
-  const passed = score >= threshold && violations.length === 0
-
-  return { passed, score, matched, missing, violations }
+  // 候補ごとに評価し、合格 > 高スコア の順で最良を選ぶ
+  return candidateSets.map(evaluate).reduce((best, cur) => {
+    if (cur.passed !== best.passed) return cur.passed ? cur : best
+    return cur.score > best.score ? cur : best
+  })
 }

--- a/apps/web/src/lib/judge.ts
+++ b/apps/web/src/lib/judge.ts
@@ -6,6 +6,8 @@
  *
  * v5roadmap04 M1: 合否（boolean）から「スコア + 詳細」を返す構造へ拡張。
  * `passed` の意味は従来通り（必須をすべて満たし、禁止に違反しない）を維持する。
+ * v5roadmap04 M2: Level 1 強化（複数正解パターン `anyOf` + 部分点閾値 `passThreshold`）。
+ * 既定（anyOf / passThreshold 未指定）では M1 と同一挙動を保つ。
  */
 
 /** 判定結果モデル（合否 + 部分点 + 詳細） */
@@ -22,34 +24,63 @@ export interface JudgeResult {
   violations: string[]
 }
 
-/** キーワード判定の入力 */
+/**
+ * キーワード判定の入力。
+ *
+ * 各オプショナルは `| undefined` を明示し、`exactOptionalPropertyTypes` 下でも
+ * 呼び出し側がオプショナル値（例: `pattern.ngKeywords`）をそのまま渡せるようにする。
+ */
 export interface KeywordJudgeInput {
-  /** すべて含まれている必要があるキーワード */
-  requiredKeywords: string[]
+  /** 常に含まれている必要があるキーワード */
+  requiredKeywords?: string[] | undefined
   /** 含まれていてはいけないキーワード（任意） */
-  ngKeywords?: string[]
+  ngKeywords?: string[] | undefined
+  /**
+   * 複数正解パターン（任意）。いずれかの配列を満たせば可とする。
+   * 最も多く一致した候補が採用され、requiredKeywords と AND される。
+   */
+  anyOf?: string[][] | undefined
+  /**
+   * 部分点での合格閾値（0-100、任意）。score がこの値以上で passed。
+   * 未指定なら 100（= 全要件一致）で、M1 と同一挙動。
+   */
+  passThreshold?: number | undefined
 }
 
 /**
  * キーワードベースでコードを判定する（大文字小文字を区別しない）。
  *
- * - `matched`: requiredKeywords のうちコードに含まれるもの
- * - `missing`: requiredKeywords のうちコードに含まれないもの
+ * - `matched`: 有効な必須要件のうちコードに含まれるもの
+ * - `missing`: 有効な必須要件のうちコードに含まれないもの
  * - `violations`: ngKeywords のうちコードに含まれるもの
- * - `score`: matched / required の割合（0-100）。required が空なら 100
- * - `passed`: missing が空 かつ violations が空
+ * - `score`: matched / 有効必須 の割合（0-100）。有効必須が空なら 100
+ * - `passed`: score >= passThreshold（既定 100）かつ violations が空
+ *
+ * `anyOf` 指定時は最も多く一致した候補を requiredKeywords に合成して評価する。
  */
 export function judgeKeywords(code: string, input: KeywordJudgeInput): JudgeResult {
   const lower = code.toLowerCase()
-  const required = input.requiredKeywords
-  const ngKeywords = input.ngKeywords ?? []
+  const includes = (kw: string) => lower.includes(kw.toLowerCase())
 
-  const matched = required.filter((kw) => lower.includes(kw.toLowerCase()))
-  const missing = required.filter((kw) => !lower.includes(kw.toLowerCase()))
-  const violations = ngKeywords.filter((kw) => lower.includes(kw.toLowerCase()))
+  const violations = (input.ngKeywords ?? []).filter(includes)
+  const baseRequired = input.requiredKeywords ?? []
 
-  const score = required.length === 0 ? 100 : Math.round((matched.length / required.length) * 100)
-  const passed = missing.length === 0 && violations.length === 0
+  // 複数正解パターン: 最も多く一致した候補を採用し、base と AND する
+  let effectiveRequired = baseRequired
+  if (input.anyOf && input.anyOf.length > 0) {
+    const bestAlt = input.anyOf.reduce((best, alt) =>
+      alt.filter(includes).length > best.filter(includes).length ? alt : best,
+    )
+    effectiveRequired = [...new Set([...baseRequired, ...bestAlt])]
+  }
+
+  const matched = effectiveRequired.filter(includes)
+  const missing = effectiveRequired.filter((kw) => !includes(kw))
+
+  const score =
+    effectiveRequired.length === 0 ? 100 : Math.round((matched.length / effectiveRequired.length) * 100)
+  const threshold = input.passThreshold ?? 100
+  const passed = score >= threshold && violations.length === 0
 
   return { passed, score, matched, missing, violations }
 }


### PR DESCRIPTION
## 概要

v5roadmap04「Challenge 実装力評価の進化」の **M2: Level 1（禁止キーワード・複数正解パターン・部分点）**。v1.0 リリースゲートの必達項目。

M1 で集約した `judgeKeywords`（[lib/judge.ts](../blob/dev/apps/web/src/lib/judge.ts)）を拡張し、Challenge 判定を「必須語を入れた」から「実装要件を満たした」へ一歩近づける。

## 変更内容

| ファイル | 内容 |
|---|---|
| `lib/judge.ts` | `anyOf`（複数正解パターン）+ `passThreshold`（部分点閾値）を追加。`requiredKeywords` を optional 化 |
| `content/fundamentals/steps.ts` | `ChallengePattern` に `ngKeywords`/`anyOf`/`passThreshold`（全 optional）追加。`lists-todo` に index-key 抑止の ngKeywords 実例 |
| `features/learning/ChallengeMode.tsx` | 新フィールドを判定へ渡し、不合格時に「避けたい書き方」(violations) セクションを表示 |
| `lib/__tests__/judge.test.ts` | anyOf / 閾値境界 / 違反優先 のケース追加 |
| `features/learning/__tests__/ChallengeMode.test.tsx` | violations 表示 / anyOf 合格 のケース追加 |

## 判定ロジック仕様

- **anyOf**: 最も多く一致した候補を `requiredKeywords` と AND して評価。報告する `missing` は「最も近い候補」のものにし、"あと一歩"フィードバックを成立させる。
- **passThreshold**: `score >= passThreshold`（既定 **100**）かつ violations が空で `passed`。
- **violations**: ngKeywords は必須を満たしていても合格させない（アンチパターン抑止）。

## 後方互換（方針A）

- `passThreshold` 既定 100 = 全要件一致 → **`anyOf`/閾値を指定しない既存パターンは M1 と完全に同一挙動**。
- 実コンテンツは厳密一致を維持。閾値緩和はパターン側で明示指定したときのみ（既存合否の回帰ゼロ）。
- 全 68 パターンへの ngKeywords/anyOf 一斉付与は本 M スコープ外（ロジック + UI + 代表実例で必達条件を満たす）。

## 検証

- typecheck: PASS
- lint: PASS
- test: PASS（**894件**、+8）
- build: PASS

回帰確認: Challenge / Code Doctor の既存判定テストはすべて緑のまま（passed 互換）。

## スコープ外（次マイルストーン）

- import / 必須シンボル存在チェック・構文パース → **M3（Level 2）**
- プレビュー連動・提出レビュー型 → Stage B（v1.0 後）

## マージ判断

CI 4ゲート全通過・後方互換維持を確認済みのため dev へマージ可。これで v1.0 ゲート「Challenge 判定にキーワード以外の評価軸が 1 つ以上ある」を満たす（禁止語・複数正解・部分点の3軸を追加）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)