### PR TITLE
fix: 復習推薦と通知未読件数を改善

### DIFF
--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -76,8 +76,12 @@ export function DashboardPage() {
   }, [userId])
 
   const recommendedAction = useMemo(
-    () => getRecommendedAction({ progress: allStepProgress }),
-    [allStepProgress],
+    () => getRecommendedAction({
+      progress: allStepProgress,
+      reviewCount,
+      enableReviewQueue: true,
+    }),
+    [allStepProgress, reviewCount],
   )
   const shouldShowReviewQueue = isLoadingReview || Boolean(reviewError) || reviewCount > 0
 

--- a/apps/web/src/pages/__tests__/DashboardPage.test.tsx
+++ b/apps/web/src/pages/__tests__/DashboardPage.test.tsx
@@ -160,7 +160,7 @@ describe('DashboardPage', () => {
     expect(screen.getByRole('link', { name: '始める' }).getAttribute('href')).toBe('/step/usestate-basic')
   })
 
-  it('復習待ちがある場合は復習カードを表示し、今日のおすすめは通常学習を表示する', async () => {
+  it('復習待ちがある場合は復習カードを表示し、今日のおすすめも復習を優先する', async () => {
     testState.getOpenCountMock.mockResolvedValue(2)
     testState.listOpenMock.mockResolvedValue([
       {
@@ -184,8 +184,13 @@ describe('DashboardPage', () => {
     )
 
     expect(await screen.findByText('復習待ち 2 件')).toBeTruthy()
-    expect(screen.getByText('Step 2 の Practice から再開')).toBeTruthy()
+    expect(screen.getByText('昨日間違えた問題を復習')).toBeTruthy()
+    expect(screen.getByText('復習待ちが 2 件あります。まずは弱点を軽く戻しましょう。')).toBeTruthy()
     expect(screen.getByText(/最優先: Step 2/)).toBeTruthy()
-    expect(screen.getByRole('link', { name: '復習へ進む' }).getAttribute('href')).toBe('/step/events?mode=practice')
+    const reviewLinks = screen.getAllByRole('link', { name: '復習へ進む' })
+    expect(reviewLinks.map((link) => link.getAttribute('href'))).toEqual([
+      '/daily',
+      '/step/events?mode=practice',
+    ])
   })
 })

--- a/apps/web/src/services/__tests__/feedbackService.test.ts
+++ b/apps/web/src/services/__tests__/feedbackService.test.ts
@@ -544,6 +544,19 @@ describe('uploadFeedbackImages', () => {
     expect(uploaded).not.toMatch(/[^a-zA-Z0-9._\-/]/)
   })
 
+  it('同名ファイルも index 付きのパスにして衝突させない', async () => {
+    const files = [createTestFile('same.png', 100), createTestFile('same.png', 100)]
+    const paths = await uploadFeedbackImages(VALID_USER_ID, VALID_FEEDBACK_ID, files)
+
+    expect(paths[0]).toMatch(
+      new RegExp(`^${VALID_USER_ID}/${VALID_FEEDBACK_ID}/\\d+_0_same\\.png$`),
+    )
+    expect(paths[1]).toMatch(
+      new RegExp(`^${VALID_USER_ID}/${VALID_FEEDBACK_ID}/\\d+_1_same\\.png$`),
+    )
+    expect(new Set(paths).size).toBe(2)
+  })
+
   it('Storage エラー時にアプリ共通エラーを投げる', async () => {
     storageState.uploadResult = { error: { message: 'bucket not found' } }
     const files = [createTestFile('fail.png', 100)]

--- a/apps/web/src/services/__tests__/notificationService.test.ts
+++ b/apps/web/src/services/__tests__/notificationService.test.ts
@@ -9,6 +9,7 @@ import {
 type Row = Record<string, unknown>
 
 const notificationsState = {
+  selectColumns: null as string | null,
   orderCalls: [] as Array<{ column: string; options: Record<string, unknown> | undefined }>,
   limitCalls: [] as number[],
   result: { data: [] as Row[] | null, error: null as unknown },
@@ -40,7 +41,10 @@ function createNotificationsBuilder() {
   }
 
   return {
-    select: () => chain,
+    select: (columns: string) => {
+      notificationsState.selectColumns = columns
+      return chain
+    },
   }
 }
 
@@ -87,6 +91,7 @@ const NOTIFICATION_ID_2 = '33333333-3333-3333-3333-333333333333'
 
 function resetState() {
   vi.clearAllMocks()
+  notificationsState.selectColumns = null
   notificationsState.orderCalls = []
   notificationsState.limitCalls = []
   notificationsState.result = { data: [], error: null }
@@ -132,10 +137,12 @@ describe('getNotifications', () => {
 
     expect(from).toHaveBeenCalledWith('notifications')
     expect(from).toHaveBeenCalledWith('notification_reads')
+    expect(notificationsState.selectColumns).toBe('*')
     expect(notificationsState.orderCalls).toEqual([
       { column: 'published_at', options: { ascending: false } },
       { column: 'created_at', options: { ascending: false } },
     ])
+    expect(readsState.selectColumns).toBe('notification_id, read_at')
     expect(readsState.eqCalls).toEqual([['user_id', USER_ID]])
     expect(readsState.inCalls).toEqual([
       ['notification_id', [NOTIFICATION_ID_1, NOTIFICATION_ID_2]],
@@ -210,6 +217,40 @@ describe('getUnreadCount', () => {
     }
 
     await expect(getUnreadCount(USER_ID)).resolves.toBe(1)
+    expect(notificationsState.selectColumns).toBe('id')
+    expect(notificationsState.orderCalls).toEqual([])
+    expect(readsState.selectColumns).toBe('notification_id')
+    expect(readsState.eqCalls).toEqual([['user_id', USER_ID]])
+    expect(readsState.inCalls).toEqual([
+      ['notification_id', [NOTIFICATION_ID_1, NOTIFICATION_ID_2]],
+    ])
+  })
+
+  it('通知がないときは既読状態を問い合わせず 0 を返す', async () => {
+    notificationsState.result = { data: [], error: null }
+
+    await expect(getUnreadCount(USER_ID)).resolves.toBe(0)
+    expect(notificationsState.selectColumns).toBe('id')
+    expect(from).not.toHaveBeenCalledWith('notification_reads')
+  })
+
+  it('不正な userId は例外を投げる', async () => {
+    await expect(getUnreadCount('not-uuid')).rejects.toThrow(
+      'userId must be a valid UUID',
+    )
+    expect(from).not.toHaveBeenCalled()
+  })
+
+  it('通知 ID 取得の DB エラーを AppError に変換する', async () => {
+    notificationsState.result = {
+      data: null,
+      error: { code: 'DB_ERROR', message: 'rls denied' },
+    }
+
+    await expect(getUnreadCount(USER_ID)).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: '未読件数の取得に失敗しました',
+    })
   })
 })
 

--- a/apps/web/src/services/notificationService.ts
+++ b/apps/web/src/services/notificationService.ts
@@ -104,8 +104,33 @@ export async function getNotifications(
 
 /** 自分宛て通知の未読件数を取得する。 */
 export async function getUnreadCount(userId: string): Promise<number> {
-  const notifications = await getNotifications({ userId })
-  return notifications.filter((notification) => !notification.isRead).length
+  assertUuid(userId, 'userId')
+
+  const { data: notifications, error } = await supabase
+    .from('notifications')
+    .select('id')
+
+  if (error) {
+    throw fromSupabaseError(error, '未読件数の取得に失敗しました')
+  }
+
+  const notificationIds = (notifications ?? []).map((notification) => notification.id)
+  if (notificationIds.length === 0) {
+    return 0
+  }
+
+  const { data: reads, error: readsError } = await supabase
+    .from('notification_reads')
+    .select('notification_id')
+    .eq('user_id', userId)
+    .in('notification_id', notificationIds)
+
+  if (readsError) {
+    throw fromSupabaseError(readsError, 'お知らせの既読状態の取得に失敗しました')
+  }
+
+  const readNotificationIds = new Set((reads ?? []).map((read) => read.notification_id))
+  return notificationIds.filter((id) => !readNotificationIds.has(id)).length
 }
 
 /** 通知を既読にする。既に既読の場合も成功扱いにする。 */


### PR DESCRIPTION
## Summary
- Dashboard のおすすめアクションへ復習キュー件数を渡し、復習待ちがある場合は復習導線を優先
- getUnreadCount を通知本文全件取得から id 差分取得へ軽量化
- uploadFeedbackImages の同名ファイル衝突防止を回帰テストで固定

Closes #304
Closes #303
Closes #264

## Test plan
- npm --workspace apps/web run test -- DashboardPage.test.tsx notificationService.test.ts feedbackService.test.ts recommendationService.test.ts
- npm --workspace apps/web run typecheck
- npm --workspace apps/web run lint
- npm --workspace apps/web run test
- npm --workspace apps/web run build
- pre-push hook: build / test