### PR TITLE
release: coden-v1.1.0

### DIFF
--- a/apps/web/src/contexts/AuthContext.tsx
+++ b/apps/web/src/contexts/AuthContext.tsx
@@ -10,6 +10,8 @@ interface AuthContextValue {
   isAdmin: boolean
   signIn: (email: string, password: string) => Promise<string | null>
   signUp: (email: string, password: string) => Promise<string | 'CONFIRM_EMAIL' | null>
+  sendPasswordResetEmail: (email: string, redirectTo?: string) => Promise<string | null>
+  updatePassword: (password: string) => Promise<string | null>
   signOut: () => Promise<string | null>
 }
 
@@ -141,6 +143,24 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
         // メール確認待ち
         return 'CONFIRM_EMAIL'
+      },
+      sendPasswordResetEmail: async (email, redirectTo) => {
+        if (supabaseConfigError) {
+          return supabaseConfigError
+        }
+
+        const { error } = await supabase.auth.resetPasswordForEmail(email, {
+          ...(redirectTo ? { redirectTo } : {}),
+        })
+        return error?.message ?? null
+      },
+      updatePassword: async (password) => {
+        if (supabaseConfigError) {
+          return supabaseConfigError
+        }
+
+        const { error } = await supabase.auth.updateUser({ password })
+        return error?.message ?? null
       },
       signOut: async () => {
         if (supabaseConfigError) {

--- a/apps/web/src/contexts/__tests__/AchievementContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/AchievementContext.test.tsx
@@ -56,6 +56,8 @@ describe('AchievementContext', () => {
       isAdmin: false,
       signIn: vi.fn(),
       signUp: vi.fn(),
+      sendPasswordResetEmail: vi.fn(),
+      updatePassword: vi.fn(),
       signOut: vi.fn(),
     })
 
@@ -92,6 +94,8 @@ describe('AchievementContext', () => {
       isAdmin: false,
       signIn: vi.fn(),
       signUp: vi.fn(),
+      sendPasswordResetEmail: vi.fn(),
+      updatePassword: vi.fn(),
       signOut: vi.fn(),
     })
 

--- a/apps/web/src/contexts/__tests__/AuthContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/AuthContext.test.tsx
@@ -20,6 +20,8 @@ vi.mock('../../lib/supabaseClient', () => {
         onAuthStateChange: vi.fn(),
         signInWithPassword: vi.fn(),
         signUp: vi.fn(),
+        resetPasswordForEmail: vi.fn(),
+        updateUser: vi.fn(),
         signOut: vi.fn(),
       },
       from,
@@ -32,6 +34,8 @@ const mockGetSession = vi.mocked(supabase.auth.getSession)
 const mockOnAuthStateChange = vi.mocked(supabase.auth.onAuthStateChange)
 const mockSignInWithPassword = vi.mocked(supabase.auth.signInWithPassword)
 const mockSignUpFn = vi.mocked(supabase.auth.signUp)
+const mockResetPasswordForEmail = vi.mocked(supabase.auth.resetPasswordForEmail)
+const mockUpdateUser = vi.mocked(supabase.auth.updateUser)
 const mockSignOutFn = vi.mocked(supabase.auth.signOut)
 
 // --- Test helpers ---
@@ -42,6 +46,8 @@ interface AuthContextValue {
   isLoadingAuth: boolean
   signIn: (email: string, password: string) => Promise<string | null>
   signUp: (email: string, password: string) => Promise<string | 'CONFIRM_EMAIL' | null>
+  sendPasswordResetEmail: (email: string, redirectTo?: string) => Promise<string | null>
+  updatePassword: (password: string) => Promise<string | null>
   signOut: () => Promise<string | null>
 }
 
@@ -234,6 +240,62 @@ describe('AuthContext', () => {
 
     expect(result).toBeNull()
     expect(mockSignOutFn).toHaveBeenCalled()
+  })
+
+  it('sendPasswordResetEmail が redirectTo 付きでリセットメール送信を呼び出す', async () => {
+    mockResetPasswordForEmail.mockResolvedValue({
+      data: {},
+      error: null,
+    } as never)
+
+    let captured: AuthContextValue | undefined
+
+    await act(async () => {
+      render(
+        <AuthProvider>
+          <TestConsumer onValue={(v) => { captured = v }} />
+        </AuthProvider>,
+      )
+    })
+
+    await waitFor(() => expect(captured!.isLoadingAuth).toBe(false))
+
+    let result: string | null = 'initial'
+    await act(async () => {
+      result = await captured!.sendPasswordResetEmail('user@example.com', 'https://example.com/reset-password')
+    })
+
+    expect(result).toBeNull()
+    expect(mockResetPasswordForEmail).toHaveBeenCalledWith('user@example.com', {
+      redirectTo: 'https://example.com/reset-password',
+    })
+  })
+
+  it('updatePassword が新しいパスワードでユーザー更新を呼び出す', async () => {
+    mockUpdateUser.mockResolvedValue({
+      data: { user: fakeUser },
+      error: null,
+    } as never)
+
+    let captured: AuthContextValue | undefined
+
+    await act(async () => {
+      render(
+        <AuthProvider>
+          <TestConsumer onValue={(v) => { captured = v }} />
+        </AuthProvider>,
+      )
+    })
+
+    await waitFor(() => expect(captured!.isLoadingAuth).toBe(false))
+
+    let result: string | null = 'initial'
+    await act(async () => {
+      result = await captured!.updatePassword('new-password123')
+    })
+
+    expect(result).toBeNull()
+    expect(mockUpdateUser).toHaveBeenCalledWith({ password: 'new-password123' })
   })
 
   it('useAuth が AuthProvider の外で使用されると例外を投げる', () => {

--- a/apps/web/src/contexts/__tests__/LearningContext.test.tsx
+++ b/apps/web/src/contexts/__tests__/LearningContext.test.tsx
@@ -86,6 +86,8 @@ describe('LearningContext', () => {
       isAdmin: false,
       signIn: vi.fn(),
       signUp: vi.fn(),
+      sendPasswordResetEmail: vi.fn(),
+      updatePassword: vi.fn(),
       signOut: vi.fn(),
     })
 
@@ -129,6 +131,8 @@ describe('LearningContext', () => {
       isAdmin: false,
       signIn: vi.fn(),
       signUp: vi.fn(),
+      sendPasswordResetEmail: vi.fn(),
+      updatePassword: vi.fn(),
       signOut: vi.fn(),
     })
 

--- a/apps/web/src/features/admin/components/__tests__/ImageLightbox.test.tsx
+++ b/apps/web/src/features/admin/components/__tests__/ImageLightbox.test.tsx
@@ -52,6 +52,17 @@ describe('ImageLightbox', () => {
     expect(onClose).toHaveBeenCalledOnce()
   })
 
+  it('操作アイコンは装飾として aria-hidden を持つ', () => {
+    render(
+      <ImageLightbox images={images} currentIndex={1} onClose={vi.fn()} onChangeIndex={vi.fn()} />,
+    )
+
+    for (const name of ['閉じる', '前の画像', '次の画像']) {
+      const button = screen.getByRole('button', { name })
+      expect(button.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true')
+    }
+  })
+
   it('ArrowRight キーで次の画像に切り替わる', () => {
     const onChangeIndex = vi.fn()
     render(

--- a/apps/web/src/features/feedback/__tests__/FeedbackDialog.test.tsx
+++ b/apps/web/src/features/feedback/__tests__/FeedbackDialog.test.tsx
@@ -72,6 +72,7 @@ describe('FeedbackDialog', () => {
     await waitFor(() => {
       expect(screen.getByText(/送信しました/)).toBeTruthy()
     })
+    expect(screen.getByRole('status').textContent).toContain('送信しました')
   })
 
   it('submitFeedback が失敗したらエラーを表示し onClose を呼ばない', async () => {
@@ -85,6 +86,7 @@ describe('FeedbackDialog', () => {
     await waitFor(() => {
       expect(screen.getByText('permission denied')).toBeTruthy()
     })
+    expect(screen.getByRole('alert').textContent).toContain('permission denied')
     expect(onClose).not.toHaveBeenCalled()
   })
 
@@ -98,6 +100,7 @@ describe('FeedbackDialog', () => {
     await waitFor(() => {
       expect(screen.getByText('送信にはログインが必要です')).toBeTruthy()
     })
+    expect(screen.getByRole('alert').textContent).toContain('送信にはログインが必要です')
     expect(submitFeedbackMock).not.toHaveBeenCalled()
   })
 
@@ -124,6 +127,7 @@ describe('FeedbackDialog', () => {
     await waitFor(() => {
       expect(screen.getByText(/画像ファイルではありません/)).toBeTruthy()
     })
+    expect(screen.getByRole('alert').textContent).toContain('画像ファイルではありません')
   })
 
   it('画像を追加するとプレビューが表示され削除ボタンで除去できる', async () => {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -25,6 +25,12 @@ const DailyChallengePage = lazy(() =>
 )
 const DashboardPage = lazy(() => import('./pages/DashboardPage').then((m) => ({ default: m.DashboardPage })))
 const LoginPage = lazy(() => import('./pages/LoginPage').then((m) => ({ default: m.LoginPage })))
+const ForgotPasswordPage = lazy(() =>
+  import('./pages/ForgotPasswordPage').then((m) => ({ default: m.ForgotPasswordPage })),
+)
+const ResetPasswordPage = lazy(() =>
+  import('./pages/ResetPasswordPage').then((m) => ({ default: m.ResetPasswordPage })),
+)
 const MiniProjectDetailPage = lazy(() =>
   import('./pages/MiniProjectDetailPage').then((m) => ({ default: m.MiniProjectDetailPage })),
 )
@@ -107,6 +113,24 @@ const router = createBrowserRouter([
           <SignUpPage />
         </Suspense>
       </GuestRoute>
+    ),
+  },
+  {
+    path: '/forgot-password',
+    element: (
+      <GuestRoute>
+        <Suspense fallback={<PageLoading />}>
+          <ForgotPasswordPage />
+        </Suspense>
+      </GuestRoute>
+    ),
+  },
+  {
+    path: '/reset-password',
+    element: (
+      <Suspense fallback={<PageLoading />}>
+        <ResetPasswordPage />
+      </Suspense>
     ),
   },
   {

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -76,8 +76,12 @@ export function DashboardPage() {
   }, [userId])
 
   const recommendedAction = useMemo(
-    () => getRecommendedAction({ progress: allStepProgress }),
-    [allStepProgress],
+    () => getRecommendedAction({
+      progress: allStepProgress,
+      reviewCount,
+      enableReviewQueue: true,
+    }),
+    [allStepProgress, reviewCount],
   )
   const shouldShowReviewQueue = isLoadingReview || Boolean(reviewError) || reviewCount > 0
 

--- a/apps/web/src/pages/ForgotPasswordPage.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage.tsx
@@ -1,0 +1,107 @@
+import { type FormEvent, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { AuthBrandHeader } from '../components/AuthBrandHeader'
+import { Button } from '../components/Button'
+import { ConfigErrorView } from '../components/ConfigErrorView'
+import { ErrorBanner } from '../components/ErrorBanner'
+import { useAuth } from '../contexts/AuthContext'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { supabaseConfigError } from '../lib/supabaseClient'
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+function getResetRedirectUrl() {
+  return `${window.location.origin}/reset-password`
+}
+
+function validateEmail(email: string): string | null {
+  if (!EMAIL_PATTERN.test(email)) {
+    return '正しいメールアドレスを入力してください。'
+  }
+
+  return null
+}
+
+export function ForgotPasswordPage() {
+  const { sendPasswordResetEmail } = useAuth()
+  const [email, setEmail] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isSent, setIsSent] = useState(false)
+
+  const isDisabled = useMemo(() => isSubmitting || Boolean(supabaseConfigError), [isSubmitting])
+
+  useDocumentTitle('パスワードリセット')
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    const normalizedEmail = email.trim()
+    const validationError = validateEmail(normalizedEmail)
+    if (validationError) {
+      setError(validationError)
+      setIsSent(false)
+      return
+    }
+
+    setError(null)
+    setIsSubmitting(true)
+
+    const message = await sendPasswordResetEmail(normalizedEmail, getResetRedirectUrl())
+    if (message) {
+      setError(message)
+      setIsSent(false)
+      setIsSubmitting(false)
+      return
+    }
+
+    setIsSent(true)
+    setIsSubmitting(false)
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50 px-4 py-8 sm:px-6 sm:py-16">
+      <AuthBrandHeader subtitle="登録メールアドレスにパスワード再設定リンクを送信します。" />
+
+      {supabaseConfigError ? <ConfigErrorView message={supabaseConfigError} /> : null}
+
+      <form
+        className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
+        onSubmit={handleSubmit}
+        noValidate
+        aria-label="パスワードリセット依頼フォーム"
+      >
+        {error ? <ErrorBanner>{error}</ErrorBanner> : null}
+        {isSent ? (
+          <ErrorBanner variant="success">
+            リセットメールを送信しました。メール内のリンクから新しいパスワードを設定してください。
+          </ErrorBanner>
+        ) : null}
+
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium text-slate-700">メールアドレス</span>
+          <input
+            aria-label="メールアドレス"
+            className="min-h-[44px] w-full rounded-md border border-slate-300 px-3 py-3 text-sm outline-none focus:border-primary-mint focus:ring-2 focus:ring-primary-mint/30"
+            type="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            autoComplete="email"
+            required
+          />
+        </label>
+
+        <Button type="submit" fullWidth disabled={isDisabled}>
+          {isSubmitting ? '送信中...' : 'リセットメールを送信'}
+        </Button>
+
+        <p className="text-center text-sm text-slate-600">
+          パスワードを思い出しましたか？{' '}
+          <Link className="font-medium text-primary-dark underline" to="/login">
+            ログインへ戻る
+          </Link>
+        </p>
+      </form>
+    </main>
+  )
+}

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -78,6 +78,12 @@ export function LoginPage() {
           {isSubmitting ? 'ログイン中...' : 'ログイン'}
         </Button>
 
+        <p className="text-center text-sm">
+          <Link className="font-medium text-primary-dark underline" to="/forgot-password">
+            パスワードを忘れた方はこちら
+          </Link>
+        </p>
+
         <p className="text-center text-sm text-slate-600">
           はじめて利用しますか？{' '}
           <Link className="font-medium text-primary-dark underline" to="/signup">

--- a/apps/web/src/pages/ResetPasswordPage.tsx
+++ b/apps/web/src/pages/ResetPasswordPage.tsx
@@ -1,0 +1,157 @@
+import { type FormEvent, useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { AuthBrandHeader } from '../components/AuthBrandHeader'
+import { Button } from '../components/Button'
+import { ConfigErrorView } from '../components/ConfigErrorView'
+import { ErrorBanner } from '../components/ErrorBanner'
+import { PageSpinner } from '../components/Spinner'
+import { useAuth } from '../contexts/AuthContext'
+import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { supabaseConfigError } from '../lib/supabaseClient'
+
+const MIN_PASSWORD_LENGTH = 8
+
+function getRecoveryErrorMessage() {
+  const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ''))
+  const queryParams = new URLSearchParams(window.location.search)
+  const errorDescription = hashParams.get('error_description') ?? queryParams.get('error_description')
+
+  if (errorDescription) {
+    return decodeURIComponent(errorDescription)
+  }
+
+  return 'リンクが無効または期限切れです。もう一度リセットメールを送信してください。'
+}
+
+function validatePassword(password: string, confirmPassword: string): string | null {
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return `パスワードは${MIN_PASSWORD_LENGTH}文字以上で入力してください。`
+  }
+
+  if (password !== confirmPassword) {
+    return '確認用パスワードが一致しません。'
+  }
+
+  return null
+}
+
+export function ResetPasswordPage() {
+  const { isLoadingAuth, session, updatePassword, signOut } = useAuth()
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isUpdated, setIsUpdated] = useState(false)
+
+  const isDisabled = useMemo(() => isSubmitting || Boolean(supabaseConfigError), [isSubmitting])
+
+  useDocumentTitle('新しいパスワード設定')
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+
+    const validationError = validatePassword(password, confirmPassword)
+    if (validationError) {
+      setError(validationError)
+      return
+    }
+
+    setError(null)
+    setIsSubmitting(true)
+
+    const message = await updatePassword(password)
+    if (message) {
+      setError(message)
+      setIsSubmitting(false)
+      return
+    }
+
+    await signOut()
+    setPassword('')
+    setConfirmPassword('')
+    setIsUpdated(true)
+    setIsSubmitting(false)
+  }
+
+  if (isLoadingAuth) {
+    return <PageSpinner />
+  }
+
+  if (isUpdated) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50 px-4 py-8 sm:px-6 sm:py-16">
+        <div className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 text-center shadow-sm">
+          <h1 className="text-xl font-bold text-slate-800">パスワードを更新しました</h1>
+          <p className="text-sm text-slate-600">新しいパスワードでログインしてください。</p>
+          <Link className="inline-block text-sm font-medium text-primary-dark underline" to="/login">
+            ログインへ進む
+          </Link>
+        </div>
+      </main>
+    )
+  }
+
+  if (!session) {
+    return (
+      <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50 px-4 py-8 sm:px-6 sm:py-16">
+        <AuthBrandHeader subtitle="パスワード再設定リンクを確認できませんでした。" />
+        <section className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+          <ErrorBanner>{getRecoveryErrorMessage()}</ErrorBanner>
+          <Link className="inline-block text-sm font-medium text-primary-dark underline" to="/forgot-password">
+            リセットメールを再送信する
+          </Link>
+        </section>
+      </main>
+    )
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-3xl flex-col justify-center gap-6 bg-gradient-to-br from-white via-secondary-bg/40 to-sky-50/50 px-4 py-8 sm:px-6 sm:py-16">
+      <AuthBrandHeader subtitle="新しいパスワードを設定してください。" />
+
+      {supabaseConfigError ? <ConfigErrorView message={supabaseConfigError} /> : null}
+
+      <form
+        className="space-y-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"
+        onSubmit={handleSubmit}
+        noValidate
+        aria-label="新しいパスワード設定フォーム"
+      >
+        {error ? <ErrorBanner>{error}</ErrorBanner> : null}
+
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium text-slate-700">新しいパスワード</span>
+          <input
+            aria-label="新しいパスワード"
+            className="min-h-[44px] w-full rounded-md border border-slate-300 px-3 py-3 text-sm outline-none focus:border-primary-mint focus:ring-2 focus:ring-primary-mint/30"
+            type="password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            autoComplete="new-password"
+            minLength={MIN_PASSWORD_LENGTH}
+            required
+          />
+          <span className="mt-1 block text-xs text-slate-500">{MIN_PASSWORD_LENGTH}文字以上で入力してください。</span>
+        </label>
+
+        <label className="block">
+          <span className="mb-1 block text-sm font-medium text-slate-700">新しいパスワード（確認）</span>
+          <input
+            aria-label="新しいパスワード（確認）"
+            className="min-h-[44px] w-full rounded-md border border-slate-300 px-3 py-3 text-sm outline-none focus:border-primary-mint focus:ring-2 focus:ring-primary-mint/30"
+            type="password"
+            value={confirmPassword}
+            onChange={(event) => setConfirmPassword(event.target.value)}
+            autoComplete="new-password"
+            minLength={MIN_PASSWORD_LENGTH}
+            required
+          />
+        </label>
+
+        <Button type="submit" fullWidth disabled={isDisabled}>
+          {isSubmitting ? '更新中...' : 'パスワードを更新'}
+        </Button>
+      </form>
+    </main>
+  )
+}

--- a/apps/web/src/pages/__tests__/DashboardPage.test.tsx
+++ b/apps/web/src/pages/__tests__/DashboardPage.test.tsx
@@ -160,7 +160,7 @@ describe('DashboardPage', () => {
     expect(screen.getByRole('link', { name: '始める' }).getAttribute('href')).toBe('/step/usestate-basic')
   })
 
-  it('復習待ちがある場合は復習カードを表示し、今日のおすすめは通常学習を表示する', async () => {
+  it('復習待ちがある場合は復習カードを表示し、今日のおすすめも復習を優先する', async () => {
     testState.getOpenCountMock.mockResolvedValue(2)
     testState.listOpenMock.mockResolvedValue([
       {
@@ -184,8 +184,13 @@ describe('DashboardPage', () => {
     )
 
     expect(await screen.findByText('復習待ち 2 件')).toBeTruthy()
-    expect(screen.getByText('Step 2 の Practice から再開')).toBeTruthy()
+    expect(screen.getByText('昨日間違えた問題を復習')).toBeTruthy()
+    expect(screen.getByText('復習待ちが 2 件あります。まずは弱点を軽く戻しましょう。')).toBeTruthy()
     expect(screen.getByText(/最優先: Step 2/)).toBeTruthy()
-    expect(screen.getByRole('link', { name: '復習へ進む' }).getAttribute('href')).toBe('/step/events?mode=practice')
+    const reviewLinks = screen.getAllByRole('link', { name: '復習へ進む' })
+    expect(reviewLinks.map((link) => link.getAttribute('href'))).toEqual([
+      '/daily',
+      '/step/events?mode=practice',
+    ])
   })
 })

--- a/apps/web/src/pages/__tests__/ForgotPasswordPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ForgotPasswordPage.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ForgotPasswordPage } from '../ForgotPasswordPage'
+
+const mockSendPasswordResetEmail = vi.fn()
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    sendPasswordResetEmail: mockSendPasswordResetEmail,
+  }),
+}))
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabaseConfigError: null,
+  supabase: {},
+}))
+
+describe('ForgotPasswordPage', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  beforeEach(() => {
+    mockSendPasswordResetEmail.mockReset()
+  })
+
+  it('不正なメールアドレスでは送信せずエラーを表示する', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <ForgotPasswordPage />
+      </MemoryRouter>,
+    )
+
+    await user.type(screen.getByLabelText('メールアドレス'), 'invalid-mail')
+    await user.click(screen.getByRole('button', { name: 'リセットメールを送信' }))
+
+    expect(mockSendPasswordResetEmail).not.toHaveBeenCalled()
+    expect(screen.getByRole('alert').textContent).toContain('正しいメールアドレスを入力してください。')
+  })
+
+  it('リセットメール送信に成功すると案内を表示する', async () => {
+    const user = userEvent.setup()
+    mockSendPasswordResetEmail.mockResolvedValue(null)
+
+    render(
+      <MemoryRouter>
+        <ForgotPasswordPage />
+      </MemoryRouter>,
+    )
+
+    await user.type(screen.getByLabelText('メールアドレス'), 'user@example.com')
+    await user.click(screen.getByRole('button', { name: 'リセットメールを送信' }))
+
+    expect(mockSendPasswordResetEmail).toHaveBeenCalledWith(
+      'user@example.com',
+      `${window.location.origin}/reset-password`,
+    )
+    expect(screen.getByRole('status').textContent).toContain('リセットメールを送信しました。')
+  })
+})

