### PR TITLE
feat: パスワードリセット機能を追加

### DIFF
--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -10,6 +10,8 @@ interface AuthContextValue {
   isAdmin: boolean
   signIn: (email: string, password: string) => Promise<string | null>
   signUp: (email: string, password: string) => Promise<string | 'CONFIRM_EMAIL' | null>
+  sendPasswordResetEmail: (email: string, redirectTo?: string) => Promise<string | null>
+  updatePassword: (password: string) => Promise<string | null>
   signOut: () => Promise<string | null>
 }
 
@@ -141,6 +143,24 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
         // メール確認待ち
         return 'CONFIRM_EMAIL'
+      },
+      sendPasswordResetEmail: async (email, redirectTo) => {
+        if (supabaseConfigError) {
+          return supabaseConfigError
+        }
+
+        const { error } = await supabase.auth.resetPasswordForEmail(email, {
+          ...(redirectTo ? { redirectTo } : {}),
+        })
+        return error?.message ?? null
+      },
+      updatePassword: async (password) => {
+        if (supabaseConfigError) {
+          return supabaseConfigError
+        }
+
+        const { error } = await supabase.auth.updateUser({ password })
+        return error?.message ?? null
       },
       signOut: async () => {
         if (supabaseConfigError) {

--- a/apps/web/src/contexts/__tests__/AchievementContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/AchievementContext.test.tsx
@@ -56,6 +56,8 @@ describe('AchievementContext', () => {
       isAdmin: false,
       signIn: vi.fn(),
       signUp: vi.fn(),
+      sendPasswordResetEmail: vi.fn(),
+      updatePassword: vi.fn(),
       signOut: vi.fn(),
     })
 
@@ -92,6 +94,8 @@ describe('AchievementContext', () => {
       isAdmin: false,
       signIn: vi.fn(),
       signUp: vi.fn(),
+      sendPasswordResetEmail: vi.fn(),
+      updatePassword: vi.fn(),
       signOut: vi.fn(),
     })
 

--- a/apps/web/src/contexts/__tests__/AuthContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/AuthContext.test.tsx
@@ -20,6 +20,8 @@ vi.mock('../../lib/supabaseClient', () => {
         onAuthStateChange: vi.fn(),
         signInWithPassword: vi.fn(),
         signUp: vi.fn(),
+        resetPasswordForEmail: vi.fn(),
+        updateUser: vi.fn(),
         signOut: vi.fn(),
       },
       from,
@@ -32,6 +34,8 @@ const mockGetSession = vi.mocked(supabase.auth.getSession)
 const mockOnAuthStateChange = vi.mocked(supabase.auth.onAuthStateChange)
 const mockSignInWithPassword = vi.mocked(supabase.auth.signInWithPassword)
 const mockSignUpFn = vi.mocked(supabase.auth.signUp)
+const mockResetPasswordForEmail = vi.mocked(supabase.auth.resetPasswordForEmail)
+const mockUpdateUser = vi.mocked(supabase.auth.updateUser)
 const mockSignOutFn = vi.mocked(supabase.auth.signOut)
 
 // --- Test helpers ---
@@ -42,6 +46,8 @@ interface AuthContextValue {
   isLoadingAuth: boolean
   signIn: (email: string, password: string) => Promise<string | null>
   signUp: (email: string, password: string) => Promise<string | 'CONFIRM_EMAIL' | null>
+  sendPasswordResetEmail: (email: string, redirectTo?: string) => Promise<string | null>
+  updatePassword: (password: string) => Promise<string | null>
   signOut: () => Promise<string | null>
 }
 
@@ -234,6 +240,62 @@ describe('AuthContext', () => {
 
     expect(result).toBeNull()
     expect(mockSignOutFn).toHaveBeenCalled()
+  })
+
+  it('sendPasswordResetEmail が redirectTo 付きでリセットメール送信を呼び出す', async () => {
+    mockResetPasswordForEmail.mockResolvedValue({
+      data: {},
+      error: null,
+    } as never)
+
+    let captured: AuthContextValue | undefined
+
+    await act(async () => {
+      render(
+        <AuthProvider>
+          <TestConsumer onValue={(v) => { captured = v }} />
+        </AuthProvider>,
+      )
+    })
+
+    await waitFor(() => expect(captured!.isLoadingAuth).toBe(false))
+
+    let result: string | null = 'initial'
+    await act(async () => {
+      result = await captured!.sendPasswordResetEmail('user@example.com', 'https://example.com/reset-password')
+    })
+
+    expect(result).toBeNull()
+    expect(mockResetPasswordForEmail).toHaveBeenCalledWith('user@example.com', {
+      redirectTo: 'https://example.com/reset-password',
+    })
+  })
+
+  it('updatePassword が新しいパスワードでユーザー更新を呼び出す', async () => {
+    mockUpdateUser.mockResolvedValue({
+      data: { user: fakeUser },
+      error: null,
+    } as never)
+
+    let captured: AuthContextValue | undefined
+
+    await act(async () => {
+      render(
+        <AuthProvider>
+          <TestConsumer onValue={(v) => { captured = v }} />
+        </AuthProvider>,
+      )
+    })
+
+    await waitFor(() => expect(captured!.isLoadingAuth).toBe(false))
+
+    let result: string | null = 'initial'
+    await act(async () => {
+      result = await captured!.updatePassword('new-password123')
+    })
+
+    expect(result).toBeNull()
+    expect(mockUpdateUser).toHaveBeenCalledWith({ password: 'new-password123' })
   })
 
   it('useAuth が AuthProvider の外で使用されると例外を投げる', () => {

--- a/apps/web/src/contexts/__tests__/LearningContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/LearningContext.test.tsx
@@ -86,6 +86,8 @@ describe('LearningContext', () => {
       isAdmin: false,
       signIn: vi.fn(),
       signUp: vi.fn(),
+      sendPasswordResetEmail: vi.fn(),
+      updatePassword: vi.fn(),
       signOut: vi.fn(),
     })
 
@@ -129,6 +131,8 @@ describe('LearningContext', () => {
       isAdmin: false,
       signIn: vi.fn(),
       signUp: vi.fn(),
+      sendPasswordResetEmail: vi.fn(),
+      updatePassword: vi.fn(),
       signOut: vi.fn(),
     })
 

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -25,6 +25,12 @@ const DailyChallengePage = lazy(() =>
 )
 const DashboardPage = lazy(() => import('./pages/DashboardPage').then((m) => ({ default: m.DashboardPage })))
 const LoginPage = lazy(() => import('./pages/LoginPage').then((m) => ({ default: m.LoginPage })))
+const ForgotPasswordPage = lazy(() =>
+  import('./pages/ForgotPasswordPage').then((m) => ({ default: m.ForgotPasswordPage })),
+)
+const ResetPasswordPage = lazy(() =>
+  import('./pages/ResetPasswordPage').then((m) => ({ default: m.ResetPasswordPage })),
+)
 const MiniProjectDetailPage = lazy(() =>
   import('./pages/MiniProjectDetailPage').then((m) => ({ default: m.MiniProjectDetailPage })),
 )
@@ -107,6 +113,24 @@ const router = createBrowserRouter([
           <SignUpPage />
         </Suspense>
       </GuestRoute>
+    ),
+  },
+  {
+    path: '/forgot-password',
+    element: (
+      <GuestRoute>
+        <Suspense fallback={<PageLoading />}>
+          <ForgotPasswordPage />
+        </Suspense>
+      </GuestRoute>
+    ),
+  },
+  {
+    path: '/reset-password',
+    element: (
+      <Suspense fallback={<PageLoading />}>
+        <ResetPasswordPage />
+      </Suspense>
     ),
   },
   {

--- a/apps/web/src/pages/ForgotPasswordPage.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,107 @@
+import { type FormEvent, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { AuthBrandHeader } from '../components/AuthBrandHeader'
+import { Button } from '../components/Button'
+import { ConfigErrorView } from '../components/ConfigErrorView'
+import { ErrorBanner } from '../components/ErrorBanner'
+import { useAuth } from '../contexts/AuthContext'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { supabaseConfigError } from '../lib/supabaseClient'
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+function getResetRedirectUrl() {
+  return `${window.location.origin}/reset-password`
+}
+
+function validateEmail(email: string): string | null {
+  if (!EMAIL_PATTERN.test(email)) {
+    return '正しいメールアドレスを入力してください。'
+  }
+
+  return null
+}
+
+export function ForgotPasswordPage() {
+  const { sendPasswordResetEmail } = useAuth()
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isSent, setIsSent] = useState(false)
+
+  const isDisabled = useMemo(() => isSubmitting || Boolean(supabaseConfigError), [isSubmitting])
+
+  useDocumentTitle('パスワードリセット')
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    const normalizedEmail = email.trim()
+    const validationError = validateEmail(normalizedEmail)
+    if (validationError) {
+      setError(validationError)
+      setIsSent(false)
+      return
+    }
+
+    setError(null)
+    setIsSubmitting(true)
+
+    const message = await sendPasswordResetEmail(normalizedEmail, getResetRedirectUrl())
+    if (message) {
+      setError(message)
+      setIsSent(false)
+      setIsSubmitting(false)
+      return
+    }
+
+    setIsSent(true)
+    setIsSubmitting(false)
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50 px-4 py-8 sm:px-6 sm:py-16">
+      <AuthBrandHeader subtitle="登録メールアドレスにパスワード再設定リンクを送信します。" />
+
+      {supabaseConfigError ? <ConfigErrorView message={supabaseConfigError} /> : null}
+
+      <form
+        className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
+        onSubmit={handleSubmit}
+        noValidate
+        aria-label="パスワードリセット依頼フォーム"
+      >
+        {error ? <ErrorBanner>{error}</ErrorBanner> : null}
+        {isSent ? (
+          <ErrorBanner variant="success">
+            リセットメールを送信しました。メール内のリンクから新しいパスワードを設定してください。
+          </ErrorBanner>
+        ) : null}
+
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium text-slate-700">メールアドレス</span>
+          <input
+            aria-label="メールアドレス"
+            className="min-h-[44px] w-full rounded-md border border-slate-300 px-3 py-3 text-sm outline-none focus:border-primary-mint focus:ring-2 focus:ring-primary-mint/30"
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            autoComplete="email"
+            required
+          />
+        </label>
+
+        <Button type="submit" fullWidth disabled={isDisabled}>
+          {isSubmitting ? '送信中...' : 'リセットメールを送信'}
+        </Button>
+
+        <p className="text-center text-sm text-slate-600">
+          パスワードを思い出しましたか？{' '}
+          <Link className="font-medium text-primary-dark underline" to="/login">
+            ログインへ戻る
+          </Link>
+        </p>
+      </form>
+    </main>
+  )
+}

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -78,6 +78,12 @@ export function LoginPage() {
           {isSubmitting ? 'ログイン中...' : 'ログイン'}
         </Button>
 
+        <p className="text-center text-sm">
+          <Link className="font-medium text-primary-dark underline" to="/forgot-password">
+            パスワードを忘れた方はこちら
+          </Link>
+        </p>
+
         <p className="text-center text-sm text-slate-600">
           はじめて利用しますか？{' '}
           <Link className="font-medium text-primary-dark underline" to="/signup">

--- a/apps/web/src/pages/ResetPasswordPage.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,157 @@
+import { type FormEvent, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { AuthBrandHeader } from '../components/AuthBrandHeader'
+import { Button } from '../components/Button'
+import { ConfigErrorView } from '../components/ConfigErrorView'
+import { ErrorBanner } from '../components/ErrorBanner'
+import { PageSpinner } from '../components/Spinner'
+import { useAuth } from '../contexts/AuthContext'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { supabaseConfigError } from '../lib/supabaseClient'
+
+const MIN_PASSWORD_LENGTH = 8
+
+function getRecoveryErrorMessage() {
+  const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''))
+  const queryParams = new URLSearchParams(window.location.search)
+  const errorDescription = hashParams.get('error_description') ?? queryParams.get('error_description')
+
+  if (errorDescription) {
+    return decodeURIComponent(errorDescription)
+  }
+
+  return 'リンクが無効または期限切れです。もう一度リセットメールを送信してください。'
+}
+
+function validatePassword(password: string, confirmPassword: string): string | null {
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return `パスワードは${MIN_PASSWORD_LENGTH}文字以上で入力してください。`
+  }
+
+  if (password !== confirmPassword) {
+    return '確認用パスワードが一致しません。'
+  }
+
+  return null
+}
+
+export function ResetPasswordPage() {
+  const { isLoadingAuth, session, updatePassword, signOut } = useAuth()
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isUpdated, setIsUpdated] = useState(false)
+
+  const isDisabled = useMemo(() => isSubmitting || Boolean(supabaseConfigError), [isSubmitting])
+
+  useDocumentTitle('新しいパスワード設定')
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    const validationError = validatePassword(password, confirmPassword)
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+
+    setError(null)
+    setIsSubmitting(true)
+
+    const message = await updatePassword(password)
+    if (message) {
+      setError(message)
+      setIsSubmitting(false)
+      return
+    }
+
+    await signOut()
+    setPassword('')
+    setConfirmPassword('')
+    setIsUpdated(true)
+    setIsSubmitting(false)
+  }
+
+  if (isLoadingAuth) {
+    return <PageSpinner />
+  }
+
+  if (isUpdated) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50 px-4 py-8 sm:px-6 sm:py-16">
+        <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 text-center shadow-sm">
+          <h1 className="text-xl font-bold text-slate-800">パスワードを更新しました</h1>
+          <p className="text-sm text-slate-600">新しいパスワードでログインしてください。</p>
+          <Link className="inline-block text-sm font-medium text-primary-dark underline" to="/login">
+            ログインへ進む
+          </Link>
+        </div>
+      </main>
+    )
+  }
+
+  if (!session) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50 px-4 py-8 sm:px-6 sm:py-16">
+        <AuthBrandHeader subtitle="パスワード再設定リンクを確認できませんでした。" />
+        <section className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <ErrorBanner>{getRecoveryErrorMessage()}</ErrorBanner>
+          <Link className="inline-block text-sm font-medium text-primary-dark underline" to="/forgot-password">
+            リセットメールを再送信する
+          </Link>
+        </section>
+      </main>
+    )
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50 px-4 py-8 sm:px-6 sm:py-16">
+      <AuthBrandHeader subtitle="新しいパスワードを設定してください。" />
+
+      {supabaseConfigError ? <ConfigErrorView message={supabaseConfigError} /> : null}
+
+      <form
+        className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
+        onSubmit={handleSubmit}
+        noValidate
+        aria-label="新しいパスワード設定フォーム"
+      >
+        {error ? <ErrorBanner>{error}</ErrorBanner> : null}
+
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium text-slate-700">新しいパスワード</span>
+          <input
+            aria-label="新しいパスワード"
+            className="min-h-[44px] w-full rounded-md border border-slate-300 px-3 py-3 text-sm outline-none focus:border-primary-mint focus:ring-2 focus:ring-primary-mint/30"
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            autoComplete="new-password"
+            minLength={MIN_PASSWORD_LENGTH}
+            required
+          />
+          <span className="mt-1 block text-xs text-slate-500">{MIN_PASSWORD_LENGTH}文字以上で入力してください。</span>
+        </label>
+
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium text-slate-700">新しいパスワード（確認）</span>
+          <input
+            aria-label="新しいパスワード（確認）"
+            className="min-h-[44px] w-full rounded-md border border-slate-300 px-3 py-3 text-sm outline-none focus:border-primary-mint focus:ring-2 focus:ring-primary-mint/30"
+            type="password"
+            value={confirmPassword}
+            onChange={(event) => setConfirmPassword(event.target.value)}
+            autoComplete="new-password"
+            minLength={MIN_PASSWORD_LENGTH}
+            required
+          />
+        </label>
+
+        <Button type="submit" fullWidth disabled={isDisabled}>
+          {isSubmitting ? '更新中...' : 'パスワードを更新'}
+        </Button>
+      </form>
+    </main>
+  )
+}

