### PR TITLE
feat: Practice系完了イベントを記録

### DIFF
--- a/apps/web/src/services/__tests__/codeDoctorService.test.ts
+++ b/apps/web/src/services/__tests__/codeDoctorService.test.ts
@@ -1,6 +1,7 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { supabase } from '../../lib/supabaseClient'
 import { awardPoints } from '../pointService'
+import { trackLearningEvent } from '../eventService'
 import {
   getPointsForDifficulty,
   judgeCode,
@@ -13,9 +14,11 @@ vi.mock('../../lib/supabaseClient', () => ({
   supabase: { from: vi.fn() },
 }))
 vi.mock('../pointService', () => ({ awardPoints: vi.fn() }))
+vi.mock('../eventService', () => ({ trackLearningEvent: vi.fn() }))
 
 const mockFrom = vi.mocked(supabase.from)
 const mockAwardPoints = vi.mocked(awardPoints)
+const mockTrackLearningEvent = vi.mocked(trackLearningEvent)
 
 // ─── 純粋関数テスト ──────────────────────────────────────
 
@@ -124,6 +127,16 @@ describe('submitDoctorSolution', () => {
     expect(result.passed).toBe(true)
     expect(result.pointsEarned).toBe(15)
     expect(mockAwardPoints).toHaveBeenCalledWith(15, 'コードドクター正解（beginner）')
+    expect(mockTrackLearningEvent).toHaveBeenCalledWith({
+      userId: '00000000-0000-0000-0000-000000000001',
+      eventType: 'code_doctor_completed',
+      payload: {
+        problemId: 'cd-beginner-001',
+        category: 'react',
+        difficulty: 'beginner',
+        pointsEarned: 15,
+      },
+    })
   })
 
   it('不正解の場合は passed: false で 0 pt', async () => {
@@ -131,6 +144,7 @@ describe('submitDoctorSolution', () => {
     expect(result.passed).toBe(false)
     expect(result.pointsEarned).toBe(0)
     expect(mockAwardPoints).not.toHaveBeenCalled()
+    expect(mockTrackLearningEvent).not.toHaveBeenCalled()
   })
 
   it('不足キーワードが missingKeywords に含まれる', async () => {

--- a/apps/web/src/services/__tests__/codeReadingService.test.ts
+++ b/apps/web/src/services/__tests__/codeReadingService.test.ts
@@ -1,6 +1,7 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { supabase } from '../../lib/supabaseClient'
 import { awardPoints } from '../pointService'
+import { trackLearningEvent } from '../eventService'
 import {
   getPointsForDifficulty,
   judgeAnswer,
@@ -13,9 +14,11 @@ vi.mock('../../lib/supabaseClient', () => ({
   supabase: { from: vi.fn() },
 }))
 vi.mock('../pointService', () => ({ awardPoints: vi.fn() }))
+vi.mock('../eventService', () => ({ trackLearningEvent: vi.fn() }))
 
 const mockFrom = vi.mocked(supabase.from)
 const mockAwardPoints = vi.mocked(awardPoints)
+const mockTrackLearningEvent = vi.mocked(trackLearningEvent)
 
 // ─── サンプルデータ ──────────────────────────────────────
 
@@ -159,6 +162,17 @@ describe('submitReading', () => {
     expect(result.allCorrect).toBe(true)
     expect(result.pointsEarned).toBe(10)
     expect(mockAwardPoints).toHaveBeenCalledWith(10, 'コードリーディング完了（カスタムフック）')
+    expect(mockTrackLearningEvent).toHaveBeenCalledWith({
+      userId: '00000000-0000-0000-0000-000000000001',
+      eventType: 'code_reading_completed',
+      payload: {
+        problemId: 'cr-001',
+        difficulty: 'basic',
+        correctCount: 3,
+        totalCount: 3,
+        pointsEarned: 10,
+      },
+    })
   })
 
   it('全問正解でも previousCompleted: true の場合はポイントを付与しない', async () => {
@@ -167,6 +181,7 @@ describe('submitReading', () => {
     expect(result.allCorrect).toBe(true)
     expect(result.pointsEarned).toBe(0)
     expect(mockAwardPoints).not.toHaveBeenCalled()
+    expect(mockTrackLearningEvent).not.toHaveBeenCalled()
   })
 
   it('部分正解の場合は allCorrect: false で 0 pt', async () => {
@@ -175,6 +190,7 @@ describe('submitReading', () => {
     expect(result.allCorrect).toBe(false)
     expect(result.pointsEarned).toBe(0)
     expect(mockAwardPoints).not.toHaveBeenCalled()
+    expect(mockTrackLearningEvent).not.toHaveBeenCalled()
   })
 
   it('questionResults の長さが問題数と一致する', async () => {

--- a/apps/web/src/services/__tests__/dailyChallengeService.test.ts
+++ b/apps/web/src/services/__tests__/dailyChallengeService.test.ts
@@ -1,6 +1,7 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { supabase } from '../../lib/supabaseClient'
 import { awardPoints } from '../pointService'
+import { trackLearningEvent } from '../eventService'
 import { pickForDaily, recordWrongAnswer, resolveReviewItem } from '../reviewService'
 import {
   getTodayJst,
@@ -23,6 +24,10 @@ vi.mock('../pointService', () => ({
   awardPoints: vi.fn(),
 }))
 
+vi.mock('../eventService', () => ({
+  trackLearningEvent: vi.fn(),
+}))
+
 vi.mock('../reviewService', () => ({
   pickForDaily: vi.fn(),
   recordWrongAnswer: vi.fn(),
@@ -31,6 +36,7 @@ vi.mock('../reviewService', () => ({
 
 const mockFrom = vi.mocked(supabase.from)
 const mockAwardPoints = vi.mocked(awardPoints)
+const mockTrackLearningEvent = vi.mocked(trackLearningEvent)
 const mockPickForDaily = vi.mocked(pickForDaily)
 const mockRecordWrongAnswer = vi.mocked(recordWrongAnswer)
 const mockResolveReviewItem = vi.mocked(resolveReviewItem)
@@ -309,6 +315,18 @@ describe('submitDailyAnswer', () => {
       questionId: 'usestate-basic-daily-0',
     })
     expect(mockAwardPoints).toHaveBeenCalledWith(20, 'デイリーチャレンジ正解')
+    expect(mockTrackLearningEvent).toHaveBeenCalledWith({
+      userId,
+      eventType: 'daily_completed',
+      stepId: 'usestate-basic',
+      mode: 'daily',
+      payload: {
+        questionId: 'usestate-basic-daily-0',
+        challengeDate: dateStr,
+        pointsEarned: 20,
+        streak: 0,
+      },
+    })
   })
 
   it('弱点優先のDaily正解時は元の復習itemも resolved にする', async () => {
@@ -346,6 +364,7 @@ describe('submitDailyAnswer', () => {
       userInput: 'wrongAnswer',
     })
     expect(mockAwardPoints).not.toHaveBeenCalled()
+    expect(mockTrackLearningEvent).not.toHaveBeenCalled()
   })
 
   it('前後の空白を無視して正解判定する', async () => {

--- a/apps/web/src/services/__tests__/miniProjectService.test.ts
+++ b/apps/web/src/services/__tests__/miniProjectService.test.ts
@@ -1,6 +1,7 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { supabase } from '../../lib/supabaseClient'
 import { awardPoints } from '../pointService'
+import { trackLearningEvent } from '../eventService'
 import {
   judgeProject,
   calcStatus,
@@ -13,9 +14,11 @@ vi.mock('../../lib/supabaseClient', () => ({
   supabase: { from: vi.fn() },
 }))
 vi.mock('../pointService', () => ({ awardPoints: vi.fn() }))
+vi.mock('../eventService', () => ({ trackLearningEvent: vi.fn() }))
 
 const mockFrom = vi.mocked(supabase.from)
 const mockAwardPoints = vi.mocked(awardPoints)
+const mockTrackLearningEvent = vi.mocked(trackLearningEvent)
 
 // ─── サンプルデータ ──────────────────────────────────────
 
@@ -169,6 +172,17 @@ describe('submitProject', () => {
     expect(result.allPassed).toBe(true)
     expect(result.pointsEarned).toBe(100)
     expect(mockAwardPoints).toHaveBeenCalledWith(100, 'ミニプロジェクト完了（Todo App）')
+    expect(mockTrackLearningEvent).toHaveBeenCalledWith({
+      userId: '00000000-0000-0000-0000-000000000001',
+      eventType: 'mini_project_completed',
+      mode: 'mini_project',
+      payload: {
+        projectId: 'todo-app',
+        difficulty: 'beginner',
+        milestoneCount: 2,
+        pointsEarned: 100,
+      },
+    })
   })
 
   it('初回 completed 時のみポイントを付与する（previousStatus: not_started）', async () => {
@@ -183,6 +197,7 @@ describe('submitProject', () => {
     const result = await submitProject('00000000-0000-0000-0000-000000000001', sampleProject, code, 'completed')
     expect(result.pointsEarned).toBe(0)
     expect(mockAwardPoints).not.toHaveBeenCalled()
+    expect(mockTrackLearningEvent).not.toHaveBeenCalled()
   })
 
   it('一部通過の場合は 0 Pt で allPassed: false', async () => {
@@ -191,6 +206,7 @@ describe('submitProject', () => {
     expect(result.allPassed).toBe(false)
     expect(result.pointsEarned).toBe(0)
     expect(mockAwardPoints).not.toHaveBeenCalled()
+    expect(mockTrackLearningEvent).not.toHaveBeenCalled()
   })
 
   it('milestoneResults の長さがマイルストーン数と一致する', async () => {

--- a/apps/web/src/services/codeDoctorService.ts
+++ b/apps/web/src/services/codeDoctorService.ts
@@ -8,6 +8,7 @@ import {
 import { fromSupabaseError } from '../shared/errors'
 import { assertMaxLength, assertUuid } from '../shared/validation'
 import { awardPoints } from './pointService'
+import { trackLearningEvent } from './eventService'
 import { judgeKeywords } from '../lib/judge'
 import type { CodeDoctorProblem, CodeDoctorProgress, SubmitDoctorResult } from '../content/code-doctor/types'
 
@@ -112,6 +113,16 @@ export async function submitDoctorSolution(
       pointsEarned,
       `コードドクター正解（${problem.difficulty}）`,
     )
+    trackLearningEvent({
+      userId,
+      eventType: 'code_doctor_completed',
+      payload: {
+        problemId: problem.id,
+        category: problem.category,
+        difficulty: problem.difficulty,
+        pointsEarned,
+      },
+    })
   }
 
   return { passed, pointsEarned, missingKeywords, foundNgKeywords, explanation: problem.explanation }

--- a/apps/web/src/services/codeReadingService.ts
+++ b/apps/web/src/services/codeReadingService.ts
@@ -7,6 +7,7 @@ import {
   POINTS_CODE_READING_ADVANCED,
 } from '../shared/constants'
 import { awardPoints } from './pointService'
+import { trackLearningEvent } from './eventService'
 import type {
   CodeReadingProblem,
   CodeReadingProgress,
@@ -113,6 +114,17 @@ export async function submitReading(
 
   if (isNewlyCompleted) {
     await awardPoints(pointsEarned, `コードリーディング完了（${problem.title}）`)
+    trackLearningEvent({
+      userId,
+      eventType: 'code_reading_completed',
+      payload: {
+        problemId: problem.id,
+        difficulty: problem.difficulty,
+        correctCount,
+        totalCount: problem.questions.length,
+        pointsEarned,
+      },
+    })
   }
 
   return { questionResults, allCorrect, correctCount, pointsEarned }

--- a/apps/web/src/services/dailyChallengeService.ts
+++ b/apps/web/src/services/dailyChallengeService.ts
@@ -3,6 +3,7 @@ import { MAX_ANSWER_LENGTH, POINTS_DAILY_CORRECT, POINTS_DAILY_STREAK_BONUS } fr
 import { fromSupabaseError } from '../shared/errors'
 import { assertMaxLength, assertUuid } from '../shared/validation'
 import { awardPoints } from './pointService'
+import { trackLearningEvent } from './eventService'
 import {
   pickForDaily,
   recordWrongAnswer,
@@ -255,6 +256,19 @@ export async function submitDailyAnswer(
     if (streak > 0 && streak % 7 === 0) {
       await awardPoints(POINTS_DAILY_STREAK_BONUS, `デイリー${streak}日連続ボーナス`)
     }
+
+    trackLearningEvent({
+      userId,
+      eventType: 'daily_completed',
+      stepId: question.stepId,
+      mode: 'daily',
+      payload: {
+        questionId: question.id,
+        challengeDate: dateStr,
+        pointsEarned,
+        streak,
+      },
+    })
   } else {
     try {
       await recordWrongAnswer({

--- a/apps/web/src/services/eventService.ts
+++ b/apps/web/src/services/eventService.ts
@@ -10,6 +10,8 @@ export type LearningEventType =
   | 'test_submitted'
   | 'challenge_submitted'
   | 'daily_completed'
+  | 'code_doctor_completed'
+  | 'code_reading_completed'
   | 'review_item_created'
   | 'review_item_resolved'
   | 'mini_project_started'

--- a/apps/web/src/services/miniProjectService.ts
+++ b/apps/web/src/services/miniProjectService.ts
@@ -3,6 +3,7 @@ import { MAX_CODE_LENGTH, POINTS_MINI_PROJECT_COMPLETE } from '../shared/constan
 import { fromSupabaseError } from '../shared/errors'
 import { assertMaxLength, assertUuid } from '../shared/validation'
 import { awardPoints } from './pointService'
+import { trackLearningEvent } from './eventService'
 import type {
   MiniProject,
   MiniProjectProgress,
@@ -109,6 +110,17 @@ export async function submitProject(
 
   if (isNewlyCompleted) {
     await awardPoints(POINTS_MINI_PROJECT_COMPLETE, `ミニプロジェクト完了（${project.title}）`)
+    trackLearningEvent({
+      userId,
+      eventType: 'mini_project_completed',
+      mode: 'mini_project',
+      payload: {
+        projectId: project.id,
+        difficulty: project.difficulty,
+        milestoneCount: project.milestones.length,
+        pointsEarned,
+      },
+    })
   }
 
   return { milestoneResults, allPassed, pointsEarned, newStatus }

--- a/apps/web/supabase/sql/027_learning_event_completion_types.sql
+++ b/apps/web/supabase/sql/027_learning_event_completion_types.sql
@@ -1,0 +1,26 @@
+-- v1.0 post-release: add completion event types for practice modes
+-- Run this in Supabase SQL Editor after 022_learning_events.sql.
+
+alter table public.learning_events
+  drop constraint if exists learning_events_event_type_check;
+
+alter table public.learning_events
+  add constraint learning_events_event_type_check check (
+    event_type in (
+      'step_started',
+      'mode_started',
+      'mode_completed',
+      'practice_answer_submitted',
+      'test_submitted',
+      'challenge_submitted',
+      'daily_completed',
+      'code_doctor_completed',
+      'code_reading_completed',
+      'review_item_created',
+      'review_item_resolved',
+      'mini_project_started',
+      'mini_project_completed',
+      'feedback_created',
+      'base_nook_opened'
+    )
+  );

--- a/docs/supabase-ops.md
+++ b/docs/supabase-ops.md
@@ -48,7 +48,7 @@ NNN_short_description.sql
 - RLS対象テーブルを作る場合、同じファイル内に RLS 有効化と policy を含める
 - RPCを追加する場合、権限、`security definer`、`search_path`、admin判定の有無を明記する
 
-2026-06-10 時点の管理対象SQLの最新は `026_feedback_update_restriction.sql`。次の新規の管理対象SQLは `027_*.sql` から始める。
+2026-06-11 時点の管理対象SQLの最新は `027_learning_event_completion_types.sql`。次の新規の管理対象SQLは `028_*.sql` から始める。
 
 ---
 
@@ -78,6 +78,9 @@ NNN_short_description.sql
 | 022 | `022_learning_events.sql` | 学習イベントログ |
 | 023 | `023_notifications.sql` | アプリ内通知 / 既読管理 |
 | 024 | `024_feedback_notification_trigger.sql` | feedback作成時のadmin通知trigger |
+| 025 | `025_gamification_write_lockdown.sql` | gamification系テーブルの直接書き込み制限 |
+| 026 | `026_feedback_update_restriction.sql` | user_feedback の一般ユーザー更新制限 |
+| 027 | `027_learning_event_completion_types.sql` | Practice系完了イベントタイプ追加 |
 
 `002` / `005` は過去の seed SQL のため Git 管理対象から除外済み。seed が必要な環境では、Git 管理外の `apps/web/supabase/sql/local/*.sql` などで環境ごとに用意する。
 


### PR DESCRIPTION
Closes #305. Daily/Code Doctor/Mini Project/Code Reading の完了時に learning_events を記録。027 SQLで code_doctor_completed / code_reading_completed を CHECK 制約に追加。検証: targeted test/typecheck/lint/test/build pass。Supabase SQL: 027_learning_event_completion_types.sql は手動適用が必要。