### PR TITLE
fix: manualChunks 見直しと lucide-react 全量取り込み解消で初回ロードを65%削減

### DIFF
--- a/apps/web/src/features/base-nook/__tests__/topicIcons.test.ts
+++ b/apps/web/src/features/base-nook/__tests__/topicIcons.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { HelpCircle } from 'lucide-react'
+import { BASE_NOOK_TOPICS } from '../../../content/base-nook/topics'
+import { getTopicIcon, hasTopicIcon } from '../topicIcons'
+
+describe('topicIcons', () => {
+  it('全トピックの icon 名が明示マップに登録されている（漏れがあるとフォールバック表示になる）', () => {
+    const missing = BASE_NOOK_TOPICS.filter((topic) => !hasTopicIcon(topic.icon)).map(
+      (topic) => `${topic.id}: ${topic.icon}`,
+    )
+
+    expect(missing).toEqual([])
+  })
+
+  it('未知のアイコン名は HelpCircle にフォールバックする', () => {
+    expect(getTopicIcon('NoSuchIcon')).toBe(HelpCircle)
+  })
+
+  it('登録済みアイコン名はフォールバックしない', () => {
+    expect(getTopicIcon('FileCode')).not.toBe(HelpCircle)
+  })
+})

--- a/apps/web/src/features/base-nook/components/BaseNookSidebar.tsx
+++ b/apps/web/src/features/base-nook/components/BaseNookSidebar.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { ChevronDown, ChevronUp, Check, Minus } from 'lucide-react'
-import * as Icons from 'lucide-react'
 import type { BaseNookTopic, TopicProgressSummary } from '../../../content/base-nook/types'
