### PR TITLE
test: v1.0 E2E基盤と主要シナリオを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,13 @@ docs/qa/
 apps/web/docs/
 .playwright-mcp/
 
+# Playwright E2E 成果物
+apps/web/e2e/.auth/
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/
+
 # Supabase ローカル seed（実パスワードを含むため Git 管理外）
 # .example のみ管理下、実ファイル（.sql）は環境ごとに作成する
 apps/web/supabase/sql/local/*

--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -1,0 +1,46 @@
+# Coden E2E（Playwright）
+
+`docs/usertest/Utest-e2e.md` の仕様に基づく E2E テスト。
+
+## 前提
+
+1. `apps/web/.env.local` に有効な `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` が設定済み。
+2. テストアカウントが投入済み（`apps/web/supabase/sql/025_seed_e2e_accounts.sql`）。
+   - `e2e-general@coden.dev` / `e2e-admin@coden.dev` / `e2e-complete@coden.dev`（PW: `TestPass123!`）
+3. ブラウザ導入: `npx playwright install chromium`
+
+## 実行
+
+```bash
+npm run e2e          # ヘッドレス実行
+npm run e2e:ui       # UI モードで実行
+npm run e2e:report   # 直近のレポートを開く
+```
+
+`playwright.config.ts` の `webServer` が `npm run dev` を自動起動する（既存サーバーがあれば再利用）。
+
+## 構成
+
+| ファイル | 内容 |
+|----------|------|
+| `auth.setup.ts` | 各アカウントで UI ログインし `storageState` を生成（setup プロジェクト） |
+| `fixtures/accounts.ts` | アカウント定義（環境変数で上書き可） |
+| `auth.spec.ts` | S-AUTH 認証・ルートガード |
+| `nav.spec.ts` | S-NAV ヘッダー/ナビゲーション |
+| `.auth/` | 生成された storageState（Git 管理外） |
+
+## 方針（RuleOps/testing.md 準拠）
+
+- 共有アカウント前提のため `workers: 1`（直列）。
+- セレクタは `getByRole` / `getByLabel` / `getByText` を優先。
+- 認証が必要な spec は `test.use({ storageState })` で状態を再利用する。
+- アカウント認証情報は環境変数（`E2E_*`）で上書き可能。
+
+## アカウント認証情報の上書き
+
+```bash
+# 例（PowerShell）
+$env:E2E_PASSWORD = "..."
+$env:E2E_GENERAL_EMAIL = "..."
+npm run e2e
+```

--- a/apps/web/e2e/admin-write.spec.ts
+++ b/apps/web/e2e/admin-write.spec.ts
@@ -1,0 +1,81 @@
+import { test, expect, type Page } from '@playwright/test'
+import { accounts } from './fixtures/accounts'
+
+// 管理者の書き込み系（admin アカウント）。送信・更新と反映/永続を検証する。
+// 投稿/送信データは一意接頭辞（pw-notif- / 既存フィードバック）を使う。
+// is_admin=true のアカウントが無い環境では enterAdmin が自動スキップする。
+async function enterAdmin(page: Page) {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'カリキュラム' }).click()
+  const adminItem = page.getByRole('menuitem', { name: '管理画面' })
+  const available = await adminItem
+    .waitFor({ state: 'visible', timeout: 8000 })
+    .then(() => true)
+    .catch(() => false)
+  test.skip(!available, 'is_admin=true のアカウントが必要（提供アカウントが管理者でない/未シード）')
+  await adminItem.click()
+  await expect(page).toHaveURL('/admin')
+}
+
+test.describe('S-ADMIN 書き込み（認証済み・admin）', () => {
+  test.use({ storageState: accounts.admin.storageState })
+
+  test('PW-ADMIN-03 お知らせを送信するとユーザーのポストに反映される', async ({ page, browser }) => {
+    await enterAdmin(page)
+    const base = new URL(page.url()).origin
+
+    // ヘッダーの Mailbox リンク（/notifications）と名前が衝突するため、管理ナビは href で一意指定する
+    await page.locator('a[href="/admin/notifications"]').click()
+    await expect(page.getByRole('heading', { name: 'お知らせを送る', level: 1 })).toBeVisible()
+
+    const title = `pw-notif-${Date.now()}`
+    await page.getByLabel('タイトル').fill(title)
+    await page.getByLabel('本文').fill('E2E 自動送信テスト本文')
+    // 配信範囲は既定の「全ユーザー」のまま（learner の general も受信できる）
+    await page.getByRole('button', { name: 'お知らせを送る' }).click()
+    await expect(page.getByText('お知らせを送信しました')).toBeVisible()
+
+    // 別アカウント（general）の /notifications に反映を確認する
+    const generalContext = await browser.newContext({ storageState: accounts.general.storageState })
+    try {
+      const generalPage = await generalContext.newPage()
+      await generalPage.goto(`${base}/notifications`)
+      await expect(generalPage.getByText(title)).toBeVisible()
+    } finally {
+      await generalContext.close()
+    }
+  })
+
+  test('PW-ADMIN-02 フィードバックのステータスを更新し、再読込後も残存する', async ({ page }) => {
+    await enterAdmin(page)
+    await page.getByRole('link', { name: 'フィードバック', exact: true }).click()
+    await expect(page.getByRole('heading', { name: 'フィードバック一覧', level: 1 })).toBeVisible()
+
+    const firstItem = page.locator('main a[href^="/admin/feedback/"]').first()
+    const hasItem = await firstItem
+      .waitFor({ state: 'visible', timeout: 8000 })
+      .then(() => true)
+      .catch(() => false)
+    test.skip(!hasItem, 'フィードバックが0件（先に S-FEEDBACK の投稿が必要）')
+    await firstItem.click()
+    await expect(page.getByRole('heading', { name: 'フィードバック詳細', level: 1 })).toBeVisible()
+    const detailHref = new URL(page.url()).pathname
+
+    const select = page.getByLabel('ステータスを変更')
+    const current = await select.inputValue()
+    const next = current === 'in_progress' ? 'resolved' : 'in_progress'
+
+    const writePromise = page.waitForResponse(
+      (r) => r.url().includes('user_feedback') && r.request().method() === 'PATCH',
+    )
+    await select.selectOption(next)
+    await writePromise
+
+    // 永続確認は「一覧へ戻る→同じ項目を開き直す」アプリ内遷移で行う。
+    // 管理ページのフルリロードは AdminGuard の isAdmin 取得レースで / へ戻されるため使わない。
+    await page.locator('a[href="/admin/feedback"]').first().click()
+    await expect(page.getByRole('heading', { name: 'フィードバック一覧', level: 1 })).toBeVisible()
+    await page.locator(`a[href="${detailHref}"]`).first().click()
+    await expect(page.getByLabel('ステータスを変更')).toHaveValue(next)
+  })
+})

--- a/apps/web/e2e/admin.spec.ts
+++ b/apps/web/e2e/admin.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect, type Page } from '@playwright/test'
+import { accounts } from './fixtures/accounts'
+
+// 管理者機能（admin アカウント）。表示・遷移の堅牢なケースを検証する。
+//
+// 注意: /admin への直接 goto は isAdmin 取得前（isLoadingAuth=false かつ isAdmin=初期false）に
+// AdminGuard が一瞬 / へリダイレクトするレースに当たる。そのため必ずダッシュボードから
+// isAdmin 解決後にアプリ内遷移（クリック）で /admin に入る。
+// is_admin=true のアカウントが無い環境（既定シードの e2e-admin 等）は自動スキップする。
+//
+// PW-ADMIN-02（フィードバック更新）/ PW-ADMIN-03（通知送受信）は書込み・クロスアカウントのため
+// 本specには含めない（書込みを伴うため別途・専用データ前提で扱う）。
+async function enterAdmin(page: Page) {
+  await page.goto('/')
+  await page.getByRole('button', { name: 'カリキュラム' }).click()
+  const adminItem = page.getByRole('menuitem', { name: '管理画面' })
+  const available = await adminItem
+    .waitFor({ state: 'visible', timeout: 8000 })
+    .then(() => true)
+    .catch(() => false)
+  test.skip(!available, 'is_admin=true のアカウントが必要（提供アカウントが管理者でない/未シード）')
+  await adminItem.click()
+  await expect(page).toHaveURL('/admin')
+}
+
+test.describe('S-ADMIN 管理者機能（認証済み・admin）', () => {
+  test.use({ storageState: accounts.admin.storageState })
+
+  test('PW-ADMIN-01 /admin ダッシュボードが表示される', async ({ page }) => {
+    await enterAdmin(page)
+    await expect(page.getByRole('heading', { name: '管理画面', level: 1 })).toBeVisible()
+  })
+
+  test('PW-ADMIN-04 ユーザー一覧 → 詳細を表示できる', async ({ page }) => {
+    await enterAdmin(page)
+    // サイドバーのリンク名はラベル完全一致。ダッシュボードのカード（説明付きで名前が長い）と区別する。
+    await page.getByRole('link', { name: 'ユーザー', exact: true }).click()
+    await expect(page.getByRole('heading', { name: 'ユーザー一覧', level: 1 })).toBeVisible()
+
+    await page.locator('main a[href^="/admin/users/"]').first().click()
+    await expect(page).toHaveURL(/\/admin\/users\/.+/)
+    await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible()
+  })
+
+  test('PW-ADMIN-05 統計・品質・Step Insights・運用ページが表示される', async ({ page }) => {
+    await enterAdmin(page)
+    const targets = [
+      { link: '統計', heading: '統計' },
+      { link: '品質ダッシュボード', heading: '品質ダッシュボード' },
+      { link: 'Step Insights', heading: 'Step Insights' },
+      { link: '運用', heading: '運用' },
+    ] as const
+    for (const { link, heading } of targets) {
+      await page.getByRole('link', { name: link, exact: true }).click()
+      await expect(page.getByRole('heading', { name: heading, level: 1 })).toBeVisible()
+    }
+  })
+})

--- a/apps/web/e2e/auth.setup.ts
+++ b/apps/web/e2e/auth.setup.ts
@@ -1,0 +1,33 @@
+import { test as setup, expect, type Page } from '@playwright/test'
+import fs from 'node:fs'
+import path from 'node:path'
+import { accounts, PASSWORD } from './fixtures/accounts'
+
+/**
+ * UI 経由でログインし、storageState を保存する共通処理。
+ * 各 spec は test.use({ storageState }) でこの状態を再利用する。
+ */
+async function authenticate(page: Page, email: string, statePath: string) {
+  await page.goto('/login')
+  await page.getByLabel('メールアドレス', { exact: true }).fill(email)
+  await page.getByLabel('パスワード', { exact: true }).fill(PASSWORD)
+  await page.getByRole('button', { name: 'ログイン' }).click()
+
+  // ログイン成功 → ダッシュボードへ遷移
+  await expect(page, `login failed for ${email}`).toHaveURL('/', { timeout: 30_000 })
+
+  fs.mkdirSync(path.dirname(statePath), { recursive: true })
+  await page.context().storageState({ path: statePath })
+}
+
+setup('authenticate general user', async ({ page }) => {
+  await authenticate(page, accounts.general.email, accounts.general.storageState)
+})
+
+setup('authenticate admin user', async ({ page }) => {
+  await authenticate(page, accounts.admin.email, accounts.admin.storageState)
+})
+
+setup('authenticate complete user', async ({ page }) => {
+  await authenticate(page, accounts.complete.email, accounts.complete.storageState)
+})