--- a/apps/web/src/pages/__tests__/ForgotPasswordPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ForgotPasswordPage.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ForgotPasswordPage } from '../ForgotPasswordPage'
+
+const mockSendPasswordResetEmail = vi.fn()
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    sendPasswordResetEmail: mockSendPasswordResetEmail,
+  }),
+}))
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabaseConfigError: null,
+  supabase: {},
+}))
+
+describe('ForgotPasswordPage', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  beforeEach(() => {
+    mockSendPasswordResetEmail.mockReset()
+  })
+
+  it('不正なメールアドレスでは送信せずエラーを表示する', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <ForgotPasswordPage />
+      </MemoryRouter>,
+    )
+
+    await user.type(screen.getByLabelText('メールアドレス'), 'invalid-mail')
+    await user.click(screen.getByRole('button', { name: 'リセットメールを送信' }))
+
+    expect(mockSendPasswordResetEmail).not.toHaveBeenCalled()
+    expect(screen.getByRole('alert').textContent).toContain('正しいメールアドレスを入力してください。')
+  })
+
+  it('リセットメール送信に成功すると案内を表示する', async () => {
+    const user = userEvent.setup()
+    mockSendPasswordResetEmail.mockResolvedValue(null)
+
+    render(
+      <MemoryRouter>
+        <ForgotPasswordPage />
+      </MemoryRouter>,
+    )
+
+    await user.type(screen.getByLabelText('メールアドレス'), 'user@example.com')
+    await user.click(screen.getByRole('button', { name: 'リセットメールを送信' }))
+
+    expect(mockSendPasswordResetEmail).toHaveBeenCalledWith(
+      'user@example.com',
+      `${window.location.origin}/reset-password`,
+    )
+    expect(screen.getByRole('status').textContent).toContain('リセットメールを送信しました。')
+  })
+})

