### PR TITLE
fix: events教材とPractice許容回答を整合

### DIFF
--- a/apps/web/src/content/__tests__/stepWalkthrough.test.ts
+++ b/apps/web/src/content/__tests__/stepWalkthrough.test.ts
@@ -221,6 +221,17 @@ describe('Step メタ情報', () => {
       }
     }
   })
+
+  it('events: preventDefault を Read で説明し、Practice q5 で自然な回答を許容する', () => {
+    const step = getFundamentalsStep('events')!
+    const question = step.practiceQuestions.find((q) => q.id === 'q5')!
+
+    expect(step.readMarkdown).toContain('onSubmit')
+    expect(step.readMarkdown).toContain('e.preventDefault()')
+    expect(question.answer).toBe('preventDefault')
+    expect(question.answerAliases).toContain('e.preventDefault')
+    expect(question.answerAliases).toContain('e.preventDefault()')
+  })
 })
 
 // ─────────────────────────────────────────

--- a/apps/web/src/content/fundamentals/steps.ts
+++ b/apps/web/src/content/fundamentals/steps.ts
@@ -6,6 +6,7 @@ export interface PracticeQuestion {
   id: string
   prompt: string
   answer: string
+  answerAliases?: string[]
   hint: string
   explanation?: string
   choices?: string[]
@@ -310,6 +311,28 @@ export function NameInput() {
 
 - \`onChange\` は入力が変わるたびに呼ばれます。
 - 引数の event (\`e\`) オブジェクトを通じて、入力された最新の値 (\`e.target.value\`) を取得し、\`setName\` で状態を更新します。
+
+## フォーム送信のデフォルト動作を止める
+
+\`<form>\` はブラウザ標準の動きとして、送信時にページを再読み込みしようとします。React の SPA では画面全体を再読み込みせず、イベントハンドラの中で処理を続けたいので、\`onSubmit\` に渡した関数の中で \`e.preventDefault()\` を呼びます。
+
+\`\`\`tsx
+export function SearchForm() {
+  function handleSubmit(e) {
+    e.preventDefault();
+    alert('送信しました');
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <button type="submit">送信</button>
+    </form>
+  );
+}
+\`\`\`
+
+- \`onSubmit\` はフォームが送信されたときに呼ばれます。
+- \`e.preventDefault()\` は、ページリロードなどのブラウザ標準動作を止めるメソッドです。
 `,
     practiceQuestions: [
       {
@@ -345,6 +368,7 @@ export function NameInput() {
         id: 'q5',
         prompt: 'フォームの送信などで、ブラウザのデフォルトの動作（ページリロードなど）を防ぐために呼ぶメソッドは何ですか？（e.〇〇〇〇）',
         answer: 'preventDefault',
+        answerAliases: ['e.preventDefault', 'preventDefault()', 'e.preventDefault()'],
         hint: 'デフォルト(default)の動作を、防ぐ(prevent)関数です。',
         explanation: 'SPAではページリロードなしで動作させるため、onSubmitハンドラ内でe.preventDefault()を呼び出します。',
       },

--- a/apps/web/src/features/learning/PracticeMode.tsx
+++ b/apps/web/src/features/learning/PracticeMode.tsx
@@ -14,6 +14,15 @@ function normalize(value: string) {
   return value.replace(/\s+/g, '').toLowerCase()
 }
 
+function getAcceptedAnswers(question: PracticeQuestion) {
+  return [question.answer, ...(question.answerAliases ?? [])]
+}
+
+function isPracticeAnswerCorrect(question: PracticeQuestion, answer: string) {
+  const normalizedAnswer = normalize(answer)
+  return getAcceptedAnswers(question).some((acceptedAnswer) => normalize(acceptedAnswer) === normalizedAnswer)
+}
+
 export function PracticeMode({ stepId, questions, onComplete }: PracticeModeProps) {
   const [answers, setAnswers] = useState<Record<string, string>>({})
   const [hints, setHints] = useState<Record<string, boolean>>({})
@@ -30,7 +39,7 @@ export function PracticeMode({ stepId, questions, onComplete }: PracticeModeProp
     () =>
       questions.every((question) => {
         const answer = answers[question.id] ?? ''
-        return normalize(answer) === normalize(question.answer)
+        return isPracticeAnswerCorrect(question, answer)
       }),
     [answers, questions],
   )
@@ -47,7 +56,7 @@ export function PracticeMode({ stepId, questions, onComplete }: PracticeModeProp
     setIsJudged(true)
     const payloads = questions.filter((question) => {
       const answer = answers[question.id] ?? ''
-      const isCorrect = normalize(answer) === normalize(question.answer)
+      const isCorrect = isPracticeAnswerCorrect(question, answer)
       return isAllCorrect || !isCorrect
     }).map(getReviewPayload)
 
@@ -67,7 +76,7 @@ export function PracticeMode({ stepId, questions, onComplete }: PracticeModeProp
       <h2 className="text-lg font-semibold">Practice</h2>
       {questions.map((question, index) => {
         const answer = answers[question.id] ?? ''
-        const isCorrect = answer.length > 0 && normalize(answer) === normalize(question.answer)
+        const isCorrect = answer.length > 0 && isPracticeAnswerCorrect(question, answer)
         const showExplanation = isJudged && !isCorrect && question.explanation
 
         return (
@@ -79,7 +88,7 @@ export function PracticeMode({ stepId, questions, onComplete }: PracticeModeProp
               <div className="flex flex-wrap gap-2" role="radiogroup" aria-label={`Q${index + 1} 選択肢`}>
                 {question.choices.map((choice) => {
                   const isSelected = answer === choice
-                  const isChoiceCorrect = normalize(choice) === normalize(question.answer)
+                  const isChoiceCorrect = isPracticeAnswerCorrect(question, choice)
                   let btnClass = 'min-h-[44px] rounded-md border px-3 py-2.5 text-sm text-left transition-colors'
                   if (isJudged) {
                     if (isChoiceCorrect) {

--- a/apps/web/src/features/learning/__tests__/PracticeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/PracticeMode.test.tsx
@@ -54,6 +54,17 @@ const choiceQuestions: PracticeQuestion[] = [
   },
 ]
 
+const aliasQuestions: PracticeQuestion[] = [
+  {
+    id: 'q-alias',
+    prompt: 'デフォルト動作を止めるメソッドは？',
+    answer: 'preventDefault',
+    answerAliases: ['e.preventDefault', 'preventDefault()', 'e.preventDefault()'],
+    hint: 'イベントオブジェクトのメソッドです。',
+    explanation: 'フォーム送信時のページリロードを止めます。',
+  },
+]
+
 describe('PracticeMode', () => {
   afterEach(() => {
     cleanup()
@@ -124,6 +135,30 @@ describe('PracticeMode', () => {
       },
     })
     expect(screen.getByRole('status').textContent).toContain('まだ不正解の問題があります')
+  })
+
+  it('短答式問題で answerAliases に含まれる自然な回答を正解として扱う', async () => {
+    const user = userEvent.setup()
+    const onComplete = vi.fn()
+    render(<PracticeMode stepId="step-alias" questions={aliasQuestions} onComplete={onComplete} />)
+
+    await user.type(screen.getByLabelText('Q1 回答欄'), 'e.preventDefault()')
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+
+    expect(onComplete).toHaveBeenCalledTimes(1)
+    expect(trackLearningEvent).toHaveBeenCalledWith({
+      userId: '00000000-0000-0000-0000-000000000001',
+      eventType: 'practice_answer_submitted',
+      stepId: 'step-alias',
+      mode: 'practice',
+      courseId: null,
+      payload: {
+        isCorrect: true,
+        itemCount: 1,
+        questionIds: ['q-alias'],
+      },
+    })
+    expect(screen.getByText('正解です。')).toBeTruthy()
   })
 
   it('stepId が変わると回答・ヒント・判定状態をリセットする', async () => {


### PR DESCRIPTION
## Summary
- events Read に onSubmit / e.preventDefault() の説明を追加
- PracticeQuestion に answerAliases を追加し、自然な別解を正解扱い
- PracticeMode とコンテンツ整合性テストを追加

## Verification
- typecheck pass
- lint pass
- test pass (945 tests)
- build pass

Closes #326