--- a/apps/web/e2e/auth.setup.ts
+++ b/apps/web/e2e/auth.setup.ts
@@ -1,16 +1,16 @@
 import { test as setup, expect, type Page } from '@playwright/test'
 import fs from 'node:fs'
 import path from 'node:path'
-import { accounts, PASSWORD } from './fixtures/accounts'
+import { accounts } from './fixtures/accounts'
 
 /**
  * UI 経由でログインし、storageState を保存する共通処理。
  * 各 spec は test.use({ storageState }) でこの状態を再利用する。
  */
-async function authenticate(page: Page, email: string, statePath: string) {
+async function authenticate(page: Page, email: string, password: string, statePath: string) {
   await page.goto('/login')
   await page.getByLabel('メールアドレス', { exact: true }).fill(email)
-  await page.getByLabel('パスワード', { exact: true }).fill(PASSWORD)
+  await page.getByLabel('パスワード', { exact: true }).fill(password)
   await page.getByRole('button', { name: 'ログイン' }).click()
 
   // ログイン成功 → ダッシュボードへ遷移
@@ -21,13 +21,13 @@ async function authenticate(page: Page, email: string, statePath: string) {
 }
 
 setup('authenticate general user', async ({ page }) => {
-  await authenticate(page, accounts.general.email, accounts.general.storageState)
+  await authenticate(page, accounts.general.email, accounts.general.password, accounts.general.storageState)
 })
 
 setup('authenticate admin user', async ({ page }) => {
-  await authenticate(page, accounts.admin.email, accounts.admin.storageState)
+  await authenticate(page, accounts.admin.email, accounts.admin.password, accounts.admin.storageState)
 })
 
 setup('authenticate complete user', async ({ page }) => {
-  await authenticate(page, accounts.complete.email, accounts.complete.storageState)
+  await authenticate(page, accounts.complete.email, accounts.complete.password, accounts.complete.storageState)
 })

--- a/apps/web/e2e/auth.spec.ts
+++ b/apps/web/e2e/auth.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '@playwright/test'
+import { accounts, PASSWORD } from './fixtures/accounts'
+
+/** 未認証時にリダイレクトされるべき保護ルート */
+const PROTECTED_PATHS = [
+  '/',
+  '/profile',
+  '/step/usestate-basic',
+  '/daily',
+  '/curriculum',
+  '/practice/code-doctor',
+  '/notifications',
+]
+
+test.describe('S-AUTH 認証・ルートガード（未認証）', () => {
+  test('PW-AUTH-01 未認証で / にアクセスすると /login へ', async ({ page }) => {
+    await page.goto('/')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('PW-AUTH-02 未認証で保護ルートは /login へ', async ({ page }) => {
+    for (const p of PROTECTED_PATHS) {
+      await page.goto(p)
+      await expect(page, `path=${p}`).toHaveURL(/\/login/)
+    }
+  })
+
+  test('PW-AUTH-03 正しい認証でログイン成功 → ダッシュボード', async ({ page }) => {
+    await page.goto('/login')
+    await page.getByLabel('メールアドレス', { exact: true }).fill(accounts.general.email)
+    await page.getByLabel('パスワード', { exact: true }).fill(PASSWORD)
+    await page.getByRole('button', { name: 'ログイン' }).click()
+
+    await expect(page).toHaveURL('/')
+    await expect(page.getByRole('button', { name: 'ログアウト' })).toBeVisible()
+  })
+
+  test('PW-AUTH-04 誤った認証はエラー表示・/login に留まる', async ({ page }) => {
+    await page.goto('/login')
+    await page.getByLabel('メールアドレス', { exact: true }).fill(accounts.general.email)
+    await page.getByLabel('パスワード', { exact: true }).fill('WrongPass-000')
+    await page.getByRole('button', { name: 'ログイン' }).click()
+
+    await expect(page.getByRole('alert')).toBeVisible()
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('PW-AUTH-06a サインアップ: 不正なメール形式でエラー（クライアント検証）', async ({ page }) => {
+    await page.goto('/signup')
+    await page.getByLabel('メールアドレス', { exact: true }).fill('not-an-email')
+    await page.getByLabel('パスワード', { exact: true }).fill('ValidPass123')
+    await page.getByRole('button', { name: 'アカウントを作成' }).click()
+
+    await expect(page.getByText('正しいメールアドレスを入力してください。')).toBeVisible()
+  })
+
+  test('PW-AUTH-06b サインアップ: 短いパスワードでエラー（クライアント検証）', async ({ page }) => {
+    await page.goto('/signup')
+    await page.getByLabel('メールアドレス', { exact: true }).fill('newuser@coden.dev')
+    await page.getByLabel('パスワード', { exact: true }).fill('short')
+    await page.getByRole('button', { name: 'アカウントを作成' }).click()
+
+    await expect(page.getByText('パスワードは8文字以上で入力してください。')).toBeVisible()
+  })
+
+  // PW-AUTH-06 サインアップ happy path は実 DB にユーザーを作成し、anon 権限では削除できないため自動化しない。
+  // 手動 or 管理 API（service_role）でのクリーンアップ手順を整備してから対応する。
+  test.skip('PW-AUTH-06 サインアップ happy path（実ユーザー作成のため要クリーンアップ設計）', () => {})
+
+  test('PW-AUTH-10 存在しない URL は NotFound を表示', async ({ page }) => {
+    await page.goto('/no-such-page-xyz')
+    await expect(page.getByText('404 Not Found')).toBeVisible()
+  })
+})
+
+test.describe('S-AUTH 認証・ルートガード（認証済み・general）', () => {
+  test.use({ storageState: accounts.general.storageState })
+
+  test('PW-AUTH-05 認証済みで /login /signup は / へ', async ({ page }) => {
+    await page.goto('/login')
+    await expect(page).toHaveURL('/')
+    await page.goto('/signup')
+    await expect(page).toHaveURL('/')
+  })
+
+  test('PW-AUTH-07 ログアウトで /login、再訪も /login', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'ログアウト' }).click()
+    await expect(page).toHaveURL(/\/login/)
+
+    await page.goto('/')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('PW-AUTH-08 リロードでセッション維持', async ({ page }) => {
+    await page.goto('/')
+    await expect(page).toHaveURL('/')
+    await page.reload()
+    await expect(page).toHaveURL('/')
+    await expect(page.getByRole('button', { name: 'ログアウト' })).toBeVisible()
+  })
+
+  test('PW-AUTH-09 一般ユーザーは /admin にアクセスできず / へ', async ({ page }) => {
+    await page.goto('/admin')
+    await expect(page).toHaveURL('/')
+  })
+})

--- a/apps/web/e2e/base-nook.spec.ts
+++ b/apps/web/e2e/base-nook.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test'
+import { accounts } from './fixtures/accounts'
+
+// ベースヌックはコンテンツ静的・進捗マップ読込のみ。general アカウントで一覧/詳細遷移を検証する。
+test.describe('S-NOOK ベースナック（認証済み・general）', () => {
+  test.use({ storageState: accounts.general.storageState })
+
+  test('PW-NOOK-01 トピック一覧が表示される', async ({ page }) => {
+    await page.goto('/base-nook')
+    await expect(page.getByRole('heading', { name: 'ベースヌック', level: 1 })).toBeVisible()
+    await expect(page.getByRole('button', { name: /JavaScriptって何？/ })).toBeVisible()
+  })
+
+  test('PW-NOOK-02 トピック詳細が 404 にならず表示される', async ({ page }) => {
+    await page.goto('/base-nook')
+    await page.getByRole('button', { name: /JavaScriptって何？/ }).click()
+
+    await expect(page).toHaveURL('/base-nook/javascript')
+    await expect(page.getByRole('heading', { name: 'JavaScriptって何？', level: 1 })).toBeVisible()
+  })
+})

--- a/apps/web/e2e/code-doctor.spec.ts
+++ b/apps/web/e2e/code-doctor.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test'
+import { accounts } from './fixtures/accounts'
+
+// コードドクター（/practice/code-doctor）。一覧・フィルター・不正解フィードバックを検証する。
+// PW-DOCTOR-02（正解→ポイント）/ PW-DOCTOR-04（クリア状態の永続）は正解コードの内容依存・
+// 永続副作用のため自動化対象外（手動 or 別途データ前提）とする。
+test.describe('S-DOCTOR コードドクター（認証済み・general）', () => {
+  test.use({ storageState: accounts.general.storageState })
+
+  test('PW-DOCTOR-01 問題一覧と難易度フィルターが表示される', async ({ page }) => {
+    await page.goto('/practice/code-doctor')
+    await expect(page.getByRole('heading', { name: 'コードドクター', level: 1 })).toBeVisible()
+    await expect(page.getByRole('button', { name: /リストに key がない/ })).toBeVisible()
+
+    // 難易度フィルター（初級）に切り替えられる
+    const beginnerTab = page.getByRole('tab', { name: '初級' })
+    await beginnerTab.click()
+    await expect(beginnerTab).toHaveAttribute('aria-selected', 'true')
+  })
+
+  test('PW-DOCTOR-03 未修正コードの判定で不正解フィードバックが表示される', async ({ page }) => {
+    await page.goto('/practice/code-doctor')
+    await page.getByRole('button', { name: /リストに key がない/ }).click()
+
+    // 問題ビュー
+    await expect(page.getByRole('heading', { name: 'リストに key がない', level: 2 })).toBeVisible()
+
+    // バグ入りコードのまま判定 → 不正解フィードバック
+    await page.getByRole('button', { name: '判定する' }).click()
+    await expect(page.getByText('まだバグが残っています')).toBeVisible()
+  })
+})

--- a/apps/web/e2e/code-reading.spec.ts
+++ b/apps/web/e2e/code-reading.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test'
+import { accounts } from './fixtures/accounts'
+
+// コードリーディング（/practice/code-reading）。一覧・フィルター・設問の即時フィードバックを検証する。
+// PW-READING-03（初回全問正解時のみ加算）は初回限定・永続副作用のため自動化対象外とする。
+test.describe('S-READING コードリーディング（認証済み・general）', () => {
+  test.use({ storageState: accounts.general.storageState })
+
+  test('PW-READING-01 問題一覧と難易度フィルターが表示される', async ({ page }) => {
+    await page.goto('/practice/code-reading')
+    await expect(page.getByRole('heading', { name: 'コードリーディング', level: 1 })).toBeVisible()
+    await expect(page.getByRole('button', { name: /カスタムフック（useCounter）/ })).toBeVisible()
+
+    const basicTab = page.getByRole('tab', { name: '基礎' })
+    await basicTab.click()
+    await expect(basicTab).toHaveAttribute('aria-selected', 'true')
+  })
+
+  test('PW-READING-02 設問に回答すると即時フィードバックが表示される', async ({ page }) => {
+    await page.goto('/practice/code-reading')
+    await page.getByRole('button', { name: /カスタムフック（useCounter）/ }).click()
+
+    // 設問ビュー（最初の設問は最終設問ではないため、回答しても採点送信は走らない）
+    await page.getByRole('button', { name: /^A\./ }).click()
+    await page.getByRole('button', { name: '回答する' }).click()
+
+    // 即時フィードバック（正誤いずれか）と次設問への導線が表示される
+    await expect(page.getByRole('button', { name: /次の設問へ/ })).toBeVisible()
+  })
+})

--- a/apps/web/e2e/daily.spec.ts
+++ b/apps/web/e2e/daily.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test'
+import { accounts } from './fixtures/accounts'
+
+// デイリーチャレンジ（/daily）。完了済みステップが必要なため complete アカウントを使う。
+// 当日問題は「未回答=出題カード / 回答済み=完了ビュー」のいずれか（1日1回・状態依存）。
+// PW-DAILY-02（回答→加算）/ PW-DAILY-03（再訪で完了済み）は当日1回限りで不可逆のため
+// 自動化対象外とし、ここでは見出し・サブタイトル・週間ステータスの表示を検証する。
+test.describe('S-DAILY デイリーチャレンジ（認証済み・complete）', () => {
+  test.use({ storageState: accounts.complete.storageState })
+
+  test('PW-DAILY-01 デイリーチャレンジ画面が表示される', async ({ page }) => {
+    await page.goto('/daily')
+    await expect(page.getByRole('heading', { name: 'デイリーチャレンジ', level: 1 })).toBeVisible()
+    await expect(page.getByText('完了済みステップから毎日1問出題されます')).toBeVisible()
+  })
+
+  test('PW-DAILY-04 週間ステータス（今週の達成状況）が表示される', async ({ page }) => {
+    await page.goto('/daily')
+    await expect(page.getByRole('heading', { name: '今週の達成状況' })).toBeVisible()
+  })
+})

--- a/apps/web/e2e/dashboard.spec.ts
+++ b/apps/web/e2e/dashboard.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test'
+import { accounts } from './fixtures/accounts'
+
+test.describe('S-DASH ダッシュボード（認証済み・complete）', () => {
+  test.use({ storageState: accounts.complete.storageState })
+
+  test('PW-DASH-01 ウェルカムメッセージにユーザー名', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByRole('heading', { name: /こんにちは、.*さん/ })).toBeVisible()
+  })
+
+  test('PW-DASH-02 ヘッダーの Pt・連続がリロード後も維持（DB反映）', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByText(/Pt/).first()).toBeVisible()
+    await expect(page.getByText(/日連続/).first()).toBeVisible()
+
+    await page.reload()
+    await expect(page.getByText(/Pt/).first()).toBeVisible()
+    await expect(page.getByText(/日連続/).first()).toBeVisible()
+  })
+
+  test('PW-DASH-03 学習コースカードが表示される', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByRole('heading', { name: '学習コース' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: 'React', exact: true })).toBeVisible()
+  })
+
+  test('PW-DASH-05 学習ステータス・ヒートマップが表示される', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByRole('heading', { name: '学習ステータス' })).toBeVisible()
+    await expect(page.getByRole('heading', { name: '学習ヒートマップ' })).toBeVisible()
+  })
+})
+
+test.describe('S-DASH ダッシュボード（認証済み・general / ロック）', () => {
+  test.use({ storageState: accounts.general.storageState })
+
+  test('PW-DASH-04 未解放ステップ直アクセスは / へリダイレクト', async ({ page }) => {
+    // ロックはコース前提条件ベース。general(進捗ゼロ)は react-fundamentals 未完了のため
+    // react-hooks コースの useeffect はロックされ、ダッシュボードへリダイレクトされる。
+    await page.goto('/step/useeffect')
+    await expect(page).toHaveURL('/')
+  })
+})

