### PR TITLE
test: フィードバック安全修正の回帰テストを追加

### DIFF
--- a/apps/web/src/features/admin/components/__tests__/ImageLightbox.test.tsx
+++ b/apps/web/src/features/admin/components/__tests__/ImageLightbox.test.tsx
@@ -52,6 +52,17 @@ describe('ImageLightbox', () => {
     expect(onClose).toHaveBeenCalledOnce()
   })
 
+  it('操作アイコンは装飾として aria-hidden を持つ', () => {
+    render(
+      <ImageLightbox images={images} currentIndex={1} onClose={vi.fn()} onChangeIndex={vi.fn()} />,
+    )
+
+    for (const name of ['閉じる', '前の画像', '次の画像']) {
+      const button = screen.getByRole('button', { name })
+      expect(button.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true')
+    }
+  })
+
   it('ArrowRight キーで次の画像に切り替わる', () => {
     const onChangeIndex = vi.fn()
     render(

--- a/apps/web/src/features/feedback/__tests__/FeedbackDialog.test.tsx
+++ b/apps/web/src/features/feedback/__tests__/FeedbackDialog.test.tsx
@@ -72,6 +72,7 @@ describe('FeedbackDialog', () => {
     await waitFor(() => {
       expect(screen.getByText(/送信しました/)).toBeTruthy()
     })
+    expect(screen.getByRole('status').textContent).toContain('送信しました')
   })
 
   it('submitFeedback が失敗したらエラーを表示し onClose を呼ばない', async () => {
@@ -85,6 +86,7 @@ describe('FeedbackDialog', () => {
     await waitFor(() => {
       expect(screen.getByText('permission denied')).toBeTruthy()
     })
+    expect(screen.getByRole('alert').textContent).toContain('permission denied')
     expect(onClose).not.toHaveBeenCalled()
   })
 
@@ -98,6 +100,7 @@ describe('FeedbackDialog', () => {
     await waitFor(() => {
       expect(screen.getByText('送信にはログインが必要です')).toBeTruthy()
     })
+    expect(screen.getByRole('alert').textContent).toContain('送信にはログインが必要です')
     expect(submitFeedbackMock).not.toHaveBeenCalled()
   })
 
@@ -124,6 +127,7 @@ describe('FeedbackDialog', () => {
     await waitFor(() => {
       expect(screen.getByText(/画像ファイルではありません/)).toBeTruthy()
     })
+    expect(screen.getByRole('alert').textContent).toContain('画像ファイルではありません')
   })
 
   it('画像を追加するとプレビューが表示され削除ボタンで除去できる', async () => {

--- a/apps/web/src/pages/admin/__tests__/AdminFeedbackDetailPage.test.tsx
+++ b/apps/web/src/pages/admin/__tests__/AdminFeedbackDetailPage.test.tsx
@@ -137,6 +137,22 @@ describe('AdminFeedbackDetailPage', () => {
     expect(screen.getByAltText('添付画像 2').getAttribute('src')).toBe('https://example.com/b.jpg')
   })
 
+  it('image_paths に非文字列が混ざっていても文字列だけで signed URL を取得する', async () => {
+    getFeedbackMock.mockResolvedValue({
+      ...baseFeedback,
+      image_paths: ['uid/fid/a.png', 123, null, { path: 'bad' }, false],
+    })
+    getFeedbackImageUrlsMock.mockResolvedValue([
+      { path: 'uid/fid/a.png', url: 'https://example.com/a.png' },
+    ])
+    renderPage()
+
+    await waitFor(() => {
+      expect(getFeedbackImageUrlsMock).toHaveBeenCalledWith(['uid/fid/a.png'])
+    })
+    expect(screen.getByAltText('添付画像 1').getAttribute('src')).toBe('https://example.com/a.png')
+  })
+
   it('サムネイルクリックで Lightbox が開く', async () => {
     getFeedbackMock.mockResolvedValue({
       ...baseFeedback,


### PR DESCRIPTION
Closes #260, closes #261, closes #262, closes #263. 対象実装はdev上で修正済みだったため、型安全/a11yの再発防止テストを追加。検証: typecheck/lint/test/build pass。