### PR TITLE
feat: add notifications service foundation

### DIFF
--- a/apps/web/src/services/__tests__/adminNotificationService.test.ts
+++ b/apps/web/src/services/__tests__/adminNotificationService.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createAnnouncement,
+  createFeedbackNotification,
+} from '../adminNotificationService'
+import {
+  MAX_NOTIFICATION_BODY_LENGTH,
+  MAX_NOTIFICATION_TITLE_LENGTH,
+} from '../notificationService'
+
+type Row = Record<string, unknown>
+
+const notificationState = {
+  insertPayload: null as Row | null,
+  insertResult: { data: null as Row | null, error: null as unknown },
+}
+
+function createNotificationsBuilder() {
+  return {
+    insert: (payload: Row) => {
+      notificationState.insertPayload = payload
+      return {
+        select: () => ({
+          single: () => Promise.resolve(notificationState.insertResult),
+        }),
+      }
+    },
+  }
+}
+
+const from = vi.fn((table: string) => {
+  if (table === 'notifications') return createNotificationsBuilder()
+  throw new Error(`unexpected table: ${table}`)
+})
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {
+    from: (...args: unknown[]) => from(...(args as [string])),
+  },
+}))
+
+const ADMIN_ID = '11111111-1111-1111-1111-111111111111'
+const FEEDBACK_ID = '22222222-2222-2222-2222-222222222222'
+const NOTIFICATION_ID = '33333333-3333-3333-3333-333333333333'
+
+function resetState() {
+  vi.clearAllMocks()
+  notificationState.insertPayload = null
+  notificationState.insertResult = {
+    data: {
+      id: NOTIFICATION_ID,
+      type: 'announcement',
+      title: 'title',
+      body: 'body',
+      target_role: 'all',
+      created_by: ADMIN_ID,
+      published_at: '2026-06-05T00:00:00Z',
+      created_at: '2026-06-05T00:00:00Z',
+    },
+    error: null,
+  }
+}
+
+describe('createAnnouncement', () => {
+  beforeEach(resetState)
+
+  it('notifications に announcement を INSERT する', async () => {
+    const result = await createAnnouncement({
+      adminId: ADMIN_ID,
+      title: '  リリースのお知らせ  ',
+      body: '  新しい機能を公開しました  ',
+      targetRole: 'learner',
+    })
+
+    expect(from).toHaveBeenCalledWith('notifications')
+    expect(notificationState.insertPayload).toEqual({
+      type: 'announcement',
+      title: 'リリースのお知らせ',
+      body: '新しい機能を公開しました',
+      target_role: 'learner',
+      created_by: ADMIN_ID,
+    })
+    expect(result.id).toBe(NOTIFICATION_ID)
+  })
+
+  it('空の title は INSERT せず例外を投げる', async () => {
+    await expect(
+      createAnnouncement({
+        adminId: ADMIN_ID,
+        title: '   ',
+        body: 'body',
+        targetRole: 'all',
+      }),
+    ).rejects.toThrow('title must not be empty')
+    expect(notificationState.insertPayload).toBeNull()
+  })
+
+  it('空の body は INSERT せず例外を投げる', async () => {
+    await expect(
+      createAnnouncement({
+        adminId: ADMIN_ID,
+        title: 'title',
+        body: '   ',
+        targetRole: 'all',
+      }),
+    ).rejects.toThrow('body must not be empty')
+    expect(notificationState.insertPayload).toBeNull()
+  })
+
+  it('title / body の最大長を検証する', async () => {
+    await expect(
+      createAnnouncement({
+        adminId: ADMIN_ID,
+        title: 'a'.repeat(MAX_NOTIFICATION_TITLE_LENGTH + 1),
+        body: 'body',
+        targetRole: 'all',
+      }),
+    ).rejects.toThrow(`title must be at most ${MAX_NOTIFICATION_TITLE_LENGTH} characters`)
+
+    await expect(
+      createAnnouncement({
+        adminId: ADMIN_ID,
+        title: 'title',
+        body: 'a'.repeat(MAX_NOTIFICATION_BODY_LENGTH + 1),
+        targetRole: 'all',
+      }),
+    ).rejects.toThrow(`body must be at most ${MAX_NOTIFICATION_BODY_LENGTH} characters`)
+    expect(notificationState.insertPayload).toBeNull()
+  })
+
+  it('不正な targetRole は例外を投げる', async () => {
+    await expect(
+      createAnnouncement({
+        adminId: ADMIN_ID,
+        title: 'title',
+        body: 'body',
+        // @ts-expect-error - テスト用に不正な値を渡す
+        targetRole: 'teacher',
+      }),
+    ).rejects.toThrow('targetRole is not a valid value')
+  })
+
+  it('Supabase エラーを AppError に変換する', async () => {
+    notificationState.insertResult = {
+      data: null,
+      error: { code: 'DB_ERROR', message: 'rls denied' },
+    }
+    await expect(
+      createAnnouncement({
+        adminId: ADMIN_ID,
+        title: 'title',
+        body: 'body',
+        targetRole: 'admin',
+      }),
+    ).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: 'お知らせの作成に失敗しました',
+    })
+  })
+})
+
+describe('createFeedbackNotification', () => {
+  beforeEach(resetState)
+
+  it('admin 宛ての feedback 通知を INSERT する', async () => {
+    await createFeedbackNotification({ adminId: ADMIN_ID, feedbackId: FEEDBACK_ID })
+    expect(notificationState.insertPayload).toEqual({
+      type: 'feedback',
+      title: '新しいフィードバックが届きました',
+      body: `フィードバック ${FEEDBACK_ID} が届きました。管理画面で詳細を確認してください。`,
+      target_role: 'admin',
+      created_by: ADMIN_ID,
+    })
+  })
+
+  it('不正な feedbackId は例外を投げる', async () => {
+    await expect(
+      createFeedbackNotification({ adminId: ADMIN_ID, feedbackId: 'bad' }),
+    ).rejects.toThrow('feedbackId must be a valid UUID')
+    expect(notificationState.insertPayload).toBeNull()
+  })
+})