--- a/apps/web/e2e/errors.spec.ts
+++ b/apps/web/e2e/errors.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test'
+import { accounts } from './fixtures/accounts'
+
+// 例外系（失敗注入）。通常系と分離。route で API を abort して失敗時 UI を検証する。
+// PW-ERR-01（API Practice 通信失敗→再試行）/ PW-ERR-04（楽観的更新ロールバック）は
+// 対象画面の API 経路特定が必要なため別途、PW-ERR-03（Supabase 設定不備）は起動時 env 依存のため
+// 自動化対象外（手動）とする。
+test.describe('S-ERR 例外系（認証済み・general）', () => {
+  test.use({ storageState: accounts.general.storageState })
+
+  test('PW-ERR-02 フィードバック送信失敗時にエラーを表示する', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'フィードバックを送る' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await dialog.getByPlaceholder('気づいた点・ご要望など自由に記入してください').fill('pw-feedback-err')
+
+    // user_feedback への書込みを失敗注入（実データは作成されない）
+    await page.route('**/user_feedback*', (route) => route.abort())
+
+    await dialog.getByRole('button', { name: '送信' }).click()
+    await expect(dialog.getByRole('alert')).toBeVisible()
+  })
+})

--- a/apps/web/e2e/feedback.spec.ts
+++ b/apps/web/e2e/feedback.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test'
+import { accounts } from './fixtures/accounts'
+
+// フィードバック投稿（general アカウント）。FAB からダイアログを開いて送信完了までを検証する。
+// 投稿データは一意接頭辞 pw-feedback- を使い、次回実行と衝突しないようにする。
+// PW-FEEDBACK-03（管理側一覧反映）は管理者閲覧が必要なため admin 側ライフサイクルで担保する。
+test.describe('S-FEEDBACK フィードバック投稿（認証済み・general）', () => {
+  test.use({ storageState: accounts.general.storageState })
+
+  test('PW-FEEDBACK-01 FAB からフィードバックダイアログを開く', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'フィードバックを送る' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await expect(dialog.getByText('不具合報告・要望・レビューなど、運営宛てに送信できます。')).toBeVisible()
+  })
+
+  test('PW-FEEDBACK-02 メッセージを入力して送信 → 完了表示', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'フィードバックを送る' }).click()
+
+    const dialog = page.getByRole('dialog')
+    await dialog.getByPlaceholder('気づいた点・ご要望など自由に記入してください').fill(`pw-feedback-${Date.now()}`)
+
+    const writePromise = page.waitForResponse(
+      (r) => r.url().includes('user_feedback') && r.request().method() === 'POST',
+    )
+    await dialog.getByRole('button', { name: '送信' }).click()
+    await writePromise
+
+    await expect(page.getByText('送信しました。ありがとうございます！')).toBeVisible()
+  })
+})