--- a/apps/web/src/pages/__tests__/LoginPage.test.tsx
+++ b/apps/web/src/pages/__tests__/LoginPage.test.tsx
@@ -1,0 +1,34 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { LoginPage } from '../LoginPage'
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    signIn: vi.fn(),
+    user: null,
+  }),
+}))
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabaseConfigError: null,
+  supabase: {},
+}))
+
+describe('LoginPage', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('パスワードリセット導線を表示する', () => {
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('link', { name: 'パスワードを忘れた方はこちら' }).getAttribute('href')).toBe(
+      '/forgot-password',
+    )
+  })
+})

--- a/apps/web/src/pages/__tests__/ResetPasswordPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ResetPasswordPage.test.tsx
@@ -1,0 +1,106 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ResetPasswordPage } from '../ResetPasswordPage'
+
+const mockUpdatePassword = vi.fn()
+const mockSignOut = vi.fn()
+
+interface MockAuthValue {
+  isLoadingAuth: boolean
+  session: { user: { id: string } } | null
+  updatePassword: typeof mockUpdatePassword
+  signOut: typeof mockSignOut
+}
+
+const mockAuth = {
+  value: {
+    isLoadingAuth: false,
+    session: { user: { id: 'user-1' } },
+    updatePassword: mockUpdatePassword,
+    signOut: mockSignOut,
+  } as MockAuthValue,
+}
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => mockAuth.value,
+}))
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabaseConfigError: null,
+  supabase: {},
+}))
+
+describe('ResetPasswordPage', () => {
+  afterEach(() => {
+    cleanup()
+    window.history.replaceState(null, '', '/')
+  })
+
+  beforeEach(() => {
+    mockUpdatePassword.mockReset()
+    mockSignOut.mockReset()
+    mockAuth.value = {
+      isLoadingAuth: false,
+      session: { user: { id: 'user-1' } },
+      updatePassword: mockUpdatePassword,
+      signOut: mockSignOut,
+    }
+  })
+
+  it('session がない場合は無効リンクとして再送信導線を表示する', () => {
+    mockAuth.value = {
+      ...mockAuth.value,
+      session: null,
+    }
+    window.history.replaceState(null, '', '/reset-password#error_description=Recovery+link+expired')
+
+    render(
+      <MemoryRouter>
+        <ResetPasswordPage />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('alert').textContent).toContain('Recovery link expired')
+    expect(screen.getByRole('link', { name: 'リセットメールを再送信する' }).getAttribute('href')).toBe(
+      '/forgot-password',
+    )
+  })
+
+  it('短すぎるパスワードでは更新せずエラーを表示する', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <ResetPasswordPage />
+      </MemoryRouter>,
+    )
+
+    await user.type(screen.getByLabelText('新しいパスワード'), 'short')
+    await user.type(screen.getByLabelText('新しいパスワード（確認）'), 'short')
+    await user.click(screen.getByRole('button', { name: 'パスワードを更新' }))
+
+    expect(mockUpdatePassword).not.toHaveBeenCalled()
+    expect(screen.getByRole('alert').textContent).toContain('パスワードは8文字以上で入力してください。')
+  })
+
+  it('パスワード更新に成功するとサインアウトして完了表示にする', async () => {
+    const user = userEvent.setup()
+    mockUpdatePassword.mockResolvedValue(null)
+    mockSignOut.mockResolvedValue(null)
+
+    render(
+      <MemoryRouter>
+        <ResetPasswordPage />
+      </MemoryRouter>,
+    )
+
+    await user.type(screen.getByLabelText('新しいパスワード'), 'new-password123')
+    await user.type(screen.getByLabelText('新しいパスワード（確認）'), 'new-password123')
+    await user.click(screen.getByRole('button', { name: 'パスワードを更新' }))
+
+    expect(mockUpdatePassword).toHaveBeenCalledWith('new-password123')
+    expect(mockSignOut).toHaveBeenCalled()
+    expect(await screen.findByText('パスワードを更新しました')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## 概要
- ログイン画面にパスワードリセット導線を追加
- resetPasswordForEmail / updateUser を使うリセット依頼・新パスワード設定画面を追加
- AuthContext と関連テストを更新

## 検証
- typecheck PASS
- lint PASS
- test PASS（93 files / 943 tests）
- build PASS
- Playwright MCP: login導線 / forgot-passwordバリデーション / reset-password無効リンク / mobile表示確認 PASS

Closes #320