--- a/apps/web/src/services/__tests__/notificationService.test.ts
+++ b/apps/web/src/services/__tests__/notificationService.test.ts
@@ -1,0 +1,245 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  MAX_NOTIFICATION_LIST_LIMIT,
+  getNotifications,
+  getUnreadCount,
+  markAsRead,
+} from '../notificationService'
+
+type Row = Record<string, unknown>
+
+const notificationsState = {
+  orderCalls: [] as Array<{ column: string; options: Record<string, unknown> | undefined }>,
+  limitCalls: [] as number[],
+  result: { data: [] as Row[] | null, error: null as unknown },
+}
+
+const readsState = {
+  selectColumns: null as string | null,
+  eqCalls: [] as Array<[string, unknown]>,
+  inCalls: [] as Array<[string, unknown[]]>,
+  result: { data: [] as Row[] | null, error: null as unknown },
+  upsertPayload: null as Row | null,
+  upsertOptions: null as Record<string, unknown> | null,
+  upsertResult: { error: null as unknown },
+}
+
+function createNotificationsBuilder() {
+  const chain = {
+    order(column: string, options?: Record<string, unknown>) {
+      notificationsState.orderCalls.push({ column, options })
+      return chain
+    },
+    limit(limit: number) {
+      notificationsState.limitCalls.push(limit)
+      return chain
+    },
+    then(resolve: (value: unknown) => unknown, reject: (reason: unknown) => unknown) {
+      return Promise.resolve(notificationsState.result).then(resolve, reject)
+    },
+  }
+
+  return {
+    select: () => chain,
+  }
+}
+
+function createReadsBuilder() {
+  const chain = {
+    eq(column: string, value: unknown) {
+      readsState.eqCalls.push([column, value])
+      return chain
+    },
+    in(column: string, values: unknown[]) {
+      readsState.inCalls.push([column, values])
+      return Promise.resolve(readsState.result)
+    },
+  }
+
+  return {
+    select: (columns: string) => {
+      readsState.selectColumns = columns
+      return chain
+    },
+    upsert: (payload: Row, options?: Record<string, unknown>) => {
+      readsState.upsertPayload = payload
+      readsState.upsertOptions = options ?? null
+      return Promise.resolve(readsState.upsertResult)
+    },
+  }
+}
+
+const from = vi.fn((table: string) => {
+  if (table === 'notifications') return createNotificationsBuilder()
+  if (table === 'notification_reads') return createReadsBuilder()
+  throw new Error(`unexpected table: ${table}`)
+})
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabase: {
+    from: (...args: unknown[]) => from(...(args as [string])),
+  },
+}))
+
+const USER_ID = '11111111-1111-1111-1111-111111111111'
+const NOTIFICATION_ID_1 = '22222222-2222-2222-2222-222222222222'
+const NOTIFICATION_ID_2 = '33333333-3333-3333-3333-333333333333'
+
+function resetState() {
+  vi.clearAllMocks()
+  notificationsState.orderCalls = []
+  notificationsState.limitCalls = []
+  notificationsState.result = { data: [], error: null }
+  readsState.selectColumns = null
+  readsState.eqCalls = []
+  readsState.inCalls = []
+  readsState.result = { data: [], error: null }
+  readsState.upsertPayload = null
+  readsState.upsertOptions = null
+  readsState.upsertResult = { error: null }
+}
+
+function notificationRow(id: string, title: string): Row {
+  return {
+    id,
+    type: 'announcement',
+    title,
+    body: `${title} body`,
+    target_role: 'all',
+    created_by: null,
+    published_at: '2026-06-05T00:00:00Z',
+    created_at: '2026-06-05T00:00:00Z',
+  }
+}
+
+describe('getNotifications', () => {
+  beforeEach(resetState)
+
+  it('通知一覧に自分の既読状態を合成する', async () => {
+    notificationsState.result = {
+      data: [
+        notificationRow(NOTIFICATION_ID_1, '読んだ'),
+        notificationRow(NOTIFICATION_ID_2, '未読'),
+      ],
+      error: null,
+    }
+    readsState.result = {
+      data: [{ notification_id: NOTIFICATION_ID_1, read_at: '2026-06-05T01:00:00Z' }],
+      error: null,
+    }
+
+    const result = await getNotifications({ userId: USER_ID })
+
+    expect(from).toHaveBeenCalledWith('notifications')
+    expect(from).toHaveBeenCalledWith('notification_reads')
+    expect(notificationsState.orderCalls).toEqual([
+      { column: 'published_at', options: { ascending: false } },
+      { column: 'created_at', options: { ascending: false } },
+    ])
+    expect(readsState.eqCalls).toEqual([['user_id', USER_ID]])
+    expect(readsState.inCalls).toEqual([
+      ['notification_id', [NOTIFICATION_ID_1, NOTIFICATION_ID_2]],
+    ])
+    expect(result).toMatchObject([
+      { id: NOTIFICATION_ID_1, isRead: true, readAt: '2026-06-05T01:00:00Z' },
+      { id: NOTIFICATION_ID_2, isRead: false, readAt: null },
+    ])
+  })
+
+  it('通知がないときは既読状態を問い合わせず空配列を返す', async () => {
+    notificationsState.result = { data: [], error: null }
+    const result = await getNotifications({ userId: USER_ID })
+    expect(result).toEqual([])
+    expect(from).toHaveBeenCalledWith('notifications')
+    expect(from).not.toHaveBeenCalledWith('notification_reads')
+  })
+
+  it('limit は上限でクランプする', async () => {
+    await getNotifications({ userId: USER_ID, limit: 999 })
+    expect(notificationsState.limitCalls).toEqual([MAX_NOTIFICATION_LIST_LIMIT])
+  })
+
+  it('不正な userId は例外を投げる', async () => {
+    await expect(getNotifications({ userId: 'not-uuid' })).rejects.toThrow(
+      'userId must be a valid UUID',
+    )
+    expect(from).not.toHaveBeenCalled()
+  })
+
+  it('通知一覧の DB エラーを AppError に変換する', async () => {
+    notificationsState.result = {
+      data: null,
+      error: { code: 'DB_ERROR', message: 'rls denied' },
+    }
+    await expect(getNotifications({ userId: USER_ID })).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: 'お知らせ一覧の取得に失敗しました',
+    })
+  })
+
+  it('既読状態の DB エラーを AppError に変換する', async () => {
+    notificationsState.result = {
+      data: [notificationRow(NOTIFICATION_ID_1, 'title')],
+      error: null,
+    }
+    readsState.result = {
+      data: null,
+      error: { code: 'DB_ERROR', message: 'rls denied' },
+    }
+    await expect(getNotifications({ userId: USER_ID })).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: 'お知らせの既読状態の取得に失敗しました',
+    })
+  })
+})
+
+describe('getUnreadCount', () => {
+  beforeEach(resetState)
+
+  it('未読件数を返す', async () => {
+    notificationsState.result = {
+      data: [
+        notificationRow(NOTIFICATION_ID_1, '読んだ'),
+        notificationRow(NOTIFICATION_ID_2, '未読'),
+      ],
+      error: null,
+    }
+    readsState.result = {
+      data: [{ notification_id: NOTIFICATION_ID_1, read_at: '2026-06-05T01:00:00Z' }],
+      error: null,
+    }
+
+    await expect(getUnreadCount(USER_ID)).resolves.toBe(1)
+  })
+})
+
+describe('markAsRead', () => {
+  beforeEach(resetState)
+
+  it('notification_reads に upsert する', async () => {
+    await markAsRead(NOTIFICATION_ID_1, USER_ID)
+    expect(from).toHaveBeenCalledWith('notification_reads')
+    expect(readsState.upsertPayload).toEqual({
+      notification_id: NOTIFICATION_ID_1,
+      user_id: USER_ID,
+    })
+    expect(readsState.upsertOptions).toEqual({ onConflict: 'notification_id,user_id' })
+  })
+
+  it('不正な notificationId は例外を投げる', async () => {
+    await expect(markAsRead('bad', USER_ID)).rejects.toThrow(
+      'notificationId must be a valid UUID',
+    )
+    expect(from).not.toHaveBeenCalled()
+  })
+
+  it('DB エラーを AppError に変換する', async () => {
+    readsState.upsertResult = {
+      error: { code: 'DB_ERROR', message: 'rls denied' },
+    }
+    await expect(markAsRead(NOTIFICATION_ID_1, USER_ID)).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: 'お知らせを確認済みにできませんでした',
+    })
+  })
+})