--- a/apps/web/e2e/fixtures/accounts.ts
+++ b/apps/web/e2e/fixtures/accounts.ts
@@ -1,0 +1,23 @@
+/**
+ * E2E テストアカウント定義（apps/web/supabase/sql/025_seed_e2e_accounts.sql で投入）。
+ * 実値は環境変数で上書き可能。パスワードは既定でシードと同じ TestPass123!。
+ */
+export const PASSWORD = process.env.E2E_PASSWORD ?? 'TestPass123!'
+
+export const accounts = {
+  /** 進捗ゼロの一般ユーザー */
+  general: {
+    email: process.env.E2E_GENERAL_EMAIL ?? 'e2e-general@coden.dev',
+    storageState: 'apps/web/e2e/.auth/general.json',
+  },
+  /** 管理者（profiles.is_admin = true） */
+  admin: {
+    email: process.env.E2E_ADMIN_EMAIL ?? 'e2e-admin@coden.dev',
+    storageState: 'apps/web/e2e/.auth/admin.json',
+  },
+  /** 全40ステップ完了済み */
+  complete: {
+    email: process.env.E2E_COMPLETE_EMAIL ?? 'e2e-complete@coden.dev',
+    storageState: 'apps/web/e2e/.auth/complete.json',
+  },
+} as const

