### PR TITLE
feat: M5-1型と条件判定基盤を追加

### DIFF
--- a/apps/web/src/content/fundamentals/steps.ts
+++ b/apps/web/src/content/fundamentals/steps.ts
@@ -2,13 +2,25 @@ import { withLearningGoals } from '../stepLearningGoals'
 
 export type LearningMode = 'read' | 'practice' | 'test' | 'challenge'
 
+export type PracticeQuestionLevel = 'basic' | 'applied'
+
+export interface KeywordCondition {
+  id: string
+  label: string
+  requiredKeywords: string[]
+  explanation: string
+}
+
 export interface PracticeQuestion {
   id: string
   prompt: string
   answer: string
   answerAliases?: string[]
+  level?: PracticeQuestionLevel
+  testedConcept?: string
   hint: string
   explanation?: string
+  solutionText?: string
   choices?: string[]
 }
 
@@ -16,7 +28,10 @@ export interface TestTask {
   instruction: string
   starterCode: string
   expectedKeywords: string[]
+  conditions?: KeywordCondition[]
+  hint?: string
   explanation?: string
+  solutionCode?: string
 }
 
 export interface ChallengeMobilePuzzleMultiBlank {
@@ -45,11 +60,14 @@ export interface ChallengePattern {
   anyOf?: string[][]
   /** 部分点での合格閾値（0-100。未指定なら全要件一致。任意） */
   passThreshold?: number
+  conditions?: KeywordCondition[]
   starterCode: string
+  solutionCode?: string
   mobilePuzzle?: ChallengeMobilePuzzle
 }
 
 export interface ChallengeTask {
+  primaryPatternId?: string
   patterns: ChallengePattern[]
 }
 

--- a/apps/web/src/lib/__tests__/judge.test.ts
+++ b/apps/web/src/lib/__tests__/judge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { judgeKeywords } from '../judge'
+import { judgeKeywordConditions, judgeKeywords } from '../judge'
 
 describe('judgeKeywords', () => {
   it('必須キーワードをすべて含めば passed: true / score 100', () => {
@@ -117,5 +117,107 @@ describe('judgeKeywords', () => {
       expect(result.score).toBe(100)
       expect(result.passed).toBe(false)
     })
+  })
+})
+
+describe('judgeKeywordConditions', () => {
+  it('全条件を満たすと passed: true / score 100 を返す', () => {
+    const result = judgeKeywordConditions('setCount(count - 1); onClick={handleClick}', [
+      {
+        id: 'state-update',
+        label: 'state更新',
+        requiredKeywords: ['setCount', 'count - 1'],
+        explanation: 'setCount で count を更新できているか確認しましょう。',
+      },
+      {
+        id: 'event-handler',
+        label: 'イベント接続',
+        requiredKeywords: ['onClick'],
+        explanation: 'ボタンのクリック処理に接続できているか確認しましょう。',
+      },
+    ])
+
+    expect(result.passed).toBe(true)
+    expect(result.score).toBe(100)
+    expect(result.conditions).toHaveLength(2)
+    expect(result.satisfiedConditions.map((condition) => condition.id)).toEqual(['state-update', 'event-handler'])
+    expect(result.unsatisfiedConditions).toHaveLength(0)
+  })
+
+  it('不足条件をラベルと説明つきで返す', () => {
+    const result = judgeKeywordConditions('setCount(count - 1)', [
+      {
+        id: 'state-update',
+        label: 'state更新',
+        requiredKeywords: ['setCount', 'count - 1'],
+        explanation: 'setCount で count を更新できているか確認しましょう。',
+      },
+      {
+        id: 'event-handler',
+        label: 'イベント接続',
+        requiredKeywords: ['onClick'],
+        explanation: 'ボタンのクリック処理に接続できているか確認しましょう。',
+      },
+    ])
+
+    expect(result.passed).toBe(false)
+    expect(result.score).toBe(50)
+    expect(result.satisfiedConditions.map((condition) => condition.id)).toEqual(['state-update'])
+    expect(result.unsatisfiedConditions).toHaveLength(1)
+    expect(result.unsatisfiedConditions[0]).toMatchObject({
+      id: 'event-handler',
+      label: 'イベント接続',
+      explanation: 'ボタンのクリック処理に接続できているか確認しましょう。',
+      missing: ['onClick'],
+    })
+  })
+
+  it('条件ごとの anyOf と passThreshold を既存判定と同じように扱う', () => {
+    const result = judgeKeywordConditions('setCount(prev => prev + 1)', [
+      {
+        id: 'increment',
+        label: '増加処理',
+        requiredKeywords: ['setCount'],
+        anyOf: [['count + 1'], ['prev => prev + 1']],
+        explanation: '現在値をもとに1増やせているか確認しましょう。',
+      },
+      {
+        id: 'partial',
+        label: '部分条件',
+        requiredKeywords: ['setCount', 'onClick'],
+        passThreshold: 50,
+        explanation: '必要な要素を組み合わせられているか確認しましょう。',
+      },
+    ])
+
+    expect(result.passed).toBe(true)
+    expect(result.score).toBe(100)
+    expect(result.satisfiedConditions).toHaveLength(2)
+  })
+
+  it('条件内の ngKeywords 違反を不足条件として扱う', () => {
+    const result = judgeKeywordConditions('var count = 0; setCount(count + 1)', [
+      {
+        id: 'safe-update',
+        label: '安全な更新',
+        requiredKeywords: ['setCount'],
+        ngKeywords: ['var '],
+        explanation: '避けたい書き方を含めずに実装できているか確認しましょう。',
+      },
+    ])
+
+    expect(result.passed).toBe(false)
+    expect(result.score).toBe(0)
+    expect(result.unsatisfiedConditions[0]?.violations).toEqual(['var '])
+  })
+
+  it('条件が空なら互換的に passed: true / score 100 を返す', () => {
+    const result = judgeKeywordConditions('anything', [])
+
+    expect(result.passed).toBe(true)
+    expect(result.score).toBe(100)
+    expect(result.conditions).toEqual([])
+    expect(result.satisfiedConditions).toEqual([])
+    expect(result.unsatisfiedConditions).toEqual([])
   })
 })

--- a/apps/web/src/lib/judge.ts
+++ b/apps/web/src/lib/judge.ts
@@ -47,6 +47,40 @@ export interface KeywordJudgeInput {
   passThreshold?: number | undefined
 }
 
+/** 条件単位のキーワード判定入力 */
+export interface KeywordConditionJudgeInput extends KeywordJudgeInput {
+  /** 条件を一意に識別するID */
+  id: string
+  /** 学習者に表示する条件名 */
+  label: string
+  /** 条件が不足したときに表示する説明 */
+  explanation: string
+  /** 条件単位では requiredKeywords を必須にする */
+  requiredKeywords: string[]
+}
+
+/** 条件単位の判定結果 */
+export interface KeywordConditionJudgeResult extends JudgeResult {
+  id: string
+  label: string
+  explanation: string
+  requiredKeywords: string[]
+}
+
+/** 複数条件の判定結果 */
+export interface KeywordConditionsJudgeResult {
+  /** 全条件を満たしたか */
+  passed: boolean
+  /** 条件単位の達成率 0-100 */
+  score: number
+  /** 全条件の判定詳細 */
+  conditions: KeywordConditionJudgeResult[]
+  /** 満たした条件 */
+  satisfiedConditions: KeywordConditionJudgeResult[]
+  /** 不足または違反がある条件 */
+  unsatisfiedConditions: KeywordConditionJudgeResult[]
+}
+
 /**
  * キーワードベースでコードを判定する（大文字小文字を区別しない）。
  *
@@ -87,4 +121,44 @@ export function judgeKeywords(code: string, input: KeywordJudgeInput): JudgeResu
     if (cur.passed !== best.passed) return cur.passed ? cur : best
     return cur.score > best.score ? cur : best
   })
+}
+
+/**
+ * Test / Challenge の正解条件を、表示用ラベルつきで条件単位に判定する。
+ *
+ * `judgeKeywords` の互換挙動を保ったまま、後続UIが「どの条件が不足したか」を
+ * キーワード文字列ではなく日本語ラベル・説明で表示できるようにする。
+ */
+export function judgeKeywordConditions(
+  code: string,
+  conditions: KeywordConditionJudgeInput[],
+): KeywordConditionsJudgeResult {
+  const results = conditions.map((condition): KeywordConditionJudgeResult => {
+    const result = judgeKeywords(code, {
+      requiredKeywords: condition.requiredKeywords,
+      ngKeywords: condition.ngKeywords,
+      anyOf: condition.anyOf,
+      passThreshold: condition.passThreshold,
+    })
+
+    return {
+      ...result,
+      id: condition.id,
+      label: condition.label,
+      explanation: condition.explanation,
+      requiredKeywords: condition.requiredKeywords,
+    }
+  })
+
+  const satisfiedConditions = results.filter((condition) => condition.passed)
+  const unsatisfiedConditions = results.filter((condition) => !condition.passed)
+  const score = results.length === 0 ? 100 : Math.round((satisfiedConditions.length / results.length) * 100)
+
+  return {
+    passed: unsatisfiedConditions.length === 0,
+    score,
+    conditions: results,
+    satisfiedConditions,
+    unsatisfiedConditions,
+  }
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -15,6 +15,11 @@ export default defineConfig({
       brotliSize: true,
     }),
   ],
+  server: {
+    host: '127.0.0.1',
+    port: 5175,
+    strictPort: true,
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## 概要
- M5-1としてPractice/Test/Challenge向けの追加メタ情報型をoptionalで追加
- Test/Challengeの不足条件表示に使うjudgeKeywordConditionsを追加
- 条件判定ヘルパーのユニットテストを追加
- 今回のみ、ローカル開発ポート固定のvite.config.ts変更も同梱

## 検証
- cmd /c npm run typecheck: pass
- cmd /c npm --workspace @coden/web run test -- src/lib/__tests__/judge.test.ts: pass
- cmd /c npm run lint: pass
- cmd /c npm run test: pass
- cmd /c npm run build: pass（既存のchunk size warningあり）

Issue要否: 不要。v6本体はroadmapで管理済み。