### PR TITLE
fix: ポイント・実績テーブルの直接書き込みを封鎖し award_points_tx に上限を追加

### DIFF
--- a/apps/web/src/services/__tests__/achievementService.test.ts
+++ b/apps/web/src/services/__tests__/achievementService.test.ts
@@ -9,6 +9,7 @@ import type { LearningStats } from '../statsService'
 vi.mock('../../lib/supabaseClient', () => ({
   supabase: {
     from: vi.fn(),
+    rpc: vi.fn(),
   },
 }))
 
@@ -26,6 +27,7 @@ vi.mock('../statsService', () => ({
 }))
 
 const mockFrom = vi.mocked(supabase.from)
+const mockRpc = vi.mocked(supabase.rpc)
 const mockGetAllStepProgress = vi.mocked(getAllStepProgress)
 const mockGetLearningStats = vi.mocked(getLearningStats)
 
@@ -70,7 +72,6 @@ function mockFromWithTable(overrides: Record<string, unknown[]>) {
       select: vi.fn().mockReturnValue({
         eq: vi.fn().mockResolvedValue({ data, error: null }),
       }),
-      insert: vi.fn().mockResolvedValue({ error: null }),
     } as unknown as ReturnType<typeof supabase.from>
   })
 }
@@ -79,13 +80,13 @@ describe('checkAndUnlockAchievements', () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    // デフォルト: 既存バッジなし、INSERT 成功、全 DB クエリは空
+    // デフォルト: 既存バッジなし、RPC 付与成功、全 DB クエリは空
     mockFrom.mockReturnValue({
       select: vi.fn().mockReturnValue({
         eq: vi.fn().mockResolvedValue({ data: [], error: null }),
       }),
-      insert: vi.fn().mockResolvedValue({ error: null }),
     } as unknown as ReturnType<typeof supabase.from>)
+    mockRpc.mockResolvedValue({ data: true, error: null } as unknown as Awaited<ReturnType<typeof supabase.rpc>>)
 
     // デフォルト: ステップ未完了、ストリーク 0
     mockGetAllStepProgress.mockResolvedValue([])
@@ -204,7 +205,6 @@ describe('checkAndUnlockAchievements', () => {
           error: null,
         }),
       }),
-      insert: vi.fn().mockResolvedValue({ error: null }),
     } as unknown as ReturnType<typeof supabase.from>)
 
     mockGetAllStepProgress.mockResolvedValue([makeCompletedProgress('usestate-basic')])

--- a/apps/web/src/services/achievementService.ts
+++ b/apps/web/src/services/achievementService.ts
@@ -152,18 +152,16 @@ export async function getUnlockedAchievements(userId: string): Promise<BadgeId[]
   return (data ?? []).map((row) => row.badge_id).filter(isBadgeId)
 }
 