--- a/apps/web/e2e/fixtures/accounts.ts
+++ b/apps/web/e2e/fixtures/accounts.ts
@@ -1,6 +1,7 @@
 /**
  * E2E テストアカウント定義（apps/web/supabase/sql/025_seed_e2e_accounts.sql で投入）。
  * 実値は環境変数で上書き可能。パスワードは既定でシードと同じ TestPass123!。
+ * admin のみ別アカウント検証用に E2E_ADMIN_PASSWORD で個別上書きできる。
  */
 export const PASSWORD = process.env.E2E_PASSWORD ?? 'TestPass123!'
 
@@ -8,16 +9,19 @@ export const accounts = {
   /** 進捗ゼロの一般ユーザー */
   general: {
     email: process.env.E2E_GENERAL_EMAIL ?? 'e2e-general@coden.dev',
+    password: PASSWORD,
     storageState: 'apps/web/e2e/.auth/general.json',
   },
   /** 管理者（profiles.is_admin = true） */
   admin: {
     email: process.env.E2E_ADMIN_EMAIL ?? 'e2e-admin@coden.dev',
+    password: process.env.E2E_ADMIN_PASSWORD ?? PASSWORD,
     storageState: 'apps/web/e2e/.auth/admin.json',
   },
   /** 全40ステップ完了済み */
   complete: {
     email: process.env.E2E_COMPLETE_EMAIL ?? 'e2e-complete@coden.dev',
+    password: PASSWORD,
     storageState: 'apps/web/e2e/.auth/complete.json',
   },
 } as const

