### PR TITLE
feat: add notifications user UI

### DIFF
--- a/apps/web/src/features/dashboard/components/AppHeader.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeader.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
-import { Flame, Gem, Menu } from 'lucide-react'
+import { Flame, Gem, Mailbox, Menu } from 'lucide-react'
 import { useAuth } from '@/contexts/AuthContext'
 import { useFeedbackContext } from '@/contexts/FeedbackContext'
 import { useLearningContext } from '@/contexts/LearningContext'
+import { getUnreadCount, subscribeNotificationsUpdated } from '@/services/notificationService'
 import { AppHeaderDesktopNav } from './AppHeaderDesktopNav'
 import { AppHeaderMobileDrawer } from './AppHeaderMobileDrawer'
 
@@ -14,11 +15,13 @@ interface AppHeaderProps {
 
 export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
   const { stats } = useLearningContext()
-  const { isAdmin } = useAuth()
+  const { isAdmin, user } = useAuth()
   const { openFeedback } = useFeedbackContext()
   const location = useLocation()
   const [isDrawerOpen, setIsDrawerOpen] = useState(false)
+  const [unreadCount, setUnreadCount] = useState(0)
   const menuButtonRef = useRef<HTMLButtonElement>(null)
+  const userId = user?.id ?? null
 
   const closeDrawer = useCallback(() => {
     setIsDrawerOpen(false)
@@ -29,6 +32,34 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
   useEffect(() => {
     closeDrawer()
   }, [location.pathname, closeDrawer])
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function loadUnreadCount() {
+      if (!userId) {
+        setUnreadCount(0)
+        return
+      }
+
+      try {
+        const count = await getUnreadCount(userId)
+        if (!cancelled) setUnreadCount(count)
+      } catch {
+        if (!cancelled) setUnreadCount(0)
+      }
+    }
+
+    void loadUnreadCount()
+    const unsubscribe = subscribeNotificationsUpdated(() => {
+      void loadUnreadCount()
+    })
+
+    return () => {
+      cancelled = true
+      unsubscribe()
+    }
+  }, [userId])
 
   const navLinkClass = (active: boolean) =>
     `pb-1 ${active ? 'border-b-2 border-primary-mint text-slate-900' : 'text-slate-500 hover:text-slate-700'}`
@@ -61,6 +92,23 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
           <div className="hidden rounded-full border border-primary-mint/30 bg-secondary-bg px-3 py-1 text-xs font-semibold text-primary-dark sm:block">
             <Flame className="inline-block h-3.5 w-3.5" aria-hidden="true" /> {stats?.current_streak ?? 0}日連続
           </div>
+          <Link
+            to="/notifications"
+            className={`relative inline-flex h-10 w-10 items-center justify-center rounded-lg border text-slate-600 transition hover:bg-slate-50 ${
+              location.pathname.startsWith('/notifications')
+                ? 'border-primary-mint bg-secondary-bg text-primary-dark'
+                : 'border-slate-200 bg-white'
+            }`}
+            aria-label={unreadCount > 0 ? `お知らせ、未読 ${unreadCount} 件` : 'お知らせ'}
+            aria-current={location.pathname.startsWith('/notifications') ? 'page' : undefined}
+          >
+            <Mailbox className="h-5 w-5" aria-hidden="true" />
+            {unreadCount > 0 ? (
+              <span className="absolute -right-1 -top-1 rounded-full bg-rose-500 px-1.5 py-0.5 text-[10px] font-bold leading-none text-white shadow-sm">
+                新着
+              </span>
+            ) : null}
+          </Link>
           <div className="hidden text-sm font-medium text-slate-600 sm:block">{displayName}</div>
           <button
             className="hidden rounded-lg border border-slate-300 bg-white px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-50 md:block"
@@ -89,6 +137,7 @@ export function AppHeader({ displayName, onSignOut }: AppHeaderProps) {
         displayName={displayName}
         pathname={location.pathname}
         stats={stats}
+        unreadCount={unreadCount}
         isAdmin={isAdmin}
         openFeedback={openFeedback}
         onClose={closeDrawer}

--- a/apps/web/src/features/dashboard/components/AppHeaderMobileDrawer.tsx
+++ b/apps/web/src/features/dashboard/components/AppHeaderMobileDrawer.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react'
 import { Link } from 'react-router-dom'
-import { Flame, Gem, MessageSquarePlus, Shield, X } from 'lucide-react'
+import { Flame, Gem, Mailbox, MessageSquarePlus, Shield, X } from 'lucide-react'
 import { CATEGORIES } from '@/content/courseData'
 import type { LearningStats } from '@/services/statsService'
 import { PRACTICE_LINKS, TOP_NAV_LINKS } from './appHeaderLinks'
@@ -9,6 +9,7 @@ interface AppHeaderMobileDrawerProps {
   displayName: string
   pathname: string
   stats: LearningStats | null
+  unreadCount: number
   isAdmin: boolean
   openFeedback: () => void
   onClose: () => void
@@ -20,6 +21,7 @@ export function AppHeaderMobileDrawer({
   displayName,
   pathname,
   stats,
+  unreadCount,
   isAdmin,
   openFeedback,
   onClose,
@@ -127,6 +129,20 @@ export function AppHeaderMobileDrawer({
             aria-current={pathname === '/curriculum' ? 'page' : undefined}
           >
             カリキュラム
+          </Link>
+          <Link
+            to="/notifications"
+            className={drawerLinkClass(pathname.startsWith('/notifications'))}
+            aria-current={pathname.startsWith('/notifications') ? 'page' : undefined}
+            aria-label={unreadCount > 0 ? `お知らせ、未読 ${unreadCount} 件` : 'お知らせ'}
+          >
+            <Mailbox className="mr-2 h-4 w-4" aria-hidden="true" />
+            <span>お知らせ</span>
+            {unreadCount > 0 ? (
+              <span className="ml-auto rounded-full bg-rose-500 px-2 py-0.5 text-xs font-bold text-white">
+                新着
+              </span>
+            ) : null}
           </Link>
         </div>
 

--- a/apps/web/src/features/dashboard/components/__tests__/AppHeaderNotifications.test.tsx
+++ b/apps/web/src/features/dashboard/components/__tests__/AppHeaderNotifications.test.tsx
@@ -1,0 +1,100 @@
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AppHeader } from '../AppHeader'
+
+const testState = vi.hoisted(() => ({
+  getUnreadCountMock: vi.fn(),
+  notificationListener: null as (() => void) | null,
+}))
+
+vi.mock('@/contexts/LearningContext', () => ({
+  useLearningContext: () => ({
+    stats: {
+      total_points: 200,
+      current_streak: 5,
+    },
+  }),
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: { id: '11111111-1111-1111-1111-111111111111' },
+    isAdmin: false,
+  }),
+}))
+
+vi.mock('@/contexts/FeedbackContext', () => ({
+  useFeedbackContext: () => ({ openFeedback: vi.fn() }),
+}))
+
+vi.mock('@/services/notificationService', () => ({
+  getUnreadCount: (...args: unknown[]) => testState.getUnreadCountMock(...args),
+  subscribeNotificationsUpdated: (listener: () => void) => {
+    testState.notificationListener = listener
+    return () => {
+      testState.notificationListener = null
+    }
+  },
+}))
+
+function renderHeader(pathname = '/') {
+  return render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <AppHeader displayName="テストユーザー" onSignOut={() => undefined} />
+    </MemoryRouter>,
+  )
+}
+
+describe('AppHeader お知らせ入口', () => {
+  beforeEach(() => {
+    testState.getUnreadCountMock.mockReset()
+    testState.getUnreadCountMock.mockResolvedValue(0)
+    testState.notificationListener = null
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('デスクトップヘッダーにお知らせリンクを表示する', async () => {
+    renderHeader()
+
+    const link = await screen.findByRole('link', { name: 'お知らせ' })
+    expect(link.getAttribute('href')).toBe('/notifications')
+  })
+
+  it('未読がある場合は新着バッジを表示する', async () => {
+    testState.getUnreadCountMock.mockResolvedValue(3)
+    renderHeader()
+
+    expect(await screen.findByRole('link', { name: 'お知らせ、未読 3 件' })).toBeTruthy()
+    expect(screen.getByText('新着')).toBeTruthy()
+  })
+
+  it('通知更新イベントで未読件数を再取得する', async () => {
+    testState.getUnreadCountMock.mockResolvedValueOnce(0).mockResolvedValueOnce(2)
+    renderHeader()
+
+    await screen.findByRole('link', { name: 'お知らせ' })
+    testState.notificationListener?.()
+
+    expect(await screen.findByRole('link', { name: 'お知らせ、未読 2 件' })).toBeTruthy()
+    expect(testState.getUnreadCountMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('モバイルドロワーにもお知らせリンクと新着バッジを表示する', async () => {
+    testState.getUnreadCountMock.mockResolvedValue(1)
+    renderHeader()
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'お知らせ、未読 1 件' })).toBeTruthy()
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'メニューを開く' }))
+
+    const drawer = screen.getByRole('dialog', { name: 'モバイルナビゲーション' })
+    const link = within(drawer).getByRole('link', { name: 'お知らせ、未読 1 件' })
+    expect(link.getAttribute('href')).toBe('/notifications')
+    expect(within(drawer).getByText('新着')).toBeTruthy()
+  })
+})

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -31,6 +31,9 @@ const MiniProjectDetailPage = lazy(() =>
 const MiniProjectsPage = lazy(() =>
   import('./pages/MiniProjectsPage').then((m) => ({ default: m.MiniProjectsPage })),
 )
+const NotificationsPage = lazy(() =>
+  import('./pages/NotificationsPage').then((m) => ({ default: m.NotificationsPage })),
+)
 const BaseNookPage = lazy(() => import('./pages/BaseNookPage').then((m) => ({ default: m.BaseNookPage })))
 const BaseNookTopicPage = lazy(() =>
   import('./pages/BaseNookTopicPage').then((m) => ({ default: m.BaseNookTopicPage })),
@@ -129,6 +132,16 @@ const router = createBrowserRouter([
       <ProtectedRoute>
         <Suspense fallback={<PageLoading />}>
           <ProfilePage />
+        </Suspense>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/notifications',
+    element: (
+      <ProtectedRoute>
+        <Suspense fallback={<PageLoading />}>
+          <NotificationsPage />
         </Suspense>
       </ProtectedRoute>
     ),

--- a/apps/web/src/pages/NotificationsPage.tsx
+++ b/apps/web/src/pages/NotificationsPage.tsx
@@ -1,0 +1,185 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Check, Mailbox } from 'lucide-react'
+import { AppHeader } from '../features/dashboard/components/AppHeader'
+import { ConfigErrorView } from '../components/ConfigErrorView'
+import { ErrorBanner } from '../components/ErrorBanner'
+import { Spinner } from '../components/Spinner'
+import { useAuth } from '../contexts/AuthContext'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { useGreetingName } from '../hooks/useGreetingName'
+import { useSignOut } from '../hooks/useSignOut'
+import { supabaseConfigError } from '../lib/supabaseClient'
+import {
+  getNotifications,
+  markAsRead,
+  type NotificationType,
+  type NotificationWithRead,
+} from '../services/notificationService'
+import { formatDateTime } from '../shared/utils/dateTime'
+
+const NOTIFICATION_TYPE_LABELS: Record<NotificationType, string> = {
+  announcement: 'お知らせ',
+  release: 'リリース',
+  event: 'イベント',
+  feedback: 'フィードバック',
+  system: 'システム',
+}
+
+function getTypeLabel(type: string): string {
+  return NOTIFICATION_TYPE_LABELS[type as NotificationType] ?? 'お知らせ'
+}
+
+export function NotificationsPage() {
+  useDocumentTitle('ポスト')
+  const { user } = useAuth()
+  const userId = user?.id ?? null
+  const { greetingName } = useGreetingName()
+  const [notifications, setNotifications] = useState<NotificationWithRead[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [markingId, setMarkingId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const onSignOutError = useCallback((msg: string) => setError(msg), [])
+  const handleSignOut = useSignOut(onSignOutError)
+
+  const loadNotifications = useCallback(async () => {
+    if (!userId || supabaseConfigError) {
+      setNotifications([])
+      setIsLoading(false)
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+    try {
+      const rows = await getNotifications({ userId })
+      setNotifications(rows)
+    } catch (loadError) {
+      const message = loadError instanceof Error ? loadError.message : 'お知らせ一覧の取得に失敗しました'
+      setError(message)
+      setNotifications([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [userId])
+
+  useEffect(() => {
+    void loadNotifications()
+  }, [loadNotifications])
+
+  async function handleMarkAsRead(notificationId: string) {
+    if (!userId) {
+      return
+    }
+
+    setMarkingId(notificationId)
+    setError(null)
+    try {
+      await markAsRead(notificationId, userId)
+      setNotifications((current) =>
+        current.map((notification) =>
+          notification.id === notificationId
+            ? { ...notification, isRead: true, readAt: notification.readAt ?? new Date().toISOString() }
+            : notification,
+        ),
+      )
+    } catch (markError) {
+      const message = markError instanceof Error ? markError.message : 'お知らせを確認済みにできませんでした'
+      setError(message)
+    } finally {
+      setMarkingId(null)
+    }
+  }
+
+  const unreadCount = notifications.filter((notification) => !notification.isRead).length
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50">
+      <AppHeader displayName={greetingName} onSignOut={() => void handleSignOut()} />
+
+      <main className="mx-auto w-full max-w-5xl px-4 py-8 sm:px-6 lg:px-8">
+        {supabaseConfigError ? <ConfigErrorView message={supabaseConfigError} /> : null}
+        {error ? <ErrorBanner className="mb-4">{error}</ErrorBanner> : null}
+
+        <header className="mb-6 flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-2 text-primary-dark">
+              <Mailbox className="h-5 w-5" aria-hidden="true" />
+              <p className="text-xs font-semibold uppercase tracking-wide">Post</p>
+            </div>
+            <h1 className="mt-2 text-3xl font-bold text-slate-900">ポスト</h1>
+          </div>
+          <div className="rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-semibold text-slate-700 shadow-sm">
+            新着 {unreadCount} 件
+          </div>
+        </header>
+
+        <section className="space-y-3" aria-label="お知らせ一覧">
+          {isLoading ? (
+            <div className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+              <Spinner label="お知らせを読み込み中..." />
+            </div>
+          ) : null}
+
+          {!isLoading && notifications.length === 0 ? (
+            <div className="rounded-lg border border-dashed border-slate-300 bg-white p-8 text-center shadow-sm">
+              <Mailbox className="mx-auto h-9 w-9 text-slate-400" aria-hidden="true" />
+              <p className="mt-3 text-sm font-semibold text-slate-700">
+                まだ届いているお知らせはありません
+              </p>
+            </div>
+          ) : null}
+
+          {!isLoading && notifications.map((notification) => {
+            const isMarking = markingId === notification.id
+            return (
+              <article
+                key={notification.id}
+                className={`rounded-lg border bg-white p-5 shadow-sm ${
+                  notification.isRead ? 'border-slate-200' : 'border-primary-mint/50'
+                }`}
+              >
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="mb-2 flex flex-wrap items-center gap-2">
+                      <span className="rounded-full bg-secondary-bg px-2 py-0.5 text-xs font-bold text-primary-dark">
+                        {getTypeLabel(notification.type)}
+                      </span>
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-xs font-bold ${
+                          notification.isRead
+                            ? 'bg-slate-100 text-slate-500'
+                            : 'bg-rose-50 text-rose-600'
+                        }`}
+                      >
+                        {notification.isRead ? '確認済み' : '新着'}
+                      </span>
+                      <time className="text-xs text-slate-500" dateTime={notification.published_at}>
+                        {formatDateTime(notification.published_at)}
+                      </time>
+                    </div>
+                    <h2 className="text-lg font-bold text-slate-900">{notification.title}</h2>
+                    <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-slate-600">
+                      {notification.body}
+                    </p>
+                  </div>
+
+                  {!notification.isRead ? (
+                    <button
+                      type="button"
+                      onClick={() => void handleMarkAsRead(notification.id)}
+                      disabled={isMarking}
+                      className="inline-flex min-h-[40px] items-center gap-1.5 rounded-lg border border-primary-mint bg-white px-3 py-2 text-sm font-semibold text-primary-dark transition hover:bg-secondary-bg disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      <Check className="h-4 w-4" aria-hidden="true" />
+                      {isMarking ? '処理中...' : '確認済みにする'}
+                    </button>
+                  ) : null}
+                </div>
+              </article>
+            )
+          })}
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/apps/web/src/pages/__tests__/NotificationsPage.test.tsx
+++ b/apps/web/src/pages/__tests__/NotificationsPage.test.tsx
@@ -1,0 +1,131 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { NotificationsPage } from '../NotificationsPage'
+import type { NotificationWithRead } from '@/services/notificationService'
+
+const testState = vi.hoisted(() => ({
+  getNotificationsMock: vi.fn(),
+  markAsReadMock: vi.fn(),
+}))
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: () => ({
+    user: {
+      id: '11111111-1111-1111-1111-111111111111',
+      email: 'tester@example.com',
+      user_metadata: {},
+    },
+    signOut: vi.fn(),
+  }),
+}))
+
+vi.mock('@/hooks/useGreetingName', () => ({
+  useGreetingName: () => ({ greetingName: 'テストユーザー' }),
+}))
+
+vi.mock('@/hooks/useSignOut', () => ({
+  useSignOut: () => vi.fn(),
+}))
+
+vi.mock('@/features/dashboard/components/AppHeader', () => ({
+  AppHeader: ({ displayName }: { displayName: string }) => <header>{displayName} header</header>,
+}))
+
+vi.mock('@/lib/supabaseClient', () => ({
+  supabaseConfigError: null,
+}))
+
+vi.mock('@/services/notificationService', () => ({
+  getNotifications: (...args: unknown[]) => testState.getNotificationsMock(...args),
+  markAsRead: (...args: unknown[]) => testState.markAsReadMock(...args),
+}))
+
+const USER_ID = '11111111-1111-1111-1111-111111111111'
+const NOTIFICATION_ID = '22222222-2222-2222-2222-222222222222'
+
+function createNotification(overrides: Partial<NotificationWithRead> = {}): NotificationWithRead {
+  return {
+    id: NOTIFICATION_ID,
+    type: 'announcement',
+    title: 'メンテナンスのお知らせ',
+    body: '明日の朝に短いメンテナンスがあります。',
+    target_role: 'all',
+    created_by: null,
+    published_at: '2026-06-05T00:00:00Z',
+    created_at: '2026-06-05T00:00:00Z',
+    readAt: null,
+    isRead: false,
+    ...overrides,
+  }
+}
+
+describe('NotificationsPage', () => {
+  beforeEach(() => {
+    testState.getNotificationsMock.mockReset()
+    testState.getNotificationsMock.mockResolvedValue([])
+    testState.markAsReadMock.mockReset()
+    testState.markAsReadMock.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('空状態を表示する', async () => {
+    render(<NotificationsPage />)
+
+    expect(await screen.findByText('まだ届いているお知らせはありません')).toBeTruthy()
+    expect(testState.getNotificationsMock).toHaveBeenCalledWith({ userId: USER_ID })
+  })
+
+  it('通知一覧と未読件数を表示する', async () => {
+    testState.getNotificationsMock.mockResolvedValue([
+      createNotification(),
+      createNotification({
+        id: '33333333-3333-3333-3333-333333333333',
+        title: '確認済みのお知らせ',
+        readAt: '2026-06-05T01:00:00Z',
+        isRead: true,
+      }),
+    ])
+
+    render(<NotificationsPage />)
+
+    expect(await screen.findByText('メンテナンスのお知らせ')).toBeTruthy()
+    expect(screen.getByText('確認済みのお知らせ')).toBeTruthy()
+    expect(screen.getByText('新着 1 件')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /確認済みにする/ })).toBeTruthy()
+  })
+
+  it('未読通知を確認済みにできる', async () => {
+    testState.getNotificationsMock.mockResolvedValue([createNotification()])
+    render(<NotificationsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /確認済みにする/ }))
+
+    await waitFor(() => {
+      expect(testState.markAsReadMock).toHaveBeenCalledWith(NOTIFICATION_ID, USER_ID)
+    })
+    expect(screen.getByText('新着 0 件')).toBeTruthy()
+    expect(screen.getByText('確認済み')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: /確認済みにする/ })).toBeNull()
+  })
+
+  it('取得エラーを表示する', async () => {
+    testState.getNotificationsMock.mockRejectedValue(new Error('お知らせ一覧の取得に失敗しました'))
+    render(<NotificationsPage />)
+
+    expect(await screen.findByText('お知らせ一覧の取得に失敗しました')).toBeTruthy()
+  })
+
+  it('既読化エラーを表示する', async () => {
+    testState.getNotificationsMock.mockResolvedValue([createNotification()])
+    testState.markAsReadMock.mockRejectedValue(new Error('お知らせを確認済みにできませんでした'))
+    render(<NotificationsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /確認済みにする/ }))
+
+    expect(await screen.findByText('お知らせを確認済みにできませんでした')).toBeTruthy()
+    expect(screen.getByText('新着 1 件')).toBeTruthy()
+  })
+})

--- a/apps/web/src/services/notificationService.ts
+++ b/apps/web/src/services/notificationService.ts
@@ -26,6 +26,7 @@ export const NOTIFICATION_TARGET_ROLES: ReadonlySet<string> = new Set([
 export const MAX_NOTIFICATION_TITLE_LENGTH = 120
 export const MAX_NOTIFICATION_BODY_LENGTH = 4000
 export const MAX_NOTIFICATION_LIST_LIMIT = 100
+export const NOTIFICATIONS_UPDATED_EVENT = 'coden:notifications-updated'
 
 export interface NotificationWithRead extends Notification {
   readAt: string | null
@@ -35,6 +36,18 @@ export interface NotificationWithRead extends Notification {
 export interface GetNotificationsInput {
   userId: string
   limit?: number
+}
+
+function isBrowserEnvironment() {
+  return typeof window !== 'undefined'
+}
+
+function notifyNotificationsUpdated() {
+  if (!isBrowserEnvironment()) {
+    return
+  }
+
+  window.dispatchEvent(new CustomEvent(NOTIFICATIONS_UPDATED_EVENT))
 }
 
 /** 自分に届く通知一覧を取得し、既読状態を合成する。 */
@@ -113,4 +126,15 @@ export async function markAsRead(notificationId: string, userId: string): Promis
   if (error) {
     throw fromSupabaseError(error, 'お知らせを確認済みにできませんでした')
   }
+
+  notifyNotificationsUpdated()
+}
+
+export function subscribeNotificationsUpdated(onChange: () => void): () => void {
+  if (!isBrowserEnvironment()) {
+    return () => {}
+  }
+
+  window.addEventListener(NOTIFICATIONS_UPDATED_EVENT, onChange)
+  return () => window.removeEventListener(NOTIFICATIONS_UPDATED_EVENT, onChange)
 }


### PR DESCRIPTION
## Summary
- Add the Mailbox-based お知らせ entry point to the app header with unread 新着 badge support.
- Add /notifications as the ポスト page with loading, error, empty, unread/read states, and mark-as-read actions.
- Add notification update event wiring so marking a notice as read refreshes the header unread count.
- Add page and header tests for unread badges, empty state, list rendering, and read handling.

## Test plan
- cmd /c npm --workspace apps/web run typecheck
- cmd /c npm --workspace apps/web run lint
- cmd /c npm --workspace apps/web run test
- cmd /c npm --workspace apps/web run build
- pre-commit: lint, typecheck
- pre-push: test, build

Note: Browser visual confirmation was intentionally left to the requester per handoff.