-export async function unlockAchievement(userId: string, badgeId: BadgeId): Promise<boolean> {
-  const { error } = await supabase.from('achievements').insert({ user_id: userId, badge_id: badgeId })
+export async function unlockAchievement(badgeId: BadgeId): Promise<boolean> {
+  // RLS で achievements への直 INSERT は封鎖済み（025）。付与は RPC 経由に限定し、
+  // 既保持の場合は false が返る。
+  const { data, error } = await supabase.rpc('unlock_achievement_tx', { p_badge_id: badgeId })
 
-  if (!error) {
-    return true
+  if (error) {
+    throw fromSupabaseError(error, 'バッジの付与に失敗しました')
   }
 
-  if (error.code === '23505') {
-    return false
-  }
-
-  throw fromSupabaseError(error, 'バッジの付与に失敗しました')
+  return data === true
 }
 
 export async function checkAndUnlockAchievements(userId: string): Promise<BadgeId[]> {
@@ -219,7 +217,7 @@ export async function checkAndUnlockAchievements(userId: string): Promise<BadgeI
 
   // 並列で一括解禁
   const results = await Promise.allSettled(
-    candidates.map((badgeId) => unlockAchievement(userId, badgeId)),
+    candidates.map((badgeId) => unlockAchievement(badgeId)),
   )
 
   const newlyUnlocked: BadgeId[] = []

--- a/apps/web/src/shared/types/database.types.ts
+++ b/apps/web/src/shared/types/database.types.ts
@@ -489,6 +489,12 @@ export type Database = {
         Args: Record<string, never>
         Returns: undefined
       }
+      unlock_achievement_tx: {
+        Args: {
+          p_badge_id: string
+        }
+        Returns: boolean
+      }
       is_admin: {
         Args: Record<string, never>
         Returns: boolean

--- a/apps/web/supabase/sql/025_gamification_write_lockdown.sql
+++ b/apps/web/supabase/sql/025_gamification_write_lockdown.sql
@@ -1,0 +1,135 @@
+-- 025_gamification_write_lockdown.sql
+-- Issue: #292
+--
+-- 脆弱性: learning_stats / point_history / achievements の own_* ポリシーが
+-- for all のため、本人がクライアントから直接 UPDATE / INSERT でポイント・
+-- ストリーク・バッジを改ざん可能。また award_points_tx に金額上限がなく、
+-- 任意の正数ポイントを自己付与できる。
+--
+-- 修正:
+--   1. 3テーブルの本人ポリシーを SELECT のみに分割（書き込みは RPC 経由に限定）
+--   2. バッジ付与 RPC unlock_achievement_tx を新設（クライアント直 INSERT を置換）
+--   3. award_points_tx に上限 (200) と reason 検証を追加
+--
+-- 注意: admin_select_* ポリシー（014）には影響しない。
+
+-- =========================================================================
+-- 1. own_* ポリシーを SELECT のみに分割
+--    INSERT / UPDATE / DELETE はポリシー未定義 = 全拒否となり、
+--    書き込みは SECURITY DEFINER RPC（award_points_tx /
+--    record_study_activity / unlock_achievement_tx / admin_grant_*）に限定される。
+-- =========================================================================
+
+drop policy if exists own_learning_stats on public.learning_stats;
+create policy own_learning_stats_select on public.learning_stats
+  for select using (auth.uid() = user_id);
+
+drop policy if exists own_point_history on public.point_history;
+create policy own_point_history_select on public.point_history
+  for select using (auth.uid() = user_id);
+
+drop policy if exists own_achievements on public.achievements;
+create policy own_achievements_select on public.achievements
+  for select using (auth.uid() = user_id);
+
+-- =========================================================================
+-- 2. unlock_achievement_tx RPC
+--    本人のバッジ解禁。既保持なら false を返す（重複付与しない）。
+--    バッジ条件の判定はクライアント側（achievementService）で行う設計を
+--    維持しつつ、書き込み経路だけを RPC に一本化する。
+-- =========================================================================
+
+create or replace function public.unlock_achievement_tx(
+  p_badge_id text
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id  uuid := auth.uid();
+  v_inserted integer;
+begin
+  -- 認証チェック
+  if v_user_id is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  -- 入力バリデーション
+  if p_badge_id is null or char_length(btrim(p_badge_id)) = 0 then
+    raise exception 'badge_id is required';
+  end if;
+  if char_length(p_badge_id) > 100 then
+    raise exception 'badge_id is too long (max 100)';
+  end if;
+
+  -- バッジ INSERT（既保持なら do nothing）
+  with ins as (
+    insert into public.achievements (user_id, badge_id)
+    values (v_user_id, p_badge_id)
+    on conflict (user_id, badge_id) do nothing
+    returning 1
+  )
+  select count(*)::int into v_inserted from ins;
+
+  return v_inserted > 0;
+end;
+$$;
+
+grant execute on function public.unlock_achievement_tx(text) to authenticated;
+
+-- =========================================================================
+-- 3. award_points_tx に上限 + reason 検証を追加
+--    アプリ内の最大単発付与は POINTS_MINI_PROJECT_COMPLETE = 100。
+--    余裕を見て上限 200 とする（admin の手動付与は admin_grant_points 側で
+--    上限 10000 を別途持つ）。
+-- =========================================================================
+
+create or replace function public.award_points_tx(
+  p_amount   integer,
+  p_reason   text
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+begin
+  -- 認証チェック
+  if v_user_id is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  -- 金額バリデーション
+  if p_amount <= 0 then
+    raise exception 'Amount must be positive';
+  end if;
+  if p_amount > 200 then
+    raise exception 'Amount exceeds max (200)';
+  end if;
+
+  -- reason バリデーション
+  if p_reason is null or char_length(btrim(p_reason)) = 0 then
+    raise exception 'Reason is required';
+  end if;
+  if char_length(p_reason) > 200 then
+    raise exception 'Reason is too long (max 200)';
+  end if;
+
+  -- total_points をアトミックに加算（行が存在しなければ INSERT）
+  insert into public.learning_stats (user_id, total_points, updated_at)
+  values (v_user_id, p_amount, now())
+  on conflict (user_id) do update
+    set total_points = public.learning_stats.total_points + excluded.total_points,
+        updated_at   = now();
+
+  -- ポイント履歴を記録
+  insert into public.point_history (user_id, amount, reason)
+  values (v_user_id, p_amount, p_reason);
+end;
+$$;
+
+grant execute on function public.award_points_tx(integer, text) to authenticated;


### PR DESCRIPTION
## 概要

Closes #292

v1.0 診断（2026-06-10）で発見したゲーミフィケーションデータの自己改ざん経路を封鎖する。

## 変更内容

### SQL（025_gamification_write_lockdown.sql）
- `learning_stats` / `point_history` / `achievements` の `own_*`（for all）ポリシーを **SELECT のみ**に分割。書き込みは SECURITY DEFINER RPC（`award_points_tx` / `record_study_activity` / `unlock_achievement_tx` / `admin_grant_*`）に限定
- **`unlock_achievement_tx(p_badge_id)` RPC を新設**: 本人バッジ付与を RPC 経由に一本化。既保持なら false を返す（重複付与なし）。badge_id の空文字・長さ検証つき
- **`award_points_tx` を強化**: 上限 200（アプリ内最大単発付与は MINI_PROJECT の 100pt）、reason の空文字拒否・max 200 文字

### クライアント
- `achievementService.unlockAchievement`: 直接 INSERT → RPC 呼び出しに変更（23505 ハンドリングは RPC の戻り値判定に置換、`userId` 引数は不要になり削除）
- `database.types.ts`: `unlock_achievement_tx` の Function 型を追加
- テスト: rpc モックに更新

## ⚠️ デプロイ前の適用が必要

**`025_gamification_write_lockdown.sql` を Supabase に適用してからマージ後のデプロイを行ってください**（適用前にクライアントだけ更新されると、バッジ付与が RPC 不在でエラーになります。逆に SQL だけ先行適用するのは安全です = 旧クライアントの直 INSERT は拒否されますが、Promise.allSettled 内のため学習フローは壊れません）。

## 検証

- CI 4 ゲート PASS（typecheck / lint / **test 927件** / build）
- RLS 変更後の手動確認項目（SQL 適用後）:
  - 非 admin で `learning_stats.total_points` の直接 UPDATE が拒否されること
  - `achievements` への直接 INSERT が拒否されること
  - `award_points_tx(999999, 'x')` が例外になること
  - 学習フロー（4段階 + 練習モード）のポイント付与・バッジ解禁が動作すること

## マージ判断

セキュリティ修正であり、クライアント変更は unlockAchievement の呼び出し経路のみ（判定ロジック不変）。全927テスト PASS のためマージ可と判断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)