--- a/apps/web/e2e/learning.spec.ts
+++ b/apps/web/e2e/learning.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test'
+import { accounts } from './fixtures/accounts'
+
+// 全ステップ解放済みの complete アカウントで学習フローの UI 挙動を検証する。
+// ポイント加算・完了の永続値は状態依存のため assert せず、判定 UI・遷移・入力を確認する。
+test.describe('S-LEARN 学習フロー（認証済み・complete）', () => {
+  test.use({ storageState: accounts.complete.storageState })
+
+  test('PW-LEARN-01 ステップページにヘッダー・パンくず・モードタブ', async ({ page }) => {
+    await page.goto('/step/usestate-basic')
+    await expect(page.getByRole('heading', { name: 'useStateの基礎', level: 1 })).toBeVisible()
+    await expect(page.getByRole('navigation', { name: 'パンくずリスト' })).toBeVisible()
+    await expect(page.getByRole('tab', { name: 'Read' })).toBeVisible()
+  })
+
+  test('PW-LEARN-02 学習モードタブを切り替えられる', async ({ page }) => {
+    await page.goto('/step/usestate-basic')
+    await expect(page.getByRole('heading', { name: 'Read', level: 2 })).toBeVisible()
+
+    await page.getByRole('tab', { name: 'Practice' }).click()
+    await expect(page.getByRole('heading', { name: 'Practice', level: 2 })).toBeVisible()
+
+    await page.getByRole('tab', { name: 'Test' }).click()
+    await expect(page.getByRole('heading', { name: 'Test', level: 2 })).toBeVisible()
+  })
+
+  test('PW-LEARN-03 Practice: 判定前は判定されず、誤答で解説が表示される', async ({ page }) => {
+    await page.goto('/step/usestate-basic?mode=practice')
+
+    // 判定ボタン押下前は正誤表示なし
+    await expect(page.getByText('不正解です。もう一度試してください。')).toHaveCount(0)
+
+    // Q1 で誤答を選択（answer は「いいえ」なので「はい」を選ぶ）
+    await page.getByRole('radiogroup', { name: 'Q1 選択肢' }).getByRole('radio', { name: 'はい' }).click()
+    // 入力中（判定前）はまだ判定されない
+    await expect(page.getByText('不正解です。もう一度試してください。')).toHaveCount(0)
+
+    await page.getByRole('button', { name: '判定する' }).click()
+    await expect(page.getByText('まだ不正解の問題があります。')).toBeVisible()
+    await expect(page.getByText('解説').first()).toBeVisible()
+  })
+
+  test('PW-LEARN-06 Test: コード空欄に入力でき、誤答で解説が表示される', async ({ page }) => {
+    await page.goto('/step/usestate-basic?mode=test')
+
+    const blank = page.getByRole('textbox', { name: 'コードの空欄を入力' })
+    await blank.fill('wrong')
+    await page.getByRole('button', { name: '判定する' }).click()
+
+    await expect(page.getByText('必要キーワードを満たしていません。')).toBeVisible()
+    await expect(page.getByText('解説').first()).toBeVisible()
+  })
+
+  test('PW-LEARN-07 Test: 正答で合格表示', async ({ page }) => {
+    await page.goto('/step/usestate-basic?mode=test')
+
+    const blank = page.getByRole('textbox', { name: 'コードの空欄を入力' })
+    await blank.fill('setCount(count - 1)')
+    await page.getByRole('button', { name: '判定する' }).click()
+
+    await expect(page.getByText('テスト合格！ ライブプレビューが解禁されました。')).toBeVisible()
+  })
+
+  test('PW-LEARN-12 代表ステップが 404・リダイレクトなく表示される', async ({ page }) => {
+    const stepIds = ['useeffect', 'custom-hooks', 'api-counter-get', 'error-boundary', 'ts-types']
+    for (const id of stepIds) {
+      await page.goto(`/step/${id}`)
+      await expect(page, `step=${id}`).toHaveURL(`/step/${id}`)
+      // Read の markdown にも h1 があるため、ページ見出し（先頭の h1）を確認する
+      await expect(page.getByRole('heading', { level: 1 }).first()).toBeVisible()
+    }
+  })
+})

--- a/apps/web/e2e/mini-projects.spec.ts
+++ b/apps/web/e2e/mini-projects.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+import { accounts } from './fixtures/accounts'
+
+// ミニプロジェクト（/practice/mini-projects）。一覧と詳細ページ遷移を検証する。
+// PW-PROJ-03（マイルストーン判定→完了で加算）/ PW-PROJ-04（完了状態の永続）は
+// 実装内容依存・永続副作用のため自動化対象外とする。
+test.describe('S-PROJ ミニプロジェクト（認証済み・general）', () => {
+  test.use({ storageState: accounts.general.storageState })
+
+  test('PW-PROJ-01 プロジェクト一覧と難易度フィルターが表示される', async ({ page }) => {
+    await page.goto('/practice/mini-projects')
+    await expect(page.getByRole('heading', { name: 'ミニプロジェクト', level: 1 })).toBeVisible()
+    await expect(page.getByRole('button', { name: /Todo App/ })).toBeVisible()
+
+    const beginnerTab = page.getByRole('tab', { name: '初級' })
+    await beginnerTab.click()
+    await expect(beginnerTab).toHaveAttribute('aria-selected', 'true')
+  })
+
+  test('PW-PROJ-02 詳細ページ（/:projectId）でエディタ付きの実装画面が表示される', async ({ page }) => {
+    await page.goto('/practice/mini-projects')
+    await page.getByRole('button', { name: /Todo App/ }).click()
+
+    await expect(page).toHaveURL('/practice/mini-projects/todo-app')
+    await expect(page.getByRole('button', { name: '判定する' })).toBeVisible()
+  })
+})

--- a/apps/web/e2e/nav.spec.ts
+++ b/apps/web/e2e/nav.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test'
+import { accounts } from './fixtures/accounts'
+
+test.describe('S-NAV ヘッダー/ナビゲーション（認証済み・general）', () => {
+  test.use({ storageState: accounts.general.storageState })
+
+  test('PW-NAV-01 ロゴクリックで / へ', async ({ page }) => {
+    await page.goto('/profile')
+    await page.getByRole('link', { name: 'Coden ホームへ戻る' }).click()
+    await expect(page).toHaveURL('/')
+  })
+
+  test('PW-NAV-02 主要リンクが正しい URL へ', async ({ page }) => {
+    // ページ本文にも同名リンク（例: プロフィールページの「ベースヌック」カード）が
+    // 存在するため、ヘッダーのメインナビゲーションにスコープする。
+    await page.goto('/')
+    const nav = page.getByRole('navigation', { name: 'メインナビゲーション' })
+
+    await nav.getByRole('link', { name: 'プロフィール' }).click()
+    await expect(page).toHaveURL('/profile')
+
+    await nav.getByRole('link', { name: 'ベースヌック' }).click()
+    await expect(page).toHaveURL('/base-nook')
+
+    await nav.getByRole('link', { name: 'ダッシュボード' }).click()
+    await expect(page).toHaveURL('/')
+  })
+
+  test('PW-NAV-02b カリキュラムドロップダウンから練習モードへ', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'カリキュラム' }).click()
+    await page.getByRole('menuitem', { name: 'デイリーチャレンジ' }).click()
+    await expect(page).toHaveURL('/daily')
+  })
+
+  test('PW-NAV-03 一般ユーザーには管理画面リンクが表示されない', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('button', { name: 'カリキュラム' }).click()
+    await expect(page.getByRole('menuitem', { name: '管理画面' })).toHaveCount(0)
+  })
+
+  test('PW-NAV-04 通知ベルから /notifications へ', async ({ page }) => {
+    await page.goto('/')
+    await page.getByRole('link', { name: /お知らせ/ }).click()
+    await expect(page).toHaveURL('/notifications')
+  })
+
+  test('PW-NAV-05 ステップから戻るとダッシュボードへ', async ({ page }) => {
+    await page.goto('/')
+    await page.goto('/step/usestate-basic')
+    await expect(page).toHaveURL('/step/usestate-basic')
+    await page.goBack()
+    await expect(page).toHaveURL('/')
+  })
+})