--- a/apps/web/src/pages/__tests__/LoginPage.test.tsx
+++ b/apps/web/src/pages/__tests__/LoginPage.test.tsx
@@ -1,0 +1,34 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { LoginPage } from '../LoginPage'
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({
+    signIn: vi.fn(),
+    user: null,
+  }),
+}))
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabaseConfigError: null,
+  supabase: {},
+}))
+
+describe('LoginPage', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('パスワードリセット導線を表示する', () => {
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('link', { name: 'パスワードを忘れた方はこちら' }).getAttribute('href')).toBe(
+      '/forgot-password',
+    )
+  })
+})

--- a/apps/web/src/pages/__tests__/ResetPasswordPage.test.tsx
+++ b/apps/web/src/pages/__tests__/ResetPasswordPage.test.tsx
@@ -1,0 +1,106 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ResetPasswordPage } from '../ResetPasswordPage'
+
+const mockUpdatePassword = vi.fn()
+const mockSignOut = vi.fn()
+
+interface MockAuthValue {
+  isLoadingAuth: boolean
+  session: { user: { id: string } } | null
+  updatePassword: typeof mockUpdatePassword
+  signOut: typeof mockSignOut
+}
+
+const mockAuth = {
+  value: {
+    isLoadingAuth: false,
+    session: { user: { id: 'user-1' } },
+    updatePassword: mockUpdatePassword,
+    signOut: mockSignOut,
+  } as MockAuthValue,
+}
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => mockAuth.value,
+}))
+
+vi.mock('../../lib/supabaseClient', () => ({
+  supabaseConfigError: null,
+  supabase: {},
+}))
+
+describe('ResetPasswordPage', () => {
+  afterEach(() => {
+    cleanup()
+    window.history.replaceState(null, '', '/')
+  })
+
+  beforeEach(() => {
+    mockUpdatePassword.mockReset()
+    mockSignOut.mockReset()
+    mockAuth.value = {
+      isLoadingAuth: false,
+      session: { user: { id: 'user-1' } },
+      updatePassword: mockUpdatePassword,
+      signOut: mockSignOut,
+    }
+  })
+
+  it('session がない場合は無効リンクとして再送信導線を表示する', () => {
+    mockAuth.value = {
+      ...mockAuth.value,
+      session: null,
+    }
+    window.history.replaceState(null, '', '/reset-password#error_description=Recovery+link+expired')
+
+    render(
+      <MemoryRouter>
+        <ResetPasswordPage />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('alert').textContent).toContain('Recovery link expired')
+    expect(screen.getByRole('link', { name: 'リセットメールを再送信する' }).getAttribute('href')).toBe(
+      '/forgot-password',
+    )
+  })
+
+  it('短すぎるパスワードでは更新せずエラーを表示する', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <ResetPasswordPage />
+      </MemoryRouter>,
+    )
+
+    await user.type(screen.getByLabelText('新しいパスワード'), 'short')
+    await user.type(screen.getByLabelText('新しいパスワード（確認）'), 'short')
+    await user.click(screen.getByRole('button', { name: 'パスワードを更新' }))
+
+    expect(mockUpdatePassword).not.toHaveBeenCalled()
+    expect(screen.getByRole('alert').textContent).toContain('パスワードは8文字以上で入力してください。')
+  })
+
+  it('パスワード更新に成功するとサインアウトして完了表示にする', async () => {
+    const user = userEvent.setup()
+    mockUpdatePassword.mockResolvedValue(null)
+    mockSignOut.mockResolvedValue(null)
+
+    render(
+      <MemoryRouter>
+        <ResetPasswordPage />
+      </MemoryRouter>,
+    )
+
+    await user.type(screen.getByLabelText('新しいパスワード'), 'new-password123')
+    await user.type(screen.getByLabelText('新しいパスワード（確認）'), 'new-password123')
+    await user.click(screen.getByRole('button', { name: 'パスワードを更新' }))
+
+    expect(mockUpdatePassword).toHaveBeenCalledWith('new-password123')
+    expect(mockSignOut).toHaveBeenCalled()
+    expect(await screen.findByText('パスワードを更新しました')).toBeTruthy()
+  })
+})

