### PR TITLE
feat: M5-3 Challenge代表パターンを決定論的に固定

### DIFF
--- a/apps/web/src/content/__tests__/resolvePrimaryPattern.test.ts
+++ b/apps/web/src/content/__tests__/resolvePrimaryPattern.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { resolvePrimaryPattern, type ChallengeTask } from '../fundamentals/steps'
+
+function makeTask(overrides: Partial<ChallengeTask> = {}): ChallengeTask {
+  return {
+    patterns: [
+      { id: 'pattern-a', prompt: 'A', requirements: [], hints: [], expectedKeywords: [], starterCode: 'A' },
+      { id: 'pattern-b', prompt: 'B', requirements: [], hints: [], expectedKeywords: [], starterCode: 'B' },
+    ],
+    ...overrides,
+  }
+}
+
+describe('resolvePrimaryPattern', () => {
+  it('primaryPatternId が一致するパターンを返す', () => {
+    const task = makeTask({ primaryPatternId: 'pattern-b' })
+    expect(resolvePrimaryPattern(task).id).toBe('pattern-b')
+  })
+
+  it('primaryPatternId 未指定なら先頭パターンへ fallback する', () => {
+    const task = makeTask()
+    expect(resolvePrimaryPattern(task).id).toBe('pattern-a')
+  })
+
+  it('primaryPatternId が一致しない場合も先頭パターンへ fallback する', () => {
+    const task = makeTask({ primaryPatternId: 'does-not-exist' })
+    expect(resolvePrimaryPattern(task).id).toBe('pattern-a')
+  })
+
+  it('複数回呼んでも同じパターンを返す（決定論的）', () => {
+    const task = makeTask({ primaryPatternId: 'pattern-b' })
+    const first = resolvePrimaryPattern(task)
+    const second = resolvePrimaryPattern(task)
+    expect(first.id).toBe(second.id)
+  })
+
+  it('パターンが空の場合はエラーを投げる', () => {
+    expect(() => resolvePrimaryPattern({ patterns: [] })).toThrow()
+  })
+})

--- a/apps/web/src/content/fundamentals/steps.ts
+++ b/apps/web/src/content/fundamentals/steps.ts
@@ -71,6 +71,21 @@ export interface ChallengeTask {
   patterns: ChallengePattern[]
 }
 