+import { getTopicIcon } from '../topicIcons'
 
 interface BaseNookSidebarProps {
   topics: BaseNookTopic[]
@@ -20,7 +20,7 @@ export function BaseNookSidebar({ topics, progressMap }: BaseNookSidebarProps) {
         const correct = progress?.correctCount ?? 0
         const isComplete = correct >= total
 
-        const IconComponent = (Icons as Record<string, Icons.LucideIcon>)[topic.icon] ?? Icons.HelpCircle
+        const IconComponent = getTopicIcon(topic.icon)
 
         return (
           <li key={topic.id}>

--- a/apps/web/src/features/base-nook/components/TopicCard.tsx
+++ b/apps/web/src/features/base-nook/components/TopicCard.tsx
@@ -1,7 +1,7 @@
 import { BookOpenCheck, ChevronRight } from 'lucide-react'
-import * as Icons from 'lucide-react'
 import type { BaseNookTopic, TopicProgressSummary } from '../../../content/base-nook/types'
 import { POINTS_BASE_NOOK_CORRECT } from '../../../shared/constants'
+import { getTopicIcon } from '../topicIcons'
 
 interface TopicCardProps {
   topic: BaseNookTopic
@@ -15,8 +15,7 @@ export function TopicCard({ topic, progress, onClick }: TopicCardProps) {
   const isComplete = correctCount >= totalQuestions
   const earnedPt = correctCount * POINTS_BASE_NOOK_CORRECT
 
-  // アイコンを動的に解決する
-  const IconComponent = (Icons as Record<string, Icons.LucideIcon>)[topic.icon] ?? Icons.HelpCircle
+  const IconComponent = getTopicIcon(topic.icon)
 
   return (
     <button

--- a/apps/web/src/features/base-nook/topicIcons.ts
+++ b/apps/web/src/features/base-nook/topicIcons.ts
@@ -1,0 +1,44 @@
+import {
+  ArrowLeftRight,
+  Braces,
+  Clock,
+  Code,
+  Download,
+  FileCode,
+  HelpCircle,
+  Package,
+  Plug,
+  Puzzle,
+  Send,
+  Shield,
+  TreePine,
+  type LucideIcon,
+} from 'lucide-react'
+
+// content/base-nook/topics.ts の icon 名 → コンポーネントの明示マップ。
+// `import * as Icons from 'lucide-react'` による動的解決は全アイコン
+// （約600KB）をバンドルに取り込み tree-shaking を無効化するため使わない（#295）。
+// 新しいトピックでアイコンを追加する場合はここにも追記する
+// （漏れは topicIcons.test.ts が検出する）。
+const TOPIC_ICONS: Record<string, LucideIcon> = {
+  ArrowLeftRight,
+  Braces,
+  Clock,
+  Code,
+  Download,
+  FileCode,
+  Package,
+  Plug,
+  Puzzle,
+  Send,
+  Shield,
+  TreePine,
+}
+
+export function getTopicIcon(name: string): LucideIcon {
+  return TOPIC_ICONS[name] ?? HelpCircle
+}
+
+export function hasTopicIcon(name: string): boolean {
+  return name in TOPIC_ICONS
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -24,13 +24,13 @@ export default defineConfig({
     target: 'ES2020',
     rollupOptions: {
       output: {
+        // dict 形式 manualChunks はパッケージのバレルごとチャンク化して
+        // tree-shaking を無効化し（lucide-react 全アイコン 601KB）、さらに
+        // vendor チャンクが entry の静的依存に入って lazy 化を無効化するため、
+        // eager 必須の react / supabase のみ残し、他は自然分割に任せる（#295）
         manualChunks: {
           'vendor-react': ['react', 'react-dom', 'react-router-dom'],
           'vendor-supabase': ['@supabase/supabase-js'],
-          'vendor-codemirror': ['@uiw/react-codemirror', '@codemirror/view', '@codemirror/state'],
-          'vendor-markdown': ['react-markdown', 'remark-gfm'],
-          'vendor-prism': ['prismjs'],
-          'vendor-icons': ['lucide-react'],
         },
       },
     },


### PR DESCRIPTION
## 概要

Closes #295

v1.0 診断（2026-06-10）で発見した初回ロード約 1.53MB minified の問題を解消する。原因は2つあった。

## 原因と修正

### 1. dict 形式 manualChunks の副作用（vite.config.ts）
vendor チャンク（codemirror / icons / prism / markdown）が entry の静的依存グラフに入り、main.tsx で全ページを lazy 化しているにもかかわらず初回に modulepreload されていた。eager 必須の `vendor-react` / `vendor-supabase` のみ残し、他は自然分割に変更。

### 2. lucide-react の全アイコン取り込み（base-nook）
`BaseNookSidebar.tsx` / `TopicCard.tsx` の `import * as Icons from 'lucide-react'`（文字列からの動的アイコン解決）が tree-shaking を無効化し、全アイコン約 600KB をバンドルに取り込んでいた。manualChunks を外しただけでは BaseNookPage チャンクに 584KB が移動するだけだったため、**使用12アイコンの明示マップ `topicIcons.ts` に置換**。トピック追加時の登録漏れは新規テスト `topicIcons.test.ts` が検出する（漏れても HelpCircle フォールバックで表示は破綻しない）。

## 計測結果（minified）

| | Before | After |
|---|---|---|
| 初回ロード合計 | **約 1,530 KB** | **532 KB（-65%）** |
| index.html の preload | index + react + supabase + **codemirror 398KB + icons 601KB** | index 269KB + react 98KB + supabase 171KB のみ |
| BaseNookPage | （icons が vendor に分離） | 8.65 KB |
| CodeEditor（lazy） | 115KB + vendor-codemirror 398KB | 512 KB（学習ページでのみロード） |
| prism-jsx（lazy） | 425KB + vendor-prism/markdown | 601 KB（ステップページでのみロード） |

lazy チャンク（CodeEditor / prism-jsx）は該当ページ初回表示時のみロードされ、初回ロードには含まれない。prism-jsx のコース別分割は v1.0 後の改善候補。

## 検証

- CI 4 ゲート PASS（typecheck / lint / **test 930件（+3）** / build）
- `dist/index.html` の modulepreload から codemirror / icons が消えたことを確認
- 全トピックのアイコン名がマップに存在することをテストで担保

## マージ判断

挙動変更はアイコン解決経路のみで、表示されるアイコンは同一（テストで担保）。バンドル構成の改善効果が大きく、全930テスト PASS のためマージ可と判断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)