### PR TITLE
fix: Step Insightsのイベント取得をページング対応

### DIFF
--- a/apps/web/src/services/__tests__/adminQualityService.test.ts
+++ b/apps/web/src/services/__tests__/adminQualityService.test.ts
@@ -22,13 +22,31 @@ const tableState: Record<TableName, { data: unknown[]; count: number | null; err
   learning_events: { data: [], count: null, error: null },
 }
 
+const learningEventsRanges: Array<[number, number]> = []
+
 const from = vi.fn((table: TableName) => ({
-  select: () =>
-    Promise.resolve({
+  select: () => {
+    if (table === 'learning_events') {
+      return {
+        order: () => ({
+          range: (fromIndex: number, toIndex: number) => {
+            learningEventsRanges.push([fromIndex, toIndex])
+            return Promise.resolve({
+              data: tableState[table].data.slice(fromIndex, toIndex + 1),
+              count: tableState[table].count,
+              error: tableState[table].error,
+            })
+          },
+        }),
+      }
+    }
+
+    return Promise.resolve({
       data: tableState[table].data,
       count: tableState[table].count,
       error: tableState[table].error,
-    }),
+    })
+  },
 }))
 
 vi.mock('../../lib/supabaseClient', () => ({
@@ -39,6 +57,7 @@ vi.mock('../../lib/supabaseClient', () => ({
 
 function resetState() {
   vi.clearAllMocks()
+  learningEventsRanges.length = 0
   for (const table of Object.keys(tableState) as TableName[]) {
     tableState[table] = { data: [], count: table === 'profiles' ? 0 : null, error: null }
   }
@@ -318,6 +337,7 @@ describe('getAdminStepInsights', () => {
 
     expect(from).toHaveBeenCalledWith('learning_events')
     expect(insights.totalEvents).toBe(14)
+    expect(learningEventsRanges).toEqual([[0, 999]])
     expect(insights.observedSteps).toBeGreaterThan(0)
     expect(row).toEqual(
       expect.objectContaining({
@@ -354,5 +374,28 @@ describe('getAdminStepInsights', () => {
       name: 'AppError',
       userMessage: 'Step Insightsのイベントログ取得に失敗しました',
     })
+  })
+
+  it('learning_events をページングして1000件超のイベントも集計する', async () => {
+    tableState.learning_events.data = Array.from({ length: 1001 }, (_, index) => ({
+      id: index + 1,
+      user_id: `u${index}`,
+      event_type: 'step_started',
+      step_id: 'usestate-basic',
+      mode: null,
+      payload: null,
+      created_at: '2026-06-05T00:00:00Z',
+    }))
+
+    const insights = await getAdminStepInsights()
+    const row = insights.rows.find((item) => item.stepId === 'usestate-basic')
+
+    expect(learningEventsRanges).toEqual([
+      [0, 999],
+      [1000, 1999],
+    ])
+    expect(insights.totalEvents).toBe(1001)
+    expect(row?.eventCount).toBe(1001)
+    expect(row?.startedUsers).toBe(1001)
   })
 })

--- a/apps/web/src/services/adminQualityService.ts
+++ b/apps/web/src/services/adminQualityService.ts
@@ -27,7 +27,7 @@ type StepFeedbackRow = Pick<Tables<'user_feedback'>, 'status' | 'created_at' | '
 type ReviewItemRow = Pick<Tables<'review_items'>, 'status' | 'step_id'>
 type LearningEventRow = Pick<
   Tables<'learning_events'>,
-  'user_id' | 'event_type' | 'step_id' | 'mode' | 'payload' | 'created_at'
+  'id' | 'user_id' | 'event_type' | 'step_id' | 'mode' | 'payload' | 'created_at'
 >
 
 export type AdminQualityMetricStatus = 'formal' | 'provisional' | 'future'
@@ -175,6 +175,9 @@ interface StepEventAggregate {
 }
 
 const STEP_INSIGHT_MODES: readonly LearningMode[] = ['read', 'practice', 'test', 'challenge']
+const LEARNING_EVENTS_PAGE_SIZE = 1000
+const LEARNING_EVENTS_SELECT =
+  'id, user_id, event_type, step_id, mode, payload, created_at'
 
 function isStepCompleted(row: StepProgressRow): boolean {
   return Boolean(
@@ -628,6 +631,30 @@ function buildStepInsights(aggregates: StepAggregate[]): AdminQualityStepInsight
   }).sort((a, b) => a.order - b.order)
 }
 
+async function fetchAllLearningEvents(): Promise<LearningEventRow[]> {
+  const rows: LearningEventRow[] = []
+
+  for (let from = 0; ; from += LEARNING_EVENTS_PAGE_SIZE) {
+    const to = from + LEARNING_EVENTS_PAGE_SIZE - 1
+    const { data, error } = await supabase
+      .from('learning_events')
+      .select(LEARNING_EVENTS_SELECT)
+      .order('id', { ascending: true })
+      .range(from, to)
+
+    if (error) {
+      throw fromSupabaseError(error, 'Step Insightsのイベントログ取得に失敗しました')
+    }
+
+    const pageRows = (data ?? []) as LearningEventRow[]
+    rows.push(...pageRows)
+
+    if (pageRows.length < LEARNING_EVENTS_PAGE_SIZE) {
+      return rows
+    }
+  }
+}
+
 export async function getAdminQualityDashboard(): Promise<AdminQualityDashboard> {
   const [
     usersRes,
@@ -801,19 +828,14 @@ export async function getAdminQualityDashboard(): Promise<AdminQualityDashboard>
 }
 
 export async function getAdminStepInsights(): Promise<AdminStepInsights> {
-  const [eventsRes, feedbackRes] = await Promise.all([
-    supabase
-      .from('learning_events')
-      .select('user_id, event_type, step_id, mode, payload, created_at'),
+  const [events, feedbackRes] = await Promise.all([
+    fetchAllLearningEvents(),
     supabase.from('user_feedback').select('status, created_at, page_url'),
   ])
 
-  if (eventsRes.error)
-    throw fromSupabaseError(eventsRes.error, 'Step Insightsのイベントログ取得に失敗しました')
   if (feedbackRes.error)
     throw fromSupabaseError(feedbackRes.error, 'Step Insightsのフィードバック取得に失敗しました')
 
-  const events = (eventsRes.data ?? []) as LearningEventRow[]
   const feedbackRows = (feedbackRes.data ?? []) as StepFeedbackRow[]
   const rows = buildAdminStepInsightRows(buildStepEventAggregates(events, feedbackRows))
   const observedRows = rows.filter((row) => row.eventCount > 0 || row.relatedFeedbackCount > 0)


### PR DESCRIPTION
Closes #302. learning_events を id 昇順 + range() で1000件単位にページング取得し、PostgREST上限によるStep Insights集計欠落を防止。検証: targeted test/typecheck/lint/test/build pass。