### PR TITLE
feat: add admin notifications send flow

### DIFF
--- a/apps/web/src/features/admin/components/AdminLayout.tsx
+++ b/apps/web/src/features/admin/components/AdminLayout.tsx
@@ -19,6 +19,7 @@ const ADMIN_LINKS: readonly AdminLink[] = [
   { to: '/admin/quality', label: '品質ダッシュボード' },
   { to: '/admin/step-insights', label: 'Step Insights' },
   { to: '/admin/feedback', label: 'フィードバック' },
+  { to: '/admin/notifications', label: 'お知らせ' },
   { to: '/admin/users', label: 'ユーザー' },
   { to: '/admin/stats', label: '統計' },
   { to: '/admin/ops', label: '運用' },

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -51,6 +51,9 @@ const AdminFeedbackListPage = lazy(() =>
 const AdminFeedbackDetailPage = lazy(() =>
   import('./pages/admin/AdminFeedbackDetailPage').then((m) => ({ default: m.AdminFeedbackDetailPage })),
 )
+const AdminNotificationsPage = lazy(() =>
+  import('./pages/admin/AdminNotificationsPage').then((m) => ({ default: m.AdminNotificationsPage })),
+)
 const AdminUsersPage = lazy(() =>
   import('./pages/admin/AdminUsersPage').then((m) => ({ default: m.AdminUsersPage })),
 )
@@ -257,6 +260,18 @@ const router = createBrowserRouter([
         <AdminGuard>
           <Suspense fallback={<PageLoading />}>
             <AdminFeedbackDetailPage />
+          </Suspense>
+        </AdminGuard>
+      </ProtectedRoute>
+    ),
+  },
+  {
+    path: '/admin/notifications',
+    element: (
+      <ProtectedRoute>
+        <AdminGuard>
+          <Suspense fallback={<PageLoading />}>
+            <AdminNotificationsPage />
           </Suspense>
         </AdminGuard>
       </ProtectedRoute>

--- a/apps/web/src/pages/admin/AdminNotificationsPage.tsx
+++ b/apps/web/src/pages/admin/AdminNotificationsPage.tsx
@@ -1,0 +1,208 @@
+import { useState } from 'react'
+import { AlertCircle, CheckCircle2, Loader2, Send } from 'lucide-react'
+import { AdminLayout } from '../../features/admin/components/AdminLayout'
+import { useAuth } from '../../contexts/AuthContext'
+import { useDocumentTitle } from '../../hooks/useDocumentTitle'
+import {
+  createAnnouncement,
+  type CreateAnnouncementInput,
+} from '../../services/adminNotificationService'
+import {
+  MAX_NOTIFICATION_BODY_LENGTH,
+  MAX_NOTIFICATION_TITLE_LENGTH,
+  type NotificationTargetRole,
+} from '../../services/notificationService'
+
+type Feedback =
+  | { kind: 'idle' }
+  | { kind: 'success'; message: string }
+  | { kind: 'error'; message: string }
+
+const TARGET_ROLE_OPTIONS: ReadonlyArray<{
+  value: NotificationTargetRole
+  label: string
+}> = [
+  { value: 'all', label: '全ユーザー' },
+  { value: 'learner', label: '学習者' },
+  { value: 'admin', label: '管理者' },
+]
+
+export function AdminNotificationsPage() {
+  useDocumentTitle('お知らせ送信 - 管理画面')
+  const { user } = useAuth()
+  const adminId = user?.id ?? null
+  const [title, setTitle] = useState('')
+  const [body, setBody] = useState('')
+  const [targetRole, setTargetRole] = useState<NotificationTargetRole>('all')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [feedback, setFeedback] = useState<Feedback>({ kind: 'idle' })
+
+  const trimmedTitle = title.trim()
+  const trimmedBody = body.trim()
+  const canSubmit =
+    Boolean(adminId) &&
+    !isSubmitting &&
+    trimmedTitle.length > 0 &&
+    trimmedTitle.length <= MAX_NOTIFICATION_TITLE_LENGTH &&
+    trimmedBody.length > 0 &&
+    trimmedBody.length <= MAX_NOTIFICATION_BODY_LENGTH
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    if (!canSubmit || !adminId) return
+
+    setIsSubmitting(true)
+    setFeedback({ kind: 'idle' })
+    try {
+      const input: CreateAnnouncementInput = {
+        adminId,
+        title: trimmedTitle,
+        body: trimmedBody,
+        targetRole,
+      }
+      await createAnnouncement(input)
+      setFeedback({ kind: 'success', message: 'お知らせを送信しました' })
+      setTitle('')
+      setBody('')
+      setTargetRole('all')
+    } catch (error) {
+      setFeedback({
+        kind: 'error',
+        message: error instanceof Error ? error.message : 'お知らせの作成に失敗しました',
+      })
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <AdminLayout>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-slate-900">お知らせを送る</h1>
+        <p className="mt-1 text-sm text-slate-500">
+          Coden のポストに届くアプリ内お知らせを即時送信します。
+        </p>
+      </div>
+
+      <form
+        onSubmit={(event) => void handleSubmit(event)}
+        className="max-w-3xl rounded-lg border border-slate-200 bg-white p-5 shadow-sm"
+      >
+        <FormFeedback feedback={feedback} />
+
+        <div className="mt-4 grid gap-4">
+          <div>
+            <label htmlFor="notification-title" className="mb-1 block text-xs font-semibold text-slate-600">
+              タイトル
+            </label>
+            <input
+              id="notification-title"
+              type="text"
+              value={title}
+              maxLength={MAX_NOTIFICATION_TITLE_LENGTH}
+              onChange={(event) => setTitle(event.target.value)}
+              className="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 shadow-sm focus:border-primary-mint focus:outline-none focus:ring-1 focus:ring-primary-mint"
+              required
+            />
+            <p className="mt-1 text-xs text-slate-400">
+              {trimmedTitle.length} / {MAX_NOTIFICATION_TITLE_LENGTH}
+            </p>
+          </div>
+
+          <div>
+            <label htmlFor="notification-body" className="mb-1 block text-xs font-semibold text-slate-600">
+              本文
+            </label>
+            <textarea
+              id="notification-body"
+              value={body}
+              maxLength={MAX_NOTIFICATION_BODY_LENGTH}
+              onChange={(event) => setBody(event.target.value)}
+              rows={8}
+              className="w-full resize-y rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm leading-6 text-slate-800 shadow-sm focus:border-primary-mint focus:outline-none focus:ring-1 focus:ring-primary-mint"
+              required
+            />
+            <p className="mt-1 text-xs text-slate-400">
+              {trimmedBody.length} / {MAX_NOTIFICATION_BODY_LENGTH}
+            </p>
+          </div>
+
+          <fieldset>
+            <legend className="mb-2 block text-xs font-semibold text-slate-600">配信範囲</legend>
+            <div className="flex flex-wrap gap-2">
+              {TARGET_ROLE_OPTIONS.map((option) => (
+                <label
+                  key={option.value}
+                  className={`inline-flex min-h-[40px] cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-sm font-semibold transition ${
+                    targetRole === option.value
+                      ? 'border-primary-mint bg-secondary-bg text-primary-dark'
+                      : 'border-slate-200 bg-white text-slate-600 hover:bg-slate-50'
+                  }`}
+                >
+                  <input
+                    type="radio"
+                    name="target-role"
+                    value={option.value}
+                    checked={targetRole === option.value}
+                    onChange={() => setTargetRole(option.value)}
+                    className="h-4 w-4 accent-primary-mint"
+                  />
+                  {option.label}
+                </label>
+              ))}
+            </div>
+          </fieldset>
+
+          <div>
+            <label htmlFor="notification-send-time" className="mb-1 block text-xs font-semibold text-slate-600">
+              送信時刻
+            </label>
+            <input
+              id="notification-send-time"
+              type="text"
+              value="即時送信"
+              readOnly
+              className="w-full rounded-lg border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-semibold text-slate-600"
+            />
+          </div>
+        </div>
+
+        <div className="mt-5 flex justify-end">
+          <button
+            type="submit"
+            disabled={!canSubmit}
+            className="inline-flex min-h-[44px] items-center gap-2 rounded-lg bg-slate-800 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isSubmitting ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <Send className="h-4 w-4" aria-hidden="true" />
+            )}
+            {isSubmitting ? '送信中...' : 'お知らせを送る'}
+          </button>
+        </div>
+      </form>
+    </AdminLayout>
+  )
+}
+
+function FormFeedback({ feedback }: { feedback: Feedback }) {
+  if (feedback.kind === 'idle') return null
+  if (feedback.kind === 'success') {
+    return (
+      <div role="status" className="mb-4 flex items-start gap-2 rounded-lg border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700">
+        <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+        <p>{feedback.message}</p>
+      </div>
+    )
+  }
+  return (
+    <div
+      role="alert"
+      className="mb-4 flex items-start gap-2 rounded-lg border border-rose-200 bg-rose-50 p-3 text-sm text-rose-700"
+    >
+      <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+      <p>{feedback.message}</p>
+    </div>
+  )
+}

--- a/apps/web/src/pages/admin/__tests__/AdminNotificationsPage.test.tsx
+++ b/apps/web/src/pages/admin/__tests__/AdminNotificationsPage.test.tsx
@@ -1,0 +1,114 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const testState = vi.hoisted(() => ({
+  createAnnouncementMock: vi.fn(),
+  authValue: {
+    user: { id: '11111111-1111-1111-1111-111111111111' },
+  },
+}))
+
+vi.mock('../../../features/admin/components/AdminLayout', () => ({
+  AdminLayout: ({ children }: { children: React.ReactNode }) => <div data-testid="admin-layout">{children}</div>,
+}))
+
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => testState.authValue,
+}))
+
+vi.mock('../../../hooks/useDocumentTitle', () => ({
+  useDocumentTitle: () => undefined,
+}))
+
+vi.mock('../../../services/adminNotificationService', () => ({
+  createAnnouncement: (...args: unknown[]) => testState.createAnnouncementMock(...args),
+}))
+
+import { AdminNotificationsPage } from '../AdminNotificationsPage'
+
+const ADMIN_ID = '11111111-1111-1111-1111-111111111111'
+
+function renderPage() {
+  return render(<AdminNotificationsPage />)
+}
+
+describe('AdminNotificationsPage', () => {
+  beforeEach(() => {
+    testState.createAnnouncementMock.mockReset()
+    testState.createAnnouncementMock.mockResolvedValue({
+      id: '22222222-2222-2222-2222-222222222222',
+    })
+    testState.authValue = {
+      user: { id: ADMIN_ID },
+    }
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('お知らせ送信フォームを表示する', () => {
+    renderPage()
+
+    expect(screen.getByRole('heading', { name: 'お知らせを送る' })).toBeTruthy()
+    expect(screen.getByLabelText('タイトル')).toBeTruthy()
+    expect(screen.getByLabelText('本文')).toBeTruthy()
+    expect(screen.getByLabelText('送信時刻')).toHaveProperty('value', '即時送信')
+    expect(screen.getByLabelText('全ユーザー')).toHaveProperty('checked', true)
+  })
+
+  it('タイトルと本文が空のときは送信できない', () => {
+    renderPage()
+
+    expect(screen.getByRole('button', { name: 'お知らせを送る' })).toHaveProperty('disabled', true)
+  })
+
+  it('入力値を trim して createAnnouncement を呼ぶ', async () => {
+    renderPage()
+
+    fireEvent.change(screen.getByLabelText('タイトル'), { target: { value: '  リリースのお知らせ  ' } })
+    fireEvent.change(screen.getByLabelText('本文'), { target: { value: '  新しい機能を公開しました  ' } })
+    fireEvent.click(screen.getByLabelText('学習者'))
+    fireEvent.click(screen.getByRole('button', { name: 'お知らせを送る' }))
+
+    await waitFor(() => {
+      expect(testState.createAnnouncementMock).toHaveBeenCalledWith({
+        adminId: ADMIN_ID,
+        title: 'リリースのお知らせ',
+        body: '新しい機能を公開しました',
+        targetRole: 'learner',
+      })
+    })
+    expect(await screen.findByText('お知らせを送信しました')).toBeTruthy()
+    expect(screen.getByLabelText('タイトル')).toHaveProperty('value', '')
+    expect(screen.getByLabelText('本文')).toHaveProperty('value', '')
+    expect(screen.getByLabelText('全ユーザー')).toHaveProperty('checked', true)
+  })
+
+  it('管理者向け配信を選択できる', async () => {
+    renderPage()
+
+    fireEvent.change(screen.getByLabelText('タイトル'), { target: { value: 'admin title' } })
+    fireEvent.change(screen.getByLabelText('本文'), { target: { value: 'admin body' } })
+    fireEvent.click(screen.getByLabelText('管理者'))
+    fireEvent.click(screen.getByRole('button', { name: 'お知らせを送る' }))
+
+    await waitFor(() => {
+      expect(testState.createAnnouncementMock).toHaveBeenCalledWith(
+        expect.objectContaining({ targetRole: 'admin' }),
+      )
+    })
+  })
+
+  it('送信エラーを alert で表示する', async () => {
+    testState.createAnnouncementMock.mockRejectedValue(new Error('お知らせの作成に失敗しました'))
+    renderPage()
+
+    fireEvent.change(screen.getByLabelText('タイトル'), { target: { value: 'title' } })
+    fireEvent.change(screen.getByLabelText('本文'), { target: { value: 'body' } })
+    fireEvent.click(screen.getByRole('button', { name: 'お知らせを送る' }))
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('お知らせの作成に失敗しました')
+  })
+})

--- a/apps/web/src/services/adminNotificationService.ts
+++ b/apps/web/src/services/adminNotificationService.ts
@@ -74,7 +74,10 @@ export async function createAnnouncement(input: CreateAnnouncementInput): Promis
   })
 }
 