--- a/apps/web/src/services/adminNotificationService.ts
+++ b/apps/web/src/services/adminNotificationService.ts
@@ -1,0 +1,90 @@
+import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+import { assertMaxLength, assertOneOf, assertUuid } from '../shared/validation'
+import {
+  MAX_NOTIFICATION_BODY_LENGTH,
+  MAX_NOTIFICATION_TITLE_LENGTH,
+  NOTIFICATION_TARGET_ROLES,
+  type Notification,
+  type NotificationTargetRole,
+  type NotificationType,
+} from './notificationService'
+
+export interface CreateAnnouncementInput {
+  adminId: string
+  title: string
+  body: string
+  targetRole: NotificationTargetRole
+}
+
+export interface CreateFeedbackNotificationInput {
+  adminId: string
+  feedbackId: string
+}
+
+function normalizeRequiredText(value: string, maxLength: number, name: string): string {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    throw new Error(`${name} must not be empty`)
+  }
+  assertMaxLength(trimmed, maxLength, name)
+  return trimmed
+}
+
+async function insertNotification(input: {
+  adminId: string
+  type: NotificationType
+  title: string
+  body: string
+  targetRole: NotificationTargetRole
+}): Promise<Notification> {
+  assertUuid(input.adminId, 'adminId')
+  assertOneOf(input.targetRole, NOTIFICATION_TARGET_ROLES, 'targetRole')
+
+  const title = normalizeRequiredText(input.title, MAX_NOTIFICATION_TITLE_LENGTH, 'title')
+  const body = normalizeRequiredText(input.body, MAX_NOTIFICATION_BODY_LENGTH, 'body')
+
+  const { data, error } = await supabase
+    .from('notifications')
+    .insert({
+      type: input.type,
+      title,
+      body,
+      target_role: input.targetRole,
+      created_by: input.adminId,
+    })
+    .select()
+    .single()
+
+  if (error) {
+    throw fromSupabaseError(error, 'お知らせの作成に失敗しました')
+  }
+
+  return data
+}
+
+/** 管理者が即時お知らせを作成する。予定送信は M1/MVP 対象外。 */
+export async function createAnnouncement(input: CreateAnnouncementInput): Promise<Notification> {
+  return insertNotification({
+    adminId: input.adminId,
+    type: 'announcement',
+    title: input.title,
+    body: input.body,
+    targetRole: input.targetRole,
+  })
+}
+
+/** 管理者向けのフィードバック到着通知を作成する。実際の投稿時連携は M3 で行う。 */
+export async function createFeedbackNotification(
+  input: CreateFeedbackNotificationInput,
+): Promise<Notification> {
+  assertUuid(input.feedbackId, 'feedbackId')
+
+  return insertNotification({
+    adminId: input.adminId,
+    type: 'feedback',
+    title: '新しいフィードバックが届きました',
+    body: `フィードバック ${input.feedbackId} が届きました。管理画面で詳細を確認してください。`,
+    targetRole: 'admin',
+  })
+}

