### PR TITLE
fix: user_feedback の本人 UPDATE を image_paths のみに制限

### DIFF
--- a/apps/web/src/services/__tests__/feedbackService.test.ts
+++ b/apps/web/src/services/__tests__/feedbackService.test.ts
@@ -139,9 +139,20 @@ const from = vi.fn((table: string) => {
   throw new Error(`unexpected table: ${table}`)
 })
 
+const rpcState = {
+  calls: [] as Array<{ fn: string; args: Record<string, unknown> }>,
+  result: { error: null as unknown },
+}
+
+const rpcMock = vi.fn((fn: string, args: Record<string, unknown>) => {
+  rpcState.calls.push({ fn, args })
+  return Promise.resolve({ data: null, error: rpcState.result.error })
+})
+
 vi.mock('../../lib/supabaseClient', () => ({
   supabase: {
     from: (...args: unknown[]) => from(...(args as [string])),
+    rpc: (...args: unknown[]) => rpcMock(...(args as [string, Record<string, unknown>])),
     storage: {
       from: (...args: unknown[]) => storageFrom(...(args as [string])),
     },
@@ -170,6 +181,8 @@ function resetState() {
   storageState.uploadCalls = []
   storageState.uploadResult = { error: null }
   storageState.signedUrlsResult = { data: null, error: null }
+  rpcState.calls = []
+  rpcState.result = { error: null }
 }
 
 describe('FEEDBACK_CATEGORIES / FEEDBACK_STATUSES', () => {
@@ -546,7 +559,7 @@ describe('uploadFeedbackImages', () => {
 describe('submitFeedback with files', () => {
   beforeEach(resetState)
 
-  it('画像付き送信で INSERT → Storage アップロード → UPDATE の順に実行する', async () => {
+  it('画像付き送信で INSERT → Storage アップロード → RPC 保存の順に実行する', async () => {
     const feedbackRow = {
       id: VALID_FEEDBACK_ID,
       user_id: VALID_USER_ID,
@@ -556,10 +569,6 @@ describe('submitFeedback with files', () => {
       image_paths: [],
     }
     userFeedbackState.insertResult = { data: feedbackRow, error: null }
-    userFeedbackState.updateResult = {
-      data: { ...feedbackRow, image_paths: ['path/a.png'] },
-      error: null,
-    }
 
     const files = [createTestFile('screenshot.png', 1024)]
     const result = await submitFeedback({
@@ -573,12 +582,38 @@ describe('submitFeedback with files', () => {
     expect(userFeedbackState.insertPayload).not.toBeNull()
     // Storage アップロードが呼ばれている
     expect(storageState.uploadCalls).toHaveLength(1)
-    // UPDATE で image_paths が設定されている
-    expect(userFeedbackState.updatePayload).toHaveProperty('image_paths')
-    expect(result.image_paths).toEqual(['path/a.png'])
+    // RPC で image_paths が保存されている（直接 UPDATE は RLS で封鎖済み）
+    const uploadedPath = storageState.uploadCalls[0]?.path
+    expect(rpcState.calls).toHaveLength(1)
+    expect(rpcState.calls[0]?.fn).toBe('update_own_feedback_images')
+    expect(rpcState.calls[0]?.args).toEqual({
+      p_feedback_id: VALID_FEEDBACK_ID,
+      p_image_paths: [uploadedPath],
+    })
+    expect(result.image_paths).toEqual([uploadedPath])
   })
 
-  it('画像なし送信では Storage アップロードも UPDATE も呼ばない', async () => {
+  it('image_paths 保存 RPC が失敗したらアプリ共通エラーを投げる', async () => {
+    userFeedbackState.insertResult = {
+      data: { id: VALID_FEEDBACK_ID, image_paths: [] },
+      error: null,
+    }
+    rpcState.result = { error: { message: 'permission denied' } }
+
+    await expect(
+      submitFeedback({
+        userId: VALID_USER_ID,
+        category: 'bug',
+        message: 'hello',
+        files: [createTestFile('screenshot.png', 1024)],
+      }),
+    ).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: '画像パスの保存に失敗しました',
+    })
+  })
+
+  it('画像なし送信では Storage アップロードも RPC も呼ばない', async () => {
     userFeedbackState.insertResult = {
       data: { id: VALID_FEEDBACK_ID, image_paths: [] },
       error: null,
@@ -590,7 +625,7 @@ describe('submitFeedback with files', () => {
     })
 
     expect(storageState.uploadCalls).toHaveLength(0)
-    expect(userFeedbackState.updatePayload).toBeNull()
+    expect(rpcState.calls).toHaveLength(0)
   })
 })
 

--- a/apps/web/src/services/feedbackService.ts
+++ b/apps/web/src/services/feedbackService.ts
@@ -142,20 +142,20 @@ export async function submitFeedback(input: SubmitFeedbackInput): Promise<UserFe
     throw fromSupabaseError(error, 'フィードバックの送信に失敗しました')
   }
 
-  // 2. 画像があれば Storage にアップロードし image_paths を UPDATE
+  // 2. 画像があれば Storage にアップロードし image_paths を保存する。
+  //    本人の直接 UPDATE は RLS で封鎖済み（026）。RPC がパス形式
+  //    （自分のディレクトリ配下・最大3枚）を検証して image_paths のみ更新する
   if (files.length > 0) {
     const paths = await uploadFeedbackImages(input.userId, data.id, files)
-    const { data: updated, error: updateError } = await supabase
-      .from('user_feedback')
-      .update({ image_paths: paths as Json[] })
-      .eq('id', data.id)
-      .select()
-      .single()
+    const { error: updateError } = await supabase.rpc('update_own_feedback_images', {
+      p_feedback_id: data.id,
+      p_image_paths: paths as Json[],
+    })
 
     if (updateError) {
       throw fromSupabaseError(updateError, '画像パスの保存に失敗しました')
     }
-    return updated
+    return { ...data, image_paths: paths as Json[] }
   }
 
   return data

--- a/apps/web/src/shared/types/database.types.ts
+++ b/apps/web/src/shared/types/database.types.ts
@@ -495,6 +495,13 @@ export type Database = {
         }
         Returns: boolean
       }
+      update_own_feedback_images: {
+        Args: {
+          p_feedback_id: string
+          p_image_paths: Json
+        }
+        Returns: undefined
+      }
       is_admin: {
         Args: Record<string, never>
         Returns: boolean

--- a/apps/web/supabase/sql/026_feedback_update_restriction.sql
+++ b/apps/web/supabase/sql/026_feedback_update_restriction.sql
@@ -1,0 +1,80 @@
+-- 026_feedback_update_restriction.sql
+-- Issue: #293
+--
+-- 脆弱性: 019 で追加した user_feedback_update_own_images ポリシー（for update,
+-- 本人行）は列を制限できないため、本人が自分のフィードバックの status /
+-- admin_note も書き換え可能だった（admin 運用の整合性が崩れる）。
+--
+-- 修正（案B）: 本人の直接 UPDATE ポリシーを削除し、image_paths の書き込みを
+-- SECURITY DEFINER RPC に置換する。RPC 側でパス形式（自分の Storage ディレクトリ
+-- 配下のみ・最大3枚・文字列配列）を検証するため、019 当時より制約が強くなる。
+-- admin の status / admin_note 更新は既存の user_feedback_update_admin
+-- ポリシー（admin のみ）のまま変更しない。
+
+-- =========================================================================
+-- 1. 本人の直接 UPDATE ポリシーを削除
+--    これにより一般ユーザーの user_feedback UPDATE 経路は RPC のみになる。
+-- =========================================================================
+
+drop policy if exists "user_feedback_update_own_images" on public.user_feedback;
+
+-- =========================================================================
+-- 2. update_own_feedback_images RPC
+--    本人のフィードバックの image_paths のみを更新する。
+-- =========================================================================
+
+create or replace function public.update_own_feedback_images(
+  p_feedback_id uuid,
+  p_image_paths jsonb
+)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_user_id uuid := auth.uid();
+  v_elem    jsonb;
+  v_updated integer;
+begin
+  -- 認証チェック
+  if v_user_id is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  -- 入力バリデーション
+  if p_feedback_id is null then
+    raise exception 'feedback_id is required';
+  end if;
+  if p_image_paths is null or jsonb_typeof(p_image_paths) <> 'array' then
+    raise exception 'image_paths must be a json array';
+  end if;
+  if jsonb_array_length(p_image_paths) > 3 then
+    raise exception 'image_paths exceeds max count (3)';
+  end if;
+
+  -- 各要素は文字列で、自分の Storage ディレクトリ（{user_id}/...）配下のみ許可
+  for v_elem in select * from jsonb_array_elements(p_image_paths)
+  loop
+    if jsonb_typeof(v_elem) <> 'string' then
+      raise exception 'image_paths must contain only strings';
+    end if;
+    if (v_elem #>> '{}') not like (v_user_id::text || '/%') then
+      raise exception 'image path must be under own directory';
+    end if;
+  end loop;
+
+  -- 本人の行のみ更新（他人の feedback_id を渡しても 0 行更新で拒否）
+  update public.user_feedback
+    set image_paths = p_image_paths
+    where id = p_feedback_id
+      and user_id = v_user_id;
+
+  get diagnostics v_updated = row_count;
+  if v_updated = 0 then
+    raise exception 'feedback not found';
+  end if;
+end;
+$$;
+
+grant execute on function public.update_own_feedback_images(uuid, jsonb) to authenticated;


### PR DESCRIPTION
## 概要

Closes #293

019 で追加した `user_feedback_update_own_images` ポリシー（for update, 本人行）は RLS の制約上、列を限定できないため、本人が自分のフィードバックの `status` / `admin_note` も書き換え可能だった。これを封鎖する。

## 採用案と判断

Issue の **案B（RPC 化）を採用**。案A（列レベル権限）は、admin の status / admin_note 更新も同じ authenticated ロールの直接 UPDATE で行われているため、列 grant の組み合わせでは「本人には image_paths のみ・admin には status / admin_note も」を表現できず、admin フロー全体の RPC 化が必要になり影響が大きい。案B なら本人側の書き込み経路だけを差し替えればよく、admin の既存フロー（`user_feedback_update_admin` ポリシー + 監査ログ）は無変更で済む。

## 変更内容

### SQL（026_feedback_update_restriction.sql）
- `user_feedback_update_own_images` ポリシーを削除（本人の直接 UPDATE 経路を全封鎖）
- `update_own_feedback_images(p_feedback_id, p_image_paths)` RPC を新設
  - 検証: JSON 配列・最大3要素・全要素が文字列・**パスが自分の Storage ディレクトリ（`{user_id}/...`）配下**・本人の行のみ更新
  - 019 当時より制約が強くなる（従来は任意の jsonb を書き込めた）

### クライアント
- `feedbackService.submitFeedback`: 画像パス保存を直接 UPDATE → RPC に変更
- `database.types.ts`: `update_own_feedback_images` の Function 型を追加
- テスト: RPC モック化 + RPC 失敗時のエラーケースを追加

## ⚠️ デプロイ前の適用が必要

**`026_feedback_update_restriction.sql` を Supabase に適用してからデプロイしてください。** SQL 先行適用は安全（旧クライアントの画像添付送信は一時的に失敗するが、テキストのみのフィードバック送信は影響なし）。

## 検証

- CI 4 ゲート PASS（typecheck / lint / **test 931件** / build）
- SQL 適用後の手動確認項目:
  - 一般ユーザーが自分の feedback の `status` / `admin_note` を UPDATE できないこと
  - 画像添付フロー（アップロード → 保存 → admin 詳細画面で表示）が動くこと
  - admin のステータス / メモ更新 + 監査ログが従来どおり動くこと

## マージ判断

挙動変更は画像パス保存の経路のみで、admin フローは無変更。検証強化を含むセキュリティ修正であり、全931テスト PASS のためマージ可と判断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)