### PR TITLE
feat: M5-2提出履歴にpatternIdを保存

### DIFF
--- a/apps/web/src/features/learning/ChallengeMode.tsx
+++ b/apps/web/src/features/learning/ChallengeMode.tsx
@@ -13,7 +13,7 @@ interface ChallengeModeProps {
   stepId: string
   task: ChallengeTask
   onComplete: () => void
-  onSubmitResult?: (result: { code: string; isPassed: boolean; matchedKeywords: string[] }) => Promise<void> | void
+  onSubmitResult?: (result: { code: string; isPassed: boolean; matchedKeywords: string[]; patternId: string }) => Promise<void> | void
 }
 
 function getRandomPattern(task: ChallengeTask): ChallengePattern {
@@ -68,6 +68,7 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
           code,
           isPassed: hasSatisfiedRequirements,
           matchedKeywords,
+          patternId: pattern.id,
         })
       } catch (error) {
         setSubmissionError(error instanceof Error ? error.message : '提出履歴の保存に失敗しました。')

--- a/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
@@ -117,6 +117,7 @@ describe('ChallengeMode', () => {
       code: 'const [count, setCount] = useState(0); <button onClick={() => setCount(count + 1)} />',
       isPassed: true,
       matchedKeywords: ['useState', 'onClick'],
+      patternId: 'pattern-1',
     })
     expect(resolveReviewItem).toHaveBeenCalledWith({
       userId: '00000000-0000-0000-0000-000000000001',

--- a/apps/web/src/features/learning/__tests__/ChallengeSubmissionHistory.test.tsx
+++ b/apps/web/src/features/learning/__tests__/ChallengeSubmissionHistory.test.tsx
@@ -8,6 +8,7 @@ const submissions: ChallengeSubmission[] = [
     id: 'submission-1',
     user_id: 'user-1',
     step_id: 'usestate-basic',
+    pattern_id: 'pattern-1',
     code: 'const [count, setCount] = useState(0);',
     is_passed: true,
     matched_keywords: ['useState'],

--- a/apps/web/src/features/learning/hooks/useChallengeSubmission.ts
+++ b/apps/web/src/features/learning/hooks/useChallengeSubmission.ts
@@ -6,13 +6,14 @@ export interface ChallengeSubmissionAttempt {
   code: string
   isPassed: boolean
   matchedKeywords: string[]
+  patternId: string
 }
 
 export function useChallengeSubmission(stepId: string) {
   const { user } = useAuth()
 
   return useCallback(
-    async ({ code, isPassed, matchedKeywords }: ChallengeSubmissionAttempt) => {
+    async ({ code, isPassed, matchedKeywords, patternId }: ChallengeSubmissionAttempt) => {
       if (!user?.id) {
         return
       }
@@ -20,6 +21,7 @@ export function useChallengeSubmission(stepId: string) {
       await createChallengeSubmission({
         user_id: user.id,
         step_id: stepId,
+        pattern_id: patternId,
         code,
         is_passed: isPassed,
         matched_keywords: matchedKeywords,

--- a/apps/web/src/pages/StepPage.tsx
+++ b/apps/web/src/pages/StepPage.tsx
@@ -102,7 +102,7 @@ export function StepPage() {
   const saveChallengeSubmission = useChallengeSubmission(stepId)
   const recentChallengeSubmissions = useRecentChallengeSubmissions(stepId)
   const handleChallengeSubmitResult = useCallback(
-    async (result: { code: string; isPassed: boolean; matchedKeywords: string[] }) => {
+    async (result: { code: string; isPassed: boolean; matchedKeywords: string[]; patternId: string }) => {
       await saveChallengeSubmission(result)
       await recentChallengeSubmissions.refresh()
     },

--- a/apps/web/src/pages/__tests__/StepPage.test.tsx
+++ b/apps/web/src/pages/__tests__/StepPage.test.tsx
@@ -266,6 +266,7 @@ describe('StepPage', () => {
           id: 'submission-1',
           user_id: 'user-1',
           step_id: 'usestate-basic',
+          pattern_id: 'pattern-1',
           code: 'const [count, setCount] = useState(0);',
           is_passed: true,
           matched_keywords: ['useState'],

--- a/apps/web/src/services/__tests__/challengeSubmissionService.test.ts
+++ b/apps/web/src/services/__tests__/challengeSubmissionService.test.ts
@@ -30,6 +30,7 @@ describe('createChallengeSubmission', () => {
       id: 'submission-1',
       user_id: 'user-1',
       step_id: 'usestate-basic',
+      pattern_id: 'pattern-1',
       code: 'const ok = true',
       is_passed: true,
       matched_keywords: ['useState', 'onClick'],
@@ -40,6 +41,7 @@ describe('createChallengeSubmission', () => {
     const result = await createChallengeSubmission({
       user_id: 'user-1',
       step_id: 'usestate-basic',
+      pattern_id: 'pattern-1',
       code: 'const ok = true',
       is_passed: true,
       matched_keywords: ['useState', 'onClick'],
@@ -49,11 +51,12 @@ describe('createChallengeSubmission', () => {
     expect(insert).toHaveBeenCalledWith({
       user_id: 'user-1',
       step_id: 'usestate-basic',
+      pattern_id: 'pattern-1',
       code: 'const ok = true',
       is_passed: true,
       matched_keywords: ['useState', 'onClick'],
     })
-    expect(select).toHaveBeenCalledWith('id, user_id, step_id, code, is_passed, matched_keywords, submitted_at')
+    expect(select).toHaveBeenCalledWith('id, user_id, step_id, pattern_id, code, is_passed, matched_keywords, submitted_at')
     expect(result).toEqual(savedRow)
   })
 
@@ -67,6 +70,7 @@ describe('createChallengeSubmission', () => {
       createChallengeSubmission({
         user_id: 'user-1',
         step_id: 'usestate-basic',
+        pattern_id: 'pattern-1',
         code: 'const ok = true',
         is_passed: false,
         matched_keywords: [],
@@ -84,6 +88,7 @@ describe('createChallengeSubmission', () => {
         id: 'submission-2',
         user_id: 'user-1',
         step_id: 'usestate-basic',
+        pattern_id: 'pattern-1',
         code: 'latest',
         is_passed: false,
         matched_keywords: [],
@@ -97,6 +102,7 @@ describe('createChallengeSubmission', () => {
     const result = await getRecentChallengeSubmissions('user-1', 'usestate-basic', 3)
 
     expect(from).toHaveBeenCalledWith('challenge_submissions')
+    expect(select).toHaveBeenCalledWith('id, user_id, step_id, pattern_id, code, is_passed, matched_keywords, submitted_at')
     expect(eq).toHaveBeenNthCalledWith(1, 'user_id', 'user-1')
     expect(eq).toHaveBeenNthCalledWith(2, 'step_id', 'usestate-basic')
     expect(order).toHaveBeenCalledWith('submitted_at', { ascending: false })

--- a/apps/web/src/services/challengeSubmissionService.ts
+++ b/apps/web/src/services/challengeSubmissionService.ts
@@ -4,15 +4,17 @@ import { MAX_CODE_LENGTH } from '../shared/constants'
 import { assertMaxLength } from '../shared/validation'
 import type { Tables, TablesInsert } from '../shared/types/database.types'
 const MAX_SUBMISSION_LIMIT = 100
+const CHALLENGE_SUBMISSION_SELECT =
+  'id, user_id, step_id, pattern_id, code, is_passed, matched_keywords, submitted_at'
 
 export type ChallengeSubmission = Pick<
   Tables<'challenge_submissions'>,
-  'id' | 'user_id' | 'step_id' | 'code' | 'is_passed' | 'matched_keywords' | 'submitted_at'
+  'id' | 'user_id' | 'step_id' | 'pattern_id' | 'code' | 'is_passed' | 'matched_keywords' | 'submitted_at'
 >
 
 export type CreateChallengeSubmissionInput = Pick<
   TablesInsert<'challenge_submissions'>,
-  'user_id' | 'step_id' | 'code' | 'is_passed' | 'matched_keywords'
+  'user_id' | 'step_id' | 'pattern_id' | 'code' | 'is_passed' | 'matched_keywords'
 >
 
 export async function createChallengeSubmission(
@@ -22,7 +24,7 @@ export async function createChallengeSubmission(
   const { data, error } = await supabase
     .from('challenge_submissions')
     .insert(input)
-    .select('id, user_id, step_id, code, is_passed, matched_keywords, submitted_at')
+    .select(CHALLENGE_SUBMISSION_SELECT)
     .single()
 
   if (error) {
@@ -40,7 +42,7 @@ export async function getRecentChallengeSubmissions(
   const safeLimit = Math.min(Math.max(1, limit), MAX_SUBMISSION_LIMIT)
   const { data, error } = await supabase
     .from('challenge_submissions')
-    .select('id, user_id, step_id, code, is_passed, matched_keywords, submitted_at')
+    .select(CHALLENGE_SUBMISSION_SELECT)
     .eq('user_id', userId)
     .eq('step_id', stepId)
     .order('submitted_at', { ascending: false })

--- a/apps/web/src/shared/types/database.types.ts
+++ b/apps/web/src/shared/types/database.types.ts
@@ -68,6 +68,7 @@ export type Database = {
           id: string
           is_passed: boolean
           matched_keywords: string[]
+          pattern_id: string | null
           step_id: string
           submitted_at: string
           user_id: string
@@ -77,6 +78,7 @@ export type Database = {
           id?: string
           is_passed?: boolean
           matched_keywords?: string[]
+          pattern_id?: string | null
           step_id: string
           submitted_at?: string
           user_id: string
@@ -86,6 +88,7 @@ export type Database = {
           id?: string
           is_passed?: boolean
           matched_keywords?: string[]
+          pattern_id?: string | null
           step_id?: string
           submitted_at?: string
           user_id?: string

--- a/apps/web/supabase/sql/028_challenge_submission_pattern_id.sql
+++ b/apps/web/supabase/sql/028_challenge_submission_pattern_id.sql
@@ -1,0 +1,8 @@
+-- v6roadmap02 M5-2: Challenge submissions patternId lightweight support
+-- Run this after 001_schema_and_rls.sql.
+
+alter table public.challenge_submissions
+  add column if not exists pattern_id text;
+
+create index if not exists challenge_submissions_user_step_pattern_submitted_idx
+  on public.challenge_submissions (user_id, step_id, pattern_id, submitted_at desc);


### PR DESCRIPTION
## 概要
- challenge_submissions に nullable pattern_id を追加するSQLを追加
- database.types.ts と challengeSubmissionService の insert/select を pattern_id 対応
- ChallengeMode から現在の pattern.id を保存payloadへ渡す
- 関連テストを更新

## 検証
- cmd /c npm --workspace @coden/web run test -- src/services/__tests__/challengeSubmissionService.test.ts: pass
- cmd /c npm --workspace @coden/web run test -- src/features/learning/__tests__/ChallengeMode.test.tsx: pass
- cmd /c npm --workspace @coden/web run test -- src/features/learning/__tests__/ChallengeSubmissionHistory.test.tsx: pass
- cmd /c npm --workspace @coden/web run test -- src/pages/__tests__/StepPage.test.tsx: pass
- cmd /c npm run typecheck: pass
- cmd /c npm run lint: pass
- cmd /c npm run test: pass
- cmd /c npm run build: pass（既存のchunk size warningあり）

Issue要否: 不要。v6本体はroadmapで管理済み。