--- a/apps/web/src/services/notificationService.ts
+++ b/apps/web/src/services/notificationService.ts
@@ -1,0 +1,116 @@
+import { supabase } from '../lib/supabaseClient'
+import { fromSupabaseError } from '../shared/errors'
+import { assertPositiveInteger, assertUuid } from '../shared/validation'
+import type { Tables } from '../shared/types/database.types'
+
+export type Notification = Tables<'notifications'>
+export type NotificationRead = Tables<'notification_reads'>
+
+export type NotificationType = 'announcement' | 'release' | 'event' | 'feedback' | 'system'
+export type NotificationTargetRole = 'all' | 'learner' | 'admin'
+
+export const NOTIFICATION_TYPES: ReadonlySet<string> = new Set([
+  'announcement',
+  'release',
+  'event',
+  'feedback',
+  'system',
+])
+
+export const NOTIFICATION_TARGET_ROLES: ReadonlySet<string> = new Set([
+  'all',
+  'learner',
+  'admin',
+])
+
+export const MAX_NOTIFICATION_TITLE_LENGTH = 120
+export const MAX_NOTIFICATION_BODY_LENGTH = 4000
+export const MAX_NOTIFICATION_LIST_LIMIT = 100
+
+export interface NotificationWithRead extends Notification {
+  readAt: string | null
+  isRead: boolean
+}
+
+export interface GetNotificationsInput {
+  userId: string
+  limit?: number
+}
+
+/** 自分に届く通知一覧を取得し、既読状態を合成する。 */
+export async function getNotifications(
+  input: GetNotificationsInput,
+): Promise<NotificationWithRead[]> {
+  assertUuid(input.userId, 'userId')
+
+  let notificationQuery = supabase
+    .from('notifications')
+    .select('*')
+    .order('published_at', { ascending: false })
+    .order('created_at', { ascending: false })
+
+  if (input.limit !== undefined) {
+    assertPositiveInteger(input.limit, 'limit')
+    notificationQuery = notificationQuery.limit(Math.min(input.limit, MAX_NOTIFICATION_LIST_LIMIT))
+  }
+
+  const { data: notifications, error } = await notificationQuery
+  if (error) {
+    throw fromSupabaseError(error, 'お知らせ一覧の取得に失敗しました')
+  }
+
+  const rows = notifications ?? []
+  if (rows.length === 0) {
+    return []
+  }
+
+  const notificationIds = rows.map((notification) => notification.id)
+  const { data: reads, error: readsError } = await supabase
+    .from('notification_reads')
+    .select('notification_id, read_at')
+    .eq('user_id', input.userId)
+    .in('notification_id', notificationIds)
+
+  if (readsError) {
+    throw fromSupabaseError(readsError, 'お知らせの既読状態の取得に失敗しました')
+  }
+
+  const readAtByNotificationId = new Map(
+    (reads ?? []).map((read) => [read.notification_id, read.read_at]),
+  )
+
+  return rows.map((notification) => {
+    const readAt = readAtByNotificationId.get(notification.id) ?? null
+    return {
+      ...notification,
+      readAt,
+      isRead: readAt !== null,
+    }
+  })
+}
+
+/** 自分宛て通知の未読件数を取得する。 */
+export async function getUnreadCount(userId: string): Promise<number> {
+  const notifications = await getNotifications({ userId })
+  return notifications.filter((notification) => !notification.isRead).length
+}
+
+/** 通知を既読にする。既に既読の場合も成功扱いにする。 */
+export async function markAsRead(notificationId: string, userId: string): Promise<void> {
+  assertUuid(notificationId, 'notificationId')
+  assertUuid(userId, 'userId')
+
+  const { error } = await supabase
+    .from('notification_reads')
+    .upsert(
+      {
+        notification_id: notificationId,
+        user_id: userId,
+      },
+      { onConflict: 'notification_id,user_id' },
+    )
+
+  if (error) {
+    throw fromSupabaseError(error, 'お知らせを確認済みにできませんでした')
+  }
+}