+/**
+ * Challenge の代表パターンを決定論的に解決する。
+ * `primaryPatternId` が指定され一致するパターンがあればそれを返し、
+ * 未指定または不一致の場合は先頭パターンへ fallback する（既存互換）。
+ * 出題に `Math.random()` を使わないことで、再マウントやページ離脱で問題が変わらない。
+ */
+export function resolvePrimaryPattern(task: ChallengeTask): ChallengePattern {
+  const primary = task.primaryPatternId
+    ? task.patterns.find((pattern) => pattern.id === task.primaryPatternId)
+    : undefined
+  const pattern = primary ?? task.patterns[0]
+  if (!pattern) throw new Error('ChallengeTask has no patterns')
+  return pattern
+}
+
 export interface LearningStepContent {
   id: string
   order: number

--- a/apps/web/src/features/learning/ChallengeMode.tsx
+++ b/apps/web/src/features/learning/ChallengeMode.tsx
@@ -3,7 +3,7 @@ import { Button } from '../../components/Button'
 import { CodeEditor } from '../../components/CodeEditor'
 import { ErrorBanner } from '../../components/ErrorBanner'
 import { useIsMobile } from '../../hooks/useIsMobile'
-import type { ChallengePattern, ChallengeTask } from '../../content/fundamentals/steps'
+import { resolvePrimaryPattern, type ChallengePattern, type ChallengeTask } from '../../content/fundamentals/steps'
 import { JudgmentResult } from './components/JudgmentResult'
 import { useJudgmentAction } from './hooks/useJudgmentAction'
 import { judgeKeywords } from '../../lib/judge'
@@ -16,16 +16,9 @@ interface ChallengeModeProps {
   onSubmitResult?: (result: { code: string; isPassed: boolean; matchedKeywords: string[]; patternId: string }) => Promise<void> | void
 }
 
-function getRandomPattern(task: ChallengeTask): ChallengePattern {
-  const randomIndex = Math.floor(Math.random() * task.patterns.length)
-  const pattern = task.patterns[randomIndex]
-  if (!pattern) throw new Error(`No pattern at index ${randomIndex}`)
-  return pattern
-}
-
 export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: ChallengeModeProps) {
   const isMobile = useIsMobile()
-  const [pattern, setPattern] = useState<ChallengePattern>(() => getRandomPattern(task))
+  const [pattern, setPattern] = useState<ChallengePattern>(() => resolvePrimaryPattern(task))
   const [code, setCode] = useState(() => pattern.starterCode)
   const [checked, setChecked] = useState(false)
   const [submissionError, setSubmissionError] = useState<string | null>(null)
@@ -34,7 +27,7 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
   const hasMobilePuzzle = isMobile && pattern.mobilePuzzle != null
 
   useEffect(() => {
-    const nextPattern = getRandomPattern(task)
+    const nextPattern = resolvePrimaryPattern(task)
     setPattern(nextPattern)
     setCode(nextPattern.starterCode)
     setChecked(false)

--- a/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
@@ -273,6 +273,68 @@ describe('ChallengeMode', () => {
     expect(screen.getByRole('alert').textContent).toContain('保存エラーが発生しました')
   })
 
+  it('primaryPatternId 指定時はその代表パターンが出題される', () => {
+    const multiPatternTask: ChallengeTask = {
+      primaryPatternId: 'pattern-second',
+      patterns: [
+        {
+          id: 'pattern-first',
+          prompt: '先頭パターン',
+          requirements: ['要件first'],
+          hints: ['ヒントfirst'],
+          expectedKeywords: ['first'],
+          starterCode: '',
+        },
+        {
+          id: 'pattern-second',
+          prompt: '代表パターン',
+          requirements: ['要件second'],
+          hints: ['ヒントsecond'],
+          expectedKeywords: ['second'],
+          starterCode: '',
+        },
+      ],
+    }
+
+    render(<ChallengeMode stepId="step-multi" task={multiPatternTask} onComplete={vi.fn()} />)
+
+    expect(screen.getByText('代表パターン')).toBeTruthy()
+    expect(screen.queryByText('先頭パターン')).toBeNull()
+  })
+
+  it('再レンダリングしても出題パターンが変わらない（決定論的）', () => {
+    const multiPatternTask: ChallengeTask = {
+      patterns: [
+        {
+          id: 'pattern-1',
+          prompt: '固定される課題',
+          requirements: ['要件1'],
+          hints: ['ヒント1'],
+          expectedKeywords: ['useState'],
+          starterCode: '',
+        },
+        {
+          id: 'pattern-2',
+          prompt: 'もう一方の課題',
+          requirements: ['要件2'],
+          hints: ['ヒント2'],
+          expectedKeywords: ['return'],
+          starterCode: '',
+        },
+      ],
+    }
+
+    const { rerender } = render(
+      <ChallengeMode stepId="step-fixed" task={multiPatternTask} onComplete={vi.fn()} />,
+    )
+    expect(screen.getByText('固定される課題')).toBeTruthy()
+
+    // 同一 stepId / task で再レンダリングしても先頭パターンのまま変わらない
+    rerender(<ChallengeMode stepId="step-fixed" task={multiPatternTask} onComplete={vi.fn()} />)
+    expect(screen.getByText('固定される課題')).toBeTruthy()
+    expect(screen.queryByText('もう一方の課題')).toBeNull()
+  })
+
   it('stepId が変わると入力内容と判定状態をリセットする', async () => {
     const user = userEvent.setup()
     const onComplete = vi.fn()


### PR DESCRIPTION
## 概要

v6roadmap M5-3。Challenge の出題から `Math.random()` を廃止し、出題パターンを決定論的に固定する。再マウント・ページ離脱で問題が変わる不具合を解消する。

関連: [v6roadmap02-implementation](docs/roadmaps/v6/v6roadmap02-implementation.md) の M5-3。

## 変更内容

- `resolvePrimaryPattern(task)` を追加（`apps/web/src/content/fundamentals/steps.ts`）
  - `primaryPatternId` が一致 → そのパターン
  - 未設定 / 不一致 → 先頭パターンへ fallback（既存互換）
- `ChallengeMode` から `getRandomPattern` / `Math.random()` を除去し、`resolvePrimaryPattern` に置換
- テスト追加
  - ヘルパー: 優先 / fallback / 不一致fallback / 決定論性 / 空配列エラー
  - `ChallengeMode`: `primaryPatternId` 指定時の代表出題、再レンダリングで不変

## スコープ外（ロードマップ通り）

- 全40Stepへの `primaryPatternId` 実値付与 → **M5-8（コンテンツ反映）**
- draft保存（M5-4）/ 判定補強（M5-5）

## 検証

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test`（957 passed）
- [x] `npm run build`

## マージ判断

`Math.random()` 依存が残っておらず、既存単一パターン Step は先頭fallbackで挙動不変。CI 4ゲート通過。依存PR（M5-1/M5-2）はマージ済みのため **マージ可**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)