-/** 管理者向けのフィードバック到着通知を作成する。実際の投稿時連携は M3 で行う。 */
+/**
+ * 管理者向けのフィードバック到着通知を作成する。
+ * 通常の user_feedback 投稿時通知は DB トリガーで作成する。
+ */
 export async function createFeedbackNotification(
   input: CreateFeedbackNotificationInput,
 ): Promise<Notification> {

--- a/apps/web/supabase/sql/024_feedback_notification_trigger.sql
+++ b/apps/web/supabase/sql/024_feedback_notification_trigger.sql
@@ -1,0 +1,36 @@
+-- v5roadmap06 M3: feedback-created admin notification trigger
+-- Run this in Supabase SQL Editor (または supabase db push)
+-- 目的:
+--   学習者が user_feedback を作成したとき、admin 宛ての notifications を自動作成する。
+--   通知本文にはフィードバック本文を含めず、詳細画面への導線だけを持たせる。
+
+create or replace function public.create_feedback_notification()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.notifications (
+    type,
+    title,
+    body,
+    target_role,
+    created_by
+  )
+  values (
+    'feedback',
+    '新しいフィードバックが届きました',
+    'ユーザーから新しいフィードバックが届きました。管理画面で詳細を確認してください: /admin/feedback/' || new.id,
+    'admin',
+    null
+  );
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_user_feedback_create_notification on public.user_feedback;
+create trigger trg_user_feedback_create_notification
+  after insert on public.user_feedback
+  for each row execute function public.create_feedback_notification();


### PR DESCRIPTION
## Summary
- Add a DB trigger that creates admin-targeted feedback notifications when user_feedback rows are inserted.
- Add /admin/notifications with an immediate announcement form for all users, learners, or admins.
- Add the admin navigation entry and protected route for the notifications admin page.
- Add tests for the admin notification send form.

## Test plan
- cmd /c npm --workspace apps/web run typecheck
- cmd /c npm --workspace apps/web run lint
- cmd /c npm --workspace apps/web run test
- cmd /c npm --workspace apps/web run build
- pre-commit: lint, typecheck
- pre-push: build, test

## SQL
- Apply apps/web/supabase/sql/024_feedback_notification_trigger.sql after merge.