--- a/apps/web/src/shared/types/database.types.ts
+++ b/apps/web/src/shared/types/database.types.ts
@@ -155,6 +155,57 @@ export type Database = {
         }
         Relationships: []
       }
+      notification_reads: {
+        Row: {
+          notification_id: string
+          read_at: string
+          user_id: string
+        }
+        Insert: {
+          notification_id: string
+          read_at?: string
+          user_id: string
+        }
+        Update: {
+          notification_id?: string
+          read_at?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      notifications: {
+        Row: {
+          body: string
+          created_at: string
+          created_by: string | null
+          id: string
+          published_at: string
+          target_role: string
+          title: string
+          type: string
+        }
+        Insert: {
+          body: string
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          published_at?: string
+          target_role: string
+          title: string
+          type: string
+        }
+        Update: {
+          body?: string
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          published_at?: string
+          target_role?: string
+          title?: string
+          type?: string
+        }
+        Relationships: []
+      }
       point_history: {
         Row: {
           amount: number

--- a/apps/web/supabase/sql/023_notifications.sql
+++ b/apps/web/supabase/sql/023_notifications.sql
@@ -1,0 +1,117 @@
+-- v5roadmap06 M1: notifications / notification_reads foundation
+-- Run this in Supabase SQL Editor (または supabase db push)
+-- 目的:
+--   Coden のアプリ内通知を「ポスト / お知らせ」として扱うため、
+--   通知本体とユーザーごとの既読状態を分離して保存する。
+
+create table if not exists public.notifications (
+  id uuid primary key default gen_random_uuid(),
+  type text not null,
+  title text not null,
+  body text not null,
+  target_role text not null,
+  created_by uuid references auth.users(id) on delete set null,
+  published_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  constraint notifications_type_check check (
+    type in ('announcement', 'release', 'event', 'feedback', 'system')
+  ),
+  constraint notifications_target_role_check check (
+    target_role in ('all', 'learner', 'admin')
+  ),
+  constraint notifications_title_length_check check (char_length(title) between 1 and 120),
+  constraint notifications_body_length_check check (char_length(body) between 1 and 4000)
+);
+
+create table if not exists public.notification_reads (
+  notification_id uuid not null references public.notifications(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  read_at timestamptz not null default now(),
+  primary key (notification_id, user_id)
+);
+
+alter table public.notifications enable row level security;
+alter table public.notification_reads enable row level security;
+
+create index if not exists notifications_published_at_idx
+  on public.notifications (published_at desc);
+
+create index if not exists notifications_target_role_published_at_idx
+  on public.notifications (target_role, published_at desc);
+
+create index if not exists notification_reads_user_id_read_at_idx
+  on public.notification_reads (user_id, read_at desc);
+
+-- 配信対象に含まれるログインユーザーだけが通知を SELECT できる。
+-- learner は profiles.is_admin = false として扱い、判定は既存の public.is_admin() を使う。
+drop policy if exists notifications_select_visible on public.notifications;
+create policy notifications_select_visible on public.notifications
+  for select
+  using (
+    published_at <= now()
+    and (
+      target_role = 'all'
+      or (target_role = 'admin' and public.is_admin())
+      or (target_role = 'learner' and not public.is_admin())
+    )
+  );
+
+-- admin だけが通知を作成できる。created_by は呼び出しユーザー本人に固定する。
+drop policy if exists notifications_insert_admin on public.notifications;
+create policy notifications_insert_admin on public.notifications
+  for insert
+  with check (
+    public.is_admin()
+    and auth.uid() = created_by
+    and published_at <= now()
+  );
+
+-- MVP では通知本体の編集・削除は不可（UPDATE / DELETE ポリシー未定義）。
+
+-- 既読状態は本人だけが SELECT できる。
+drop policy if exists notification_reads_select_own on public.notification_reads;
+create policy notification_reads_select_own on public.notification_reads
+  for select
+  using (auth.uid() = user_id);
+
+-- 本人だけが自分の既読状態を作成できる。
+-- notification_id は自分が SELECT 可能な通知に限定する。
+drop policy if exists notification_reads_insert_own on public.notification_reads;
+create policy notification_reads_insert_own on public.notification_reads
+  for insert
+  with check (
+    auth.uid() = user_id
+    and exists (
+      select 1
+      from public.notifications n
+      where n.id = notification_id
+        and n.published_at <= now()
+        and (
+          n.target_role = 'all'
+          or (n.target_role = 'admin' and public.is_admin())
+          or (n.target_role = 'learner' and not public.is_admin())
+        )
+    )
+  );
+
+-- 既読時刻の再更新も本人のみ許可する。
+drop policy if exists notification_reads_update_own on public.notification_reads;
+create policy notification_reads_update_own on public.notification_reads
+  for update
+  using (auth.uid() = user_id)
+  with check (
+    auth.uid() = user_id
+    and exists (
+      select 1
+      from public.notifications n
+      where n.id = notification_id
+        and n.published_at <= now()
+        and (
+          n.target_role = 'all'
+          or (n.target_role = 'admin' and public.is_admin())
+          or (n.target_role = 'learner' and not public.is_admin())
+        )
+    )
+  );
+
+-- DELETE は誰も不可（ポリシー未定義）。


### PR DESCRIPTION
## Summary
- Add notifications and notification_reads SQL with RLS, indexes, and constraints for the Coden post/announcement MVP.
- Update Supabase database types for the new tables.
- Add user/admin notification services for list, unread count, mark-as-read, announcements, and feedback notification creation.
- Add service-layer tests for validation, RLS-facing query shapes, read-state merging, and error handling.

## Test plan
- cmd /c npm --workspace apps/web run typecheck
- cmd /c npm --workspace apps/web run lint
- cmd /c npm --workspace apps/web run test
- cmd /c npm --workspace apps/web run build
- pre-commit: lint, typecheck
- pre-push: test, build