--- a/apps/web/src/pages/admin/__tests__/AdminFeedbackDetailPage.test.tsx
+++ b/apps/web/src/pages/admin/__tests__/AdminFeedbackDetailPage.test.tsx
@@ -137,6 +137,22 @@ describe('AdminFeedbackDetailPage', () => {
     expect(screen.getByAltText('添付画像 2').getAttribute('src')).toBe('https://example.com/b.jpg')
   })
 
+  it('image_paths に非文字列が混ざっていても文字列だけで signed URL を取得する', async () => {
+    getFeedbackMock.mockResolvedValue({
+      ...baseFeedback,
+      image_paths: ['uid/fid/a.png', 123, null, { path: 'bad' }, false],
+    })
+    getFeedbackImageUrlsMock.mockResolvedValue([
+      { path: 'uid/fid/a.png', url: 'https://example.com/a.png' },
+    ])
+    renderPage()
+
+    await waitFor(() => {
+      expect(getFeedbackImageUrlsMock).toHaveBeenCalledWith(['uid/fid/a.png'])
+    })
+    expect(screen.getByAltText('添付画像 1').getAttribute('src')).toBe('https://example.com/a.png')
+  })
+
   it('サムネイルクリックで Lightbox が開く', async () => {
     getFeedbackMock.mockResolvedValue({
       ...baseFeedback,

--- a/apps/web/src/services/__tests__/adminQualityService.test.ts
+++ b/apps/web/src/services/__tests__/adminQualityService.test.ts
@@ -22,13 +22,31 @@ const tableState: Record<TableName, { data: unknown[]; count: number | null; err
   learning_events: { data: [], count: null, error: null },
 }
 
+const learningEventsRanges: Array<[number, number]> = []
+
 const from = vi.fn((table: TableName) => ({
-  select: () =>
-    Promise.resolve({
+  select: () => {
+    if (table === 'learning_events') {
+      return {
+        order: () => ({
+          range: (fromIndex: number, toIndex: number) => {
+            learningEventsRanges.push([fromIndex, toIndex])
+            return Promise.resolve({
+              data: tableState[table].data.slice(fromIndex, toIndex + 1),
+              count: tableState[table].count,
+              error: tableState[table].error,
+            })
+          },
+        }),
+      }
+    }
+
+    return Promise.resolve({
       data: tableState[table].data,
       count: tableState[table].count,
       error: tableState[table].error,
-    }),
+    })
+  },
 }))
 
 vi.mock('../../lib/supabaseClient', () => ({
@@ -39,6 +57,7 @@ vi.mock('../../lib/supabaseClient', () => ({
 
 function resetState() {
   vi.clearAllMocks()
+  learningEventsRanges.length = 0
   for (const table of Object.keys(tableState) as TableName[]) {
     tableState[table] = { data: [], count: table === 'profiles' ? 0 : null, error: null }
   }
@@ -318,6 +337,7 @@ describe('getAdminStepInsights', () => {
 
     expect(from).toHaveBeenCalledWith('learning_events')
     expect(insights.totalEvents).toBe(14)
+    expect(learningEventsRanges).toEqual([[0, 999]])
     expect(insights.observedSteps).toBeGreaterThan(0)
     expect(row).toEqual(
       expect.objectContaining({
@@ -354,5 +374,28 @@ describe('getAdminStepInsights', () => {
       name: 'AppError',
       userMessage: 'Step Insightsのイベントログ取得に失敗しました',
     })
+  })
+
+  it('learning_events をページングして1000件超のイベントも集計する', async () => {
+    tableState.learning_events.data = Array.from({ length: 1001 }, (_, index) => ({
+      id: index + 1,
+      user_id: `u${index}`,
+      event_type: 'step_started',
+      step_id: 'usestate-basic',
+      mode: null,
+      payload: null,
+      created_at: '2026-06-05T00:00:00Z',
+    }))
+
+    const insights = await getAdminStepInsights()
+    const row = insights.rows.find((item) => item.stepId === 'usestate-basic')
+
+    expect(learningEventsRanges).toEqual([
+      [0, 999],
+      [1000, 1999],
+    ])
+    expect(insights.totalEvents).toBe(1001)
+    expect(row?.eventCount).toBe(1001)
+    expect(row?.startedUsers).toBe(1001)
   })
 })

--- a/apps/web/src/services/__tests__/codeDoctorService.test.ts
+++ b/apps/web/src/services/__tests__/codeDoctorService.test.ts
@@ -1,6 +1,7 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { supabase } from '../../lib/supabaseClient'
 import { awardPoints } from '../pointService'
+import { trackLearningEvent } from '../eventService'
 import {
   getPointsForDifficulty,
   judgeCode,
@@ -13,9 +14,11 @@ vi.mock('../../lib/supabaseClient', () => ({
   supabase: { from: vi.fn() },
 }))
 vi.mock('../pointService', () => ({ awardPoints: vi.fn() }))
+vi.mock('../eventService', () => ({ trackLearningEvent: vi.fn() }))
 
 const mockFrom = vi.mocked(supabase.from)
 const mockAwardPoints = vi.mocked(awardPoints)
+const mockTrackLearningEvent = vi.mocked(trackLearningEvent)
 
 // ─── 純粋関数テスト ──────────────────────────────────────
 
@@ -124,6 +127,16 @@ describe('submitDoctorSolution', () => {
     expect(result.passed).toBe(true)
     expect(result.pointsEarned).toBe(15)
     expect(mockAwardPoints).toHaveBeenCalledWith(15, 'コードドクター正解（beginner）')
+    expect(mockTrackLearningEvent).toHaveBeenCalledWith({
+      userId: '00000000-0000-0000-0000-000000000001',
+      eventType: 'code_doctor_completed',
+      payload: {
+        problemId: 'cd-beginner-001',
+        category: 'react',
+        difficulty: 'beginner',
+        pointsEarned: 15,
+      },
+    })
   })
 
   it('不正解の場合は passed: false で 0 pt', async () => {
@@ -131,6 +144,7 @@ describe('submitDoctorSolution', () => {
     expect(result.passed).toBe(false)
     expect(result.pointsEarned).toBe(0)
     expect(mockAwardPoints).not.toHaveBeenCalled()
+    expect(mockTrackLearningEvent).not.toHaveBeenCalled()
   })
 
   it('不足キーワードが missingKeywords に含まれる', async () => {

--- a/apps/web/src/services/__tests__/codeReadingService.test.ts
+++ b/apps/web/src/services/__tests__/codeReadingService.test.ts
@@ -1,6 +1,7 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { supabase } from '../../lib/supabaseClient'
 import { awardPoints } from '../pointService'
+import { trackLearningEvent } from '../eventService'
 import {
   getPointsForDifficulty,
   judgeAnswer,
@@ -13,9 +14,11 @@ vi.mock('../../lib/supabaseClient', () => ({
   supabase: { from: vi.fn() },
 }))
 vi.mock('../pointService', () => ({ awardPoints: vi.fn() }))
+vi.mock('../eventService', () => ({ trackLearningEvent: vi.fn() }))
 
 const mockFrom = vi.mocked(supabase.from)
 const mockAwardPoints = vi.mocked(awardPoints)
+const mockTrackLearningEvent = vi.mocked(trackLearningEvent)
 
 // ─── サンプルデータ ──────────────────────────────────────
 
@@ -159,6 +162,17 @@ describe('submitReading', () => {
     expect(result.allCorrect).toBe(true)
     expect(result.pointsEarned).toBe(10)
     expect(mockAwardPoints).toHaveBeenCalledWith(10, 'コードリーディング完了（カスタムフック）')
+    expect(mockTrackLearningEvent).toHaveBeenCalledWith({
+      userId: '00000000-0000-0000-0000-000000000001',
+      eventType: 'code_reading_completed',
+      payload: {
+        problemId: 'cr-001',
+        difficulty: 'basic',
+        correctCount: 3,
+        totalCount: 3,
+        pointsEarned: 10,
+      },
+    })
   })
 
   it('全問正解でも previousCompleted: true の場合はポイントを付与しない', async () => {
@@ -167,6 +181,7 @@ describe('submitReading', () => {
     expect(result.allCorrect).toBe(true)
     expect(result.pointsEarned).toBe(0)
     expect(mockAwardPoints).not.toHaveBeenCalled()
+    expect(mockTrackLearningEvent).not.toHaveBeenCalled()
   })
 
   it('部分正解の場合は allCorrect: false で 0 pt', async () => {
@@ -175,6 +190,7 @@ describe('submitReading', () => {
     expect(result.allCorrect).toBe(false)
     expect(result.pointsEarned).toBe(0)
     expect(mockAwardPoints).not.toHaveBeenCalled()
+    expect(mockTrackLearningEvent).not.toHaveBeenCalled()
   })
 
   it('questionResults の長さが問題数と一致する', async () => {

--- a/apps/web/src/services/__tests__/dailyChallengeService.test.ts
+++ b/apps/web/src/services/__tests__/dailyChallengeService.test.ts
@@ -1,6 +1,7 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { supabase } from '../../lib/supabaseClient'
 import { awardPoints } from '../pointService'
+import { trackLearningEvent } from '../eventService'
 import { pickForDaily, recordWrongAnswer, resolveReviewItem } from '../reviewService'
 import {
   getTodayJst,
@@ -23,6 +24,10 @@ vi.mock('../pointService', () => ({
   awardPoints: vi.fn(),
 }))
 
+vi.mock('../eventService', () => ({
+  trackLearningEvent: vi.fn(),
+}))
+
 vi.mock('../reviewService', () => ({
   pickForDaily: vi.fn(),
   recordWrongAnswer: vi.fn(),
@@ -31,6 +36,7 @@ vi.mock('../reviewService', () => ({
 
 const mockFrom = vi.mocked(supabase.from)
 const mockAwardPoints = vi.mocked(awardPoints)
+const mockTrackLearningEvent = vi.mocked(trackLearningEvent)
 const mockPickForDaily = vi.mocked(pickForDaily)
 const mockRecordWrongAnswer = vi.mocked(recordWrongAnswer)
 const mockResolveReviewItem = vi.mocked(resolveReviewItem)
@@ -309,6 +315,18 @@ describe('submitDailyAnswer', () => {
       questionId: 'usestate-basic-daily-0',
     })
     expect(mockAwardPoints).toHaveBeenCalledWith(20, 'デイリーチャレンジ正解')
+    expect(mockTrackLearningEvent).toHaveBeenCalledWith({
+      userId,
+      eventType: 'daily_completed',
+      stepId: 'usestate-basic',
+      mode: 'daily',
+      payload: {
+        questionId: 'usestate-basic-daily-0',
+        challengeDate: dateStr,
+        pointsEarned: 20,
+        streak: 0,
+      },
+    })
   })
 
   it('弱点優先のDaily正解時は元の復習itemも resolved にする', async () => {
@@ -346,6 +364,7 @@ describe('submitDailyAnswer', () => {
       userInput: 'wrongAnswer',
     })
     expect(mockAwardPoints).not.toHaveBeenCalled()
+    expect(mockTrackLearningEvent).not.toHaveBeenCalled()
   })
 
   it('前後の空白を無視して正解判定する', async () => {

--- a/apps/web/src/services/__tests__/feedbackService.test.ts
+++ b/apps/web/src/services/__tests__/feedbackService.test.ts
@@ -544,6 +544,19 @@ describe('uploadFeedbackImages', () => {
     expect(uploaded).not.toMatch(/[^a-zA-Z0-9._\-/]/)
   })
 
+  it('同名ファイルも index 付きのパスにして衝突させない', async () => {
+    const files = [createTestFile('same.png', 100), createTestFile('same.png', 100)]
+    const paths = await uploadFeedbackImages(VALID_USER_ID, VALID_FEEDBACK_ID, files)
+
+    expect(paths[0]).toMatch(
+      new RegExp(`^${VALID_USER_ID}/${VALID_FEEDBACK_ID}/\\d+_0_same\\.png$`),
+    )
+    expect(paths[1]).toMatch(
+      new RegExp(`^${VALID_USER_ID}/${VALID_FEEDBACK_ID}/\\d+_1_same\\.png$`),
+    )
+    expect(new Set(paths).size).toBe(2)
+  })
+
   it('Storage エラー時にアプリ共通エラーを投げる', async () => {
     storageState.uploadResult = { error: { message: 'bucket not found' } }
     const files = [createTestFile('fail.png', 100)]

--- a/apps/web/src/services/__tests__/miniProjectService.test.ts
+++ b/apps/web/src/services/__tests__/miniProjectService.test.ts
@@ -1,6 +1,7 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { supabase } from '../../lib/supabaseClient'
 import { awardPoints } from '../pointService'
+import { trackLearningEvent } from '../eventService'
 import {
   judgeProject,
   calcStatus,
@@ -13,9 +14,11 @@ vi.mock('../../lib/supabaseClient', () => ({
   supabase: { from: vi.fn() },
 }))
 vi.mock('../pointService', () => ({ awardPoints: vi.fn() }))
+vi.mock('../eventService', () => ({ trackLearningEvent: vi.fn() }))
 
 const mockFrom = vi.mocked(supabase.from)
 const mockAwardPoints = vi.mocked(awardPoints)
+const mockTrackLearningEvent = vi.mocked(trackLearningEvent)
 
 // ─── サンプルデータ ──────────────────────────────────────
 
@@ -169,6 +172,17 @@ describe('submitProject', () => {
     expect(result.allPassed).toBe(true)
     expect(result.pointsEarned).toBe(100)
     expect(mockAwardPoints).toHaveBeenCalledWith(100, 'ミニプロジェクト完了（Todo App）')
+    expect(mockTrackLearningEvent).toHaveBeenCalledWith({
+      userId: '00000000-0000-0000-0000-000000000001',
+      eventType: 'mini_project_completed',
+      mode: 'mini_project',
+      payload: {
+        projectId: 'todo-app',
+        difficulty: 'beginner',
+        milestoneCount: 2,
+        pointsEarned: 100,
+      },
+    })
   })
 
   it('初回 completed 時のみポイントを付与する（previousStatus: not_started）', async () => {
@@ -183,6 +197,7 @@ describe('submitProject', () => {
     const result = await submitProject('00000000-0000-0000-0000-000000000001', sampleProject, code, 'completed')
     expect(result.pointsEarned).toBe(0)
     expect(mockAwardPoints).not.toHaveBeenCalled()
+    expect(mockTrackLearningEvent).not.toHaveBeenCalled()
   })
 
   it('一部通過の場合は 0 Pt で allPassed: false', async () => {
@@ -191,6 +206,7 @@ describe('submitProject', () => {
     expect(result.allPassed).toBe(false)
     expect(result.pointsEarned).toBe(0)
     expect(mockAwardPoints).not.toHaveBeenCalled()
+    expect(mockTrackLearningEvent).not.toHaveBeenCalled()
   })
 
   it('milestoneResults の長さがマイルストーン数と一致する', async () => {

--- a/apps/web/src/services/__tests__/notificationService.test.ts
+++ b/apps/web/src/services/__tests__/notificationService.test.ts
@@ -9,6 +9,7 @@ import {
 type Row = Record<string, unknown>
 
 const notificationsState = {
+  selectColumns: null as string | null,
   orderCalls: [] as Array<{ column: string; options: Record<string, unknown> | undefined }>,
   limitCalls: [] as number[],
   result: { data: [] as Row[] | null, error: null as unknown },
@@ -40,7 +41,10 @@ function createNotificationsBuilder() {
   }
 
   return {
-    select: () => chain,
+    select: (columns: string) => {
+      notificationsState.selectColumns = columns
+      return chain
+    },
   }
 }
 
@@ -87,6 +91,7 @@ const NOTIFICATION_ID_2 = '33333333-3333-3333-3333-333333333333'
 
 function resetState() {
   vi.clearAllMocks()
+  notificationsState.selectColumns = null
   notificationsState.orderCalls = []
   notificationsState.limitCalls = []
   notificationsState.result = { data: [], error: null }
@@ -132,10 +137,12 @@ describe('getNotifications', () => {
 
     expect(from).toHaveBeenCalledWith('notifications')
     expect(from).toHaveBeenCalledWith('notification_reads')
+    expect(notificationsState.selectColumns).toBe('*')
     expect(notificationsState.orderCalls).toEqual([
       { column: 'published_at', options: { ascending: false } },
       { column: 'created_at', options: { ascending: false } },
     ])
+    expect(readsState.selectColumns).toBe('notification_id, read_at')
     expect(readsState.eqCalls).toEqual([['user_id', USER_ID]])
     expect(readsState.inCalls).toEqual([
       ['notification_id', [NOTIFICATION_ID_1, NOTIFICATION_ID_2]],
@@ -210,6 +217,40 @@ describe('getUnreadCount', () => {
     }
 
     await expect(getUnreadCount(USER_ID)).resolves.toBe(1)
+    expect(notificationsState.selectColumns).toBe('id')
+    expect(notificationsState.orderCalls).toEqual([])
+    expect(readsState.selectColumns).toBe('notification_id')
+    expect(readsState.eqCalls).toEqual([['user_id', USER_ID]])
+    expect(readsState.inCalls).toEqual([
+      ['notification_id', [NOTIFICATION_ID_1, NOTIFICATION_ID_2]],
+    ])
+  })
+
+  it('通知がないときは既読状態を問い合わせず 0 を返す', async () => {
+    notificationsState.result = { data: [], error: null }
+
+    await expect(getUnreadCount(USER_ID)).resolves.toBe(0)
+    expect(notificationsState.selectColumns).toBe('id')
+    expect(from).not.toHaveBeenCalledWith('notification_reads')
+  })
+
+  it('不正な userId は例外を投げる', async () => {
+    await expect(getUnreadCount('not-uuid')).rejects.toThrow(
+      'userId must be a valid UUID',
+    )
+    expect(from).not.toHaveBeenCalled()
+  })
+
+  it('通知 ID 取得の DB エラーを AppError に変換する', async () => {
+    notificationsState.result = {
+      data: null,
+      error: { code: 'DB_ERROR', message: 'rls denied' },
+    }
+
+    await expect(getUnreadCount(USER_ID)).rejects.toMatchObject({
+      name: 'AppError',
+      userMessage: '未読件数の取得に失敗しました',
+    })
   })
 })
 

--- a/apps/web/src/services/adminQualityService.ts
+++ b/apps/web/src/services/adminQualityService.ts
@@ -27,7 +27,7 @@ type StepFeedbackRow = Pick<Tables<'user_feedback'>, 'status' | 'created_at' | '
 type ReviewItemRow = Pick<Tables<'review_items'>, 'status' | 'step_id'>
 type LearningEventRow = Pick<
   Tables<'learning_events'>,
-  'user_id' | 'event_type' | 'step_id' | 'mode' | 'payload' | 'created_at'
+  'id' | 'user_id' | 'event_type' | 'step_id' | 'mode' | 'payload' | 'created_at'
 >
 
 export type AdminQualityMetricStatus = 'formal' | 'provisional' | 'future'
@@ -175,6 +175,9 @@ interface StepEventAggregate {
 }
 
 const STEP_INSIGHT_MODES: readonly LearningMode[] = ['read', 'practice', 'test', 'challenge']
+const LEARNING_EVENTS_PAGE_SIZE = 1000
+const LEARNING_EVENTS_SELECT =
+  'id, user_id, event_type, step_id, mode, payload, created_at'
 
 function isStepCompleted(row: StepProgressRow): boolean {
   return Boolean(
@@ -628,6 +631,30 @@ function buildStepInsights(aggregates: StepAggregate[]): AdminQualityStepInsight
   }).sort((a, b) => a.order - b.order)
 }
 
+async function fetchAllLearningEvents(): Promise<LearningEventRow[]> {
+  const rows: LearningEventRow[] = []
+
+  for (let from = 0; ; from += LEARNING_EVENTS_PAGE_SIZE) {
+    const to = from + LEARNING_EVENTS_PAGE_SIZE - 1
+    const { data, error } = await supabase
+      .from('learning_events')
+      .select(LEARNING_EVENTS_SELECT)
+      .order('id', { ascending: true })
+      .range(from, to)
+
+    if (error) {
+      throw fromSupabaseError(error, 'Step Insightsのイベントログ取得に失敗しました')
+    }
+
+    const pageRows = (data ?? []) as LearningEventRow[]
+    rows.push(...pageRows)
+
+    if (pageRows.length < LEARNING_EVENTS_PAGE_SIZE) {
+      return rows
+    }
+  }
+}
+
 export async function getAdminQualityDashboard(): Promise<AdminQualityDashboard> {
   const [
     usersRes,
@@ -801,19 +828,14 @@ export async function getAdminQualityDashboard(): Promise<AdminQualityDashboard>
 }
 
 export async function getAdminStepInsights(): Promise<AdminStepInsights> {
-  const [eventsRes, feedbackRes] = await Promise.all([
-    supabase
-      .from('learning_events')
-      .select('user_id, event_type, step_id, mode, payload, created_at'),
+  const [events, feedbackRes] = await Promise.all([
+    fetchAllLearningEvents(),
     supabase.from('user_feedback').select('status, created_at, page_url'),
   ])
 
-  if (eventsRes.error)
-    throw fromSupabaseError(eventsRes.error, 'Step Insightsのイベントログ取得に失敗しました')
   if (feedbackRes.error)
     throw fromSupabaseError(feedbackRes.error, 'Step Insightsのフィードバック取得に失敗しました')
 
-  const events = (eventsRes.data ?? []) as LearningEventRow[]
   const feedbackRows = (feedbackRes.data ?? []) as StepFeedbackRow[]
   const rows = buildAdminStepInsightRows(buildStepEventAggregates(events, feedbackRows))
   const observedRows = rows.filter((row) => row.eventCount > 0 || row.relatedFeedbackCount > 0)

--- a/apps/web/src/services/codeDoctorService.ts
+++ b/apps/web/src/services/codeDoctorService.ts
@@ -8,6 +8,7 @@ import {
 import { fromSupabaseError } from '../shared/errors'
 import { assertMaxLength, assertUuid } from '../shared/validation'
 import { awardPoints } from './pointService'
+import { trackLearningEvent } from './eventService'
 import { judgeKeywords } from '../lib/judge'
 import type { CodeDoctorProblem, CodeDoctorProgress, SubmitDoctorResult } from '../content/code-doctor/types'
 
@@ -112,6 +113,16 @@ export async function submitDoctorSolution(
       pointsEarned,
       `コードドクター正解（${problem.difficulty}）`,
     )
+    trackLearningEvent({
+      userId,
+      eventType: 'code_doctor_completed',
+      payload: {
+        problemId: problem.id,
+        category: problem.category,
+        difficulty: problem.difficulty,
+        pointsEarned,
+      },
+    })
   }
 
   return { passed, pointsEarned, missingKeywords, foundNgKeywords, explanation: problem.explanation }

--- a/apps/web/src/services/codeReadingService.ts
+++ b/apps/web/src/services/codeReadingService.ts
@@ -7,6 +7,7 @@ import {
   POINTS_CODE_READING_ADVANCED,
 } from '../shared/constants'
 import { awardPoints } from './pointService'
+import { trackLearningEvent } from './eventService'
 import type {
   CodeReadingProblem,
   CodeReadingProgress,
@@ -113,6 +114,17 @@ export async function submitReading(
 
   if (isNewlyCompleted) {
     await awardPoints(pointsEarned, `コードリーディング完了（${problem.title}）`)
+    trackLearningEvent({
+      userId,
+      eventType: 'code_reading_completed',
+      payload: {
+        problemId: problem.id,
+        difficulty: problem.difficulty,
+        correctCount,
+        totalCount: problem.questions.length,
+        pointsEarned,
+      },
+    })
   }
 
   return { questionResults, allCorrect, correctCount, pointsEarned }

--- a/apps/web/src/services/dailyChallengeService.ts
+++ b/apps/web/src/services/dailyChallengeService.ts
@@ -3,6 +3,7 @@ import { MAX_ANSWER_LENGTH, POINTS_DAILY_CORRECT, POINTS_DAILY_STREAK_BONUS } fr
 import { fromSupabaseError } from '../shared/errors'
 import { assertMaxLength, assertUuid } from '../shared/validation'
 import { awardPoints } from './pointService'
+import { trackLearningEvent } from './eventService'
 import {
   pickForDaily,
   recordWrongAnswer,
@@ -255,6 +256,19 @@ export async function submitDailyAnswer(
     if (streak > 0 && streak % 7 === 0) {
       await awardPoints(POINTS_DAILY_STREAK_BONUS, `デイリー${streak}日連続ボーナス`)
     }
+
+    trackLearningEvent({
+      userId,
+      eventType: 'daily_completed',
+      stepId: question.stepId,
+      mode: 'daily',
+      payload: {
+        questionId: question.id,
+        challengeDate: dateStr,
+        pointsEarned,
+        streak,
+      },
+    })
   } else {
     try {
       await recordWrongAnswer({

--- a/apps/web/src/services/eventService.ts
+++ b/apps/web/src/services/eventService.ts
@@ -10,6 +10,8 @@ export type LearningEventType =
   | 'test_submitted'
   | 'challenge_submitted'
   | 'daily_completed'
+  | 'code_doctor_completed'
+  | 'code_reading_completed'
   | 'review_item_created'
   | 'review_item_resolved'
   | 'mini_project_started'

--- a/apps/web/src/services/miniProjectService.ts
+++ b/apps/web/src/services/miniProjectService.ts
@@ -3,6 +3,7 @@ import { MAX_CODE_LENGTH, POINTS_MINI_PROJECT_COMPLETE } from '../shared/constan
 import { fromSupabaseError } from '../shared/errors'
 import { assertMaxLength, assertUuid } from '../shared/validation'
 import { awardPoints } from './pointService'
+import { trackLearningEvent } from './eventService'
 import type {
   MiniProject,
   MiniProjectProgress,
@@ -109,6 +110,17 @@ export async function submitProject(
 
   if (isNewlyCompleted) {
     await awardPoints(POINTS_MINI_PROJECT_COMPLETE, `ミニプロジェクト完了（${project.title}）`)
+    trackLearningEvent({
+      userId,
+      eventType: 'mini_project_completed',
+      mode: 'mini_project',
+      payload: {
+        projectId: project.id,
+        difficulty: project.difficulty,
+        milestoneCount: project.milestones.length,
+        pointsEarned,
+      },
+    })
   }
 
   return { milestoneResults, allPassed, pointsEarned, newStatus }

--- a/apps/web/src/services/notificationService.ts
+++ b/apps/web/src/services/notificationService.ts
@@ -104,8 +104,33 @@ export async function getNotifications(
 
 /** 自分宛て通知の未読件数を取得する。 */
 export async function getUnreadCount(userId: string): Promise<number> {
-  const notifications = await getNotifications({ userId })
-  return notifications.filter((notification) => !notification.isRead).length
+  assertUuid(userId, 'userId')
+
+  const { data: notifications, error } = await supabase
+    .from('notifications')
+    .select('id')
+
+  if (error) {
+    throw fromSupabaseError(error, '未読件数の取得に失敗しました')
+  }
+
+  const notificationIds = (notifications ?? []).map((notification) => notification.id)
+  if (notificationIds.length === 0) {
+    return 0
+  }
+
+  const { data: reads, error: readsError } = await supabase
+    .from('notification_reads')
+    .select('notification_id')
+    .eq('user_id', userId)
+    .in('notification_id', notificationIds)
+
+  if (readsError) {
+    throw fromSupabaseError(readsError, 'お知らせの既読状態の取得に失敗しました')
+  }
+
+  const readNotificationIds = new Set((reads ?? []).map((read) => read.notification_id))
+  return notificationIds.filter((id) => !readNotificationIds.has(id)).length
 }
 
 /** 通知を既読にする。既に既読の場合も成功扱いにする。 */

--- a/apps/web/supabase/sql/027_learning_event_completion_types.sql
+++ b/apps/web/supabase/sql/027_learning_event_completion_types.sql
@@ -1,0 +1,26 @@
+-- v1.0 post-release: add completion event types for practice modes
+-- Run this in Supabase SQL Editor after 022_learning_events.sql.
+
+alter table public.learning_events
+  drop constraint if exists learning_events_event_type_check;
+
+alter table public.learning_events
+  add constraint learning_events_event_type_check check (
+    event_type in (
+      'step_started',
+      'mode_started',
+      'mode_completed',
+      'practice_answer_submitted',
+      'test_submitted',
+      'challenge_submitted',
+      'daily_completed',
+      'code_doctor_completed',
+      'code_reading_completed',
+      'review_item_created',
+      'review_item_resolved',
+      'mini_project_started',
+      'mini_project_completed',
+      'feedback_created',
+      'base_nook_opened'
+    )
+  );

--- a/docs/supabase-ops.md
+++ b/docs/supabase-ops.md
@@ -48,7 +48,7 @@ NNN_short_description.sql
 - RLS対象テーブルを作る場合、同じファイル内に RLS 有効化と policy を含める
 - RPCを追加する場合、権限、`security definer`、`search_path`、admin判定の有無を明記する
 
-2026-06-10 時点の管理対象SQLの最新は `026_feedback_update_restriction.sql`。次の新規の管理対象SQLは `027_*.sql` から始める。
+2026-06-11 時点の管理対象SQLの最新は `027_learning_event_completion_types.sql`。次の新規の管理対象SQLは `028_*.sql` から始める。
 
 ---
 
@@ -78,6 +78,9 @@ NNN_short_description.sql
 | 022 | `022_learning_events.sql` | 学習イベントログ |
 | 023 | `023_notifications.sql` | アプリ内通知 / 既読管理 |
 | 024 | `024_feedback_notification_trigger.sql` | feedback作成時のadmin通知trigger |
+| 025 | `025_gamification_write_lockdown.sql` | gamification系テーブルの直接書き込み制限 |
+| 026 | `026_feedback_update_restriction.sql` | user_feedback の一般ユーザー更新制限 |
+| 027 | `027_learning_event_completion_types.sql` | Practice系完了イベントタイプ追加 |
 
 `002` / `005` は過去の seed SQL のため Git 管理対象から除外済み。seed が必要な環境では、Git 管理外の `apps/web/supabase/sql/local/*.sql` などで環境ごとに用意する。
 


### PR DESCRIPTION
## Summary
- Add password reset flow for Issue #320: login link, reset request page, recovery password update page
- Include recent dev fixes for dashboard recommendations, notification unread counts, Step Insights pagination, validation/a11y regression coverage
- Include Practice completion event tracking updates

## Test plan
- Local typecheck PASS
- Local lint PASS
- Local test PASS (93 files / 943 tests)
- Local build PASS
- Playwright MCP PASS: login reset link, forgot-password validation, reset-password invalid link, 390px mobile layout
- PR #321 CI PASS: Typecheck / Lint / Test / Build / Vercel

## Release notes
- After this PR is merged to main, tag candidate: `coden-v1.1.0`
- Supabase Auth URL Configuration must include `https://coden-lpf.vercel.app/reset-password`