--- a/apps/web/e2e/notifications.spec.ts
+++ b/apps/web/e2e/notifications.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test'
+import { accounts } from './fixtures/accounts'
+
+// 通知（ユーザー側 /notifications）。
+// PW-NOTIF-02（未読→既読化でバッジ減少）は配信済み通知データが前提のため、
+// 管理者送信→ユーザー受信を1連で見る S-ADMIN（PW-ADMIN-03）側で担保する。
+// PW-NOTIF-03（通知0件の空状態）は「受信ゼロが保証されたアカウント」が前提だが、
+// 共有テストDBでは target_role=all/learner の配信済み通知が存在しうるため自動化対象外。
+test.describe('S-NOTIF 通知ユーザー側（認証済み・general）', () => {
+  test.use({ storageState: accounts.general.storageState })
+
+  test('PW-NOTIF-01 /notifications でポスト一覧ページが表示される', async ({ page }) => {
+    await page.goto('/notifications')
+    await expect(page.getByRole('heading', { name: 'ポスト', level: 1 })).toBeVisible()
+    await expect(page.getByText(/新着 \d+ 件/)).toBeVisible()
+  })
+})

--- a/apps/web/e2e/profile.spec.ts
+++ b/apps/web/e2e/profile.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test'
+import { accounts } from './fixtures/accounts'
+
+// プロフィール（/profile）。general アカウントで表示名編集の永続と統計・実績表示を検証する。
+test.describe('S-PROFILE プロフィール（認証済み・general）', () => {
+  test.use({ storageState: accounts.general.storageState })
+
+  test('PW-PROFILE-02 統計・実績が表示される', async ({ page }) => {
+    await page.goto('/profile')
+    await expect(page.getByRole('heading', { name: 'プロフィール', level: 1 })).toBeVisible()
+    await expect(page.getByText('総ポイント')).toBeVisible()
+    await expect(page.getByRole('heading', { name: '実績バッジ' })).toBeVisible()
+  })
+
+  test('PW-PROFILE-01 表示名を編集・保存し、再読込後も残存する', async ({ page }) => {
+    await page.goto('/profile')
+    const input = page.getByPlaceholder('表示名を入力')
+    // 初期表示名のロード完了を待つ。getProfile が遅延解決して fill 内容を上書きするのを防ぐ。
+    await expect(input).not.toHaveValue('')
+
+    const original = await input.inputValue()
+    const nextName = `pw-profile-${Date.now()}`
+
+    try {
+      await input.fill(nextName)
+      await page.getByRole('button', { name: '表示名を保存' }).click()
+      await expect(page.getByText('プロフィール名を更新しました。')).toBeVisible()
+
+      // 再読込後も保存値が残存する
+      await page.reload()
+      await expect(page.getByPlaceholder('表示名を入力')).toHaveValue(nextName)
+    } finally {
+      // 後始末: 元の表示名へ戻す
+      const restore = page.getByPlaceholder('表示名を入力')
+      await expect(restore).not.toHaveValue('')
+      await restore.fill(original)
+      await page.getByRole('button', { name: '表示名を保存' }).click()
+      await page.getByText('プロフィール名を更新しました。').waitFor({ timeout: 10_000 }).catch(() => undefined)
+    }
+  })
+})

--- a/apps/web/e2e/review.spec.ts
+++ b/apps/web/e2e/review.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test'
+import { accounts } from './fixtures/accounts'
+
+// 復習キューは DB ベース（reviewService）。不正解で open 登録、正解で resolve される。
+// general アカウントで「誤答→出現→正答→消滅」を1連で検証し、自己クリーンアップする。
+test.describe('S-REVIEW 復習キュー（認証済み・general）', () => {
+  test.use({ storageState: accounts.general.storageState })
+
+  test('PW-REVIEW-01 誤答で復習キュー出現 → 正答で消滅', async ({ page }) => {
+    const reviewCard = page.getByText(/復習待ち \d+ 件/)
+
+    // 初期状態: open なし → カード非表示
+    await page.goto('/')
+    await expect(reviewCard).toHaveCount(0)
+
+    // Test を誤答 → 復習に登録される（DB書込み完了を待ってから遷移）
+    await page.goto('/step/usestate-basic?mode=test')
+    await page.getByRole('textbox', { name: 'コードの空欄を入力' }).fill('wrong')
+    const writePromise = page.waitForResponse(
+      (r) => r.url().includes('review_items') && ['POST', 'PATCH'].includes(r.request().method()),
+    )
+    await page.getByRole('button', { name: '判定する' }).click()
+    await expect(page.getByText('必要キーワードを満たしていません。')).toBeVisible()
+    await writePromise
+
+    // ダッシュボードに復習キューカードが出現
+    await page.goto('/')
+    await expect(reviewCard).toBeVisible()
+
+    // 正答 → 復習が解決される（resolve の PATCH 完了を待つ）
+    await page.goto('/step/usestate-basic?mode=test')
+    await page.getByRole('textbox', { name: 'コードの空欄を入力' }).fill('setCount(count - 1)')
+    const resolvePromise = page.waitForResponse(
+      (r) => r.url().includes('review_items') && r.request().method() === 'PATCH',
+    )
+    await page.getByRole('button', { name: '判定する' }).click()
+    await expect(page.getByText('テスト合格！ ライブプレビューが解禁されました。')).toBeVisible()
+    await resolvePromise
+
+    // ダッシュボードから復習キューカードが消滅
+    await page.goto('/')
+    await expect(reviewCard).toHaveCount(0)
+  })
+})

--- a/apps/web/supabase/sql/025_seed_e2e_accounts.sql
+++ b/apps/web/supabase/sql/025_seed_e2e_accounts.sql
@@ -1,0 +1,123 @@
+-- 025: E2E テスト用アカウントのシード
+-- 用途: docs/usertest/Utest-e2e.md の自動化シナリオで使う固定アカウントを用意する。
+--
+-- 作成するアカウント（パスワードは共通: TestPass123!）:
+--   - e2e-admin@coden.dev    … 管理者（profiles.is_admin = true）。S-ADMIN / AdminGuard 確認用
+--   - e2e-complete@coden.dev … 全40ステップ完了済み。進捗ロック対象や最終ステップ挙動の確認用
+--   - e2e-general@coden.dev  … 進捗ゼロの一般ユーザー。ロック挙動・通常フロー確認用
+--
+-- サインアップ通しフロー（PW-AUTH-06）のアカウントはここではシードしない。
+--   spec 側で e2e+<timestamp>@coden.dev を一意生成し、afterAll で削除する運用とする。
+--
+-- 前提:
+--   - 001〜024 の SQL が適用済みであること（profiles.is_admin は 013 で追加）
+--   - email_change 系カラムは空文字を明示する（GoTrue 500 回避。002 と同方針）
+--
+-- 実行先（重要）:
+--   ローカル or 専用テストプロジェクトで実行すること。
+--   本番プロジェクトには投入しない（テスト用認証情報の混入を防ぐため）。
+
+-- ─────────────────────────────────────────
+-- 1-2. auth.users と profiles を用意
+--   auth.users の email 一意制約は部分インデックス（is_sso_user = false）の
+--   場合があり ON CONFLICT (email) が使えないため、email ごとに存在チェックして
+--   insert / update する方式にする（制約に依存せず冪等）。
+-- ─────────────────────────────────────────
+do $$
+declare
+  v_emails text[] := array[
+    'e2e-admin@coden.dev',
+    'e2e-complete@coden.dev',
+    'e2e-general@coden.dev'
+  ];
+  v_email text;
+  v_id    uuid;
+begin
+  foreach v_email in array v_emails loop
+    select id into v_id from auth.users where email = v_email;
+
+    if v_id is null then
+      v_id := gen_random_uuid();
+      insert into auth.users (
+        id, email, encrypted_password, email_confirmed_at,
+        confirmation_token, recovery_token, email_change,
+        email_change_token_new, email_change_token_current,
+        created_at, updated_at, raw_app_meta_data, raw_user_meta_data,
+        is_super_admin, instance_id, aud, role
+      )
+      values (
+        v_id, v_email, crypt('TestPass123!', gen_salt('bf', 10)), now(),
+        '', '', '', '', '',
+        now(), now(),
+        '{"provider":"email","providers":["email"]}', '{}',
+        false, '00000000-0000-0000-0000-000000000000', 'authenticated', 'authenticated'
+      );
+    else
+      update auth.users
+      set encrypted_password = crypt('TestPass123!', gen_salt('bf', 10)),
+          updated_at = now()
+      where id = v_id;
+    end if;
+
+    -- profiles を UPSERT（id は PK。018 の自動作成トリガで先に行ができていても安全）
+    insert into public.profiles (id, display_name, is_admin)
+    values (v_id, split_part(v_email, '@', 1), v_email = 'e2e-admin@coden.dev')
+    on conflict (id) do update set
+      display_name = excluded.display_name,
+      is_admin     = excluded.is_admin;
+  end loop;
+end $$;
+
+-- ─────────────────────────────────────────
+-- 3. e2e-complete@coden.dev を全40ステップ完了済みにする
+-- ─────────────────────────────────────────
+do $$
+declare
+  v_user_id uuid;
+  v_step_ids text[] := array[
+    -- React基礎 / 応用 / 上級 / API実践
+    'usestate-basic','events','conditional','lists',
+    'useeffect','forms','usecontext','usereducer',
+    'custom-hooks','api-fetch','performance','testing',
+    'api-counter-get','api-counter-post','api-tasks-list','api-tasks-create',
+    'api-tasks-update','api-tasks-delete','api-custom-hook','api-error-loading',
+    -- React モダン / 実務パターン
+    'error-boundary','suspense-lazy','concurrent-features','use-optimistic','portals','forward-ref',
+    'rhf-zod','pagination','infinite-scroll','auth-flow',
+    -- TypeScript / TypeScript×React
+    'ts-types','ts-functions','ts-objects','ts-union-narrowing','ts-generics','ts-utility-types',
+    'ts-react-props','ts-react-state','ts-react-hooks','ts-react-events'
+  ];
+begin
+  select id into v_user_id
+  from auth.users
+  where email = 'e2e-complete@coden.dev';
+
+  if v_user_id is null then
+    raise exception 'User e2e-complete@coden.dev not found in auth.users';
+  end if;
+
+  -- 全ステップを全モード完了で UPSERT
+  insert into public.step_progress
+    (user_id, step_id, read_done, practice_done, test_done, challenge_done, completed_at, updated_at)
+  select v_user_id, unnest(v_step_ids), true, true, true, true, now(), now()
+  on conflict (user_id, step_id) do update set
+    read_done      = true,
+    practice_done  = true,
+    test_done      = true,
+    challenge_done = true,
+    completed_at   = now(),
+    updated_at     = now();
+
+  -- learning_stats（ストリーク1日目・最終学習日=今日）
+  insert into public.learning_stats
+    (user_id, total_points, current_streak, max_streak, last_study_date, updated_at)
+  values (v_user_id, 0, 1, 1, current_date, now())
+  on conflict (user_id) do update set
+    current_streak  = 1,
+    max_streak      = greatest(public.learning_stats.max_streak, 1),
+    last_study_date = current_date,
+    updated_at      = now();
+
+  raise notice 'Success: e2e-complete@coden.dev (%) — % steps completed', v_user_id, array_length(v_step_ids, 1);
+end $$;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest" />
 import path from 'path'
 import { defineConfig } from 'vite'
+import { defaultExclude } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { visualizer } from 'rollup-plugin-visualizer'
 
@@ -37,6 +38,8 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: false,
+    // E2E（Playwright）の spec は vitest の収集対象から除外する。
+    exclude: [...defaultExclude, 'e2e/**'],
     coverage: {
       provider: 'v8',
       include: ['src/**/*.{ts,tsx}'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "apps/*"
       ],
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "lefthook": "^2.1.4"
       },
       "engines": {
@@ -3526,6 +3527,22 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.29",
@@ -8516,6 +8533,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "typecheck": "npm --workspace @coden/web run typecheck",
     "lint": "npm --workspace @coden/web run lint",
     "test": "npm --workspace @coden/web run test",
-    "api:dev": "npm --workspace @coden/web run api:dev"
+    "api:dev": "npm --workspace @coden/web run api:dev",
+    "e2e": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:report": "playwright show-report"
   },
   "msw": {
     "workerDirectory": [
@@ -22,6 +25,7 @@
     "node": ">=22.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "lefthook": "^2.1.4"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * Coden E2E 設定（docs/usertest/Utest-e2e.md 準拠）
+ * - 共有テストアカウント前提のため直列実行（workers: 1 / fullyParallel: false）
+ * - 認証は setup プロジェクトで storageState を生成し、各 spec が再利用する
+ */
+const PORT = 5173
+const BASE_URL = process.env.E2E_BASE_URL ?? `http://localhost:${PORT}`
+
+export default defineConfig({
+  testDir: './apps/web/e2e',
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: BASE_URL,
+    locale: 'ja-JP',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    // 認証セットアップ（storageState を生成）
+    { name: 'setup', testMatch: /.*\.setup\.ts/ },
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+      dependencies: ['setup'],
+      testIgnore: /.*\.setup\.ts/,
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})


### PR DESCRIPTION
## Summary
- Playwright E2E基盤、認証setup、共有テストアカウント定義を追加
- v1.0主要導線（AUTH/NAV/DASH/LEARN/REVIEW/各練習/通知/FB/PROFILE/ADMIN/ERR）を自動化
- E2E spec を Vitest 収集対象から除外し、実行スクリプトを追加

## Test plan
- npm run e2e: 53 passed / 1 skipped
- PR CIで Build / Lint / Test / Typecheck / Vercel を確認

## Notes
- apps/web/supabase/sql/025_seed_e2e_accounts.sql はE2E用固定アカウントseedで、本番適用対象ではありません。