### PR TITLE
feat: M5-4 Challenge途中コードのlocalStorage自動保存

### DIFF
--- a/apps/web/src/features/learning/ChallengeMode.tsx
+++ b/apps/web/src/features/learning/ChallengeMode.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Button } from '../../components/Button'
 import { CodeEditor } from '../../components/CodeEditor'
 import { ErrorBanner } from '../../components/ErrorBanner'
@@ -6,6 +6,7 @@ import { useIsMobile } from '../../hooks/useIsMobile'
 import { resolvePrimaryPattern, type ChallengePattern, type ChallengeTask } from '../../content/fundamentals/steps'
 import { JudgmentResult } from './components/JudgmentResult'
 import { useJudgmentAction } from './hooks/useJudgmentAction'
+import { useChallengeDraft } from './hooks/useChallengeDraft'
 import { judgeKeywords } from '../../lib/judge'
 import { ChallengePuzzleMulti } from './ChallengePuzzle/ChallengePuzzleMulti'
 
@@ -19,17 +20,22 @@ interface ChallengeModeProps {
 export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: ChallengeModeProps) {
   const isMobile = useIsMobile()
   const [pattern, setPattern] = useState<ChallengePattern>(() => resolvePrimaryPattern(task))
-  const [code, setCode] = useState(() => pattern.starterCode)
+  const hasMobilePuzzle = isMobile && pattern.mobilePuzzle != null
+  // モバイルパズルは組み立て式のため自由入力 draft の対象外（PC自由入力を主対象とする）
+  const { readDraft, scheduleSave, clearDraft } = useChallengeDraft({ enabled: !hasMobilePuzzle })
+  const [code, setCode] = useState(() => readDraft(stepId, pattern.id) ?? pattern.starterCode)
   const [checked, setChecked] = useState(false)
   const [submissionError, setSubmissionError] = useState<string | null>(null)
   const { handleResult } = useJudgmentAction(stepId, 'challenge', onComplete)
 
-  const hasMobilePuzzle = isMobile && pattern.mobilePuzzle != null
+  // effect 内で最新の readDraft を参照しつつ、依存は [stepId, task] に保つ
+  const readDraftRef = useRef(readDraft)
+  readDraftRef.current = readDraft
 
   useEffect(() => {
     const nextPattern = resolvePrimaryPattern(task)
     setPattern(nextPattern)
-    setCode(nextPattern.starterCode)
+    setCode(readDraftRef.current(stepId, nextPattern.id) ?? nextPattern.starterCode)
     setChecked(false)
     setSubmissionError(null)
   }, [stepId, task])
@@ -55,6 +61,11 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
     setChecked(true)
     setSubmissionError(null)
 
+    // 正解した場合は途中コードの draft を削除する
+    if (hasSatisfiedRequirements) {
+      clearDraft(stepId, pattern.id)
+    }
+
     if (onSubmitResult) {
       try {
         await onSubmitResult({
@@ -75,10 +86,14 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
     })
   }
 
-  const handleCodeChange = useCallback((nextValue: string) => {
-    setChecked(false)
-    setCode(nextValue)
-  }, [])
+  const handleCodeChange = useCallback(
+    (nextValue: string) => {
+      setChecked(false)
+      setCode(nextValue)
+      scheduleSave(stepId, pattern.id, nextValue)
+    },
+    [scheduleSave, stepId, pattern.id],
+  )
 
   return (
     <section className="mt-4 space-y-4">

--- a/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ChallengeMode } from '../ChallengeMode'
 import type { ChallengeTask } from '../../../content/fundamentals/steps'
+import { buildChallengeDraftKey } from '../../../lib/challengeDraft'
 
 const recordWrongAnswer = vi.fn()
 const resolveReviewItem = vi.fn()
@@ -410,4 +411,51 @@ describe('ChallengeMode モバイルパズル', () => {
     expect(screen.queryByLabelText('challenge-editor')).toBeNull()
   })
 
+})
+
+describe('ChallengeMode draft保存', () => {
+  const userId = '00000000-0000-0000-0000-000000000001'
+
+  afterEach(() => {
+    cleanup()
+    window.localStorage.clear()
+    vi.useRealTimers()
+  })
+
+  it('入力すると userId+stepId+patternId の draft が自動保存される', () => {
+    vi.useFakeTimers()
+    render(<ChallengeMode stepId="step-a" task={firstTask} onComplete={vi.fn()} />)
+
+    const editor = screen.getByLabelText('challenge-editor')
+    fireEvent.change(editor, { target: { value: 'const draft = 1' } })
+    // デバウンス（500ms）経過で保存される
+    vi.advanceTimersByTime(500)
+
+    expect(window.localStorage.getItem(buildChallengeDraftKey(userId, 'step-a', 'pattern-1'))).toBe(
+      'const draft = 1',
+    )
+  })
+
+  it('保存済み draft が初期コードとして復元される', () => {
+    window.localStorage.setItem(buildChallengeDraftKey(userId, 'step-a', 'pattern-1'), '保存されたコード')
+
+    render(<ChallengeMode stepId="step-a" task={firstTask} onComplete={vi.fn()} />)
+
+    expect((screen.getByLabelText('challenge-editor') as HTMLTextAreaElement).value).toBe('保存されたコード')
+  })
+
+  it('正解判定後は draft が削除される', async () => {
+    const user = userEvent.setup()
+    window.localStorage.setItem(buildChallengeDraftKey(userId, 'step-a', 'pattern-1'), '途中コード')
+
+    render(<ChallengeMode stepId="step-a" task={firstTask} onComplete={vi.fn()} />)
+
+    const editor = screen.getByLabelText('challenge-editor')
+    fireEvent.change(editor, {
+      target: { value: 'const [count, setCount] = useState(0); <button onClick={() => setCount(count + 1)} />' },
+    })
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+
+    expect(window.localStorage.getItem(buildChallengeDraftKey(userId, 'step-a', 'pattern-1'))).toBeNull()
+  })
 })

--- a/apps/web/src/features/learning/hooks/useChallengeDraft.ts
+++ b/apps/web/src/features/learning/hooks/useChallengeDraft.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { useAuth } from '@/contexts/AuthContext'
+import {
+  clearChallengeDraft,
+  readChallengeDraft,
+  writeChallengeDraft,
+} from '@/lib/challengeDraft'
+
+const AUTOSAVE_DEBOUNCE_MS = 500
+
+interface UseChallengeDraftParams {
+  /** draft の保存・復元を有効にするか（モバイルパズル時は false にする） */
+  enabled: boolean
+}
+
+interface UseChallengeDraftResult {
+  /** 保存済み draft を取得する（なければ null）。初期コード決定や step 切替時の復元に使う。 */
+  readDraft: (stepId: string, patternId: string) => string | null
+  /** 入力コードをデバウンス保存する。 */
+  scheduleSave: (stepId: string, patternId: string, code: string) => void
+  /** draft を即時削除する（正解時に呼ぶ）。 */
+  clearDraft: (stepId: string, patternId: string) => void
+}
+
+/**
+ * Challenge の途中コードを `userId + stepId + patternId` 単位で localStorage 自動保存する。
+ * - 復元: readDraft() の戻り値を初期コードに使う
+ * - 保存: scheduleSave() を入力のたびに呼ぶ（デバウンス）
+ * - 削除: 正解時に clearDraft() を呼ぶ
+ *
+ * userId が未取得、または enabled=false（モバイルパズル）の場合は何もしない。
+ */
+export function useChallengeDraft({ enabled }: UseChallengeDraftParams): UseChallengeDraftResult {
+  const { user } = useAuth()
+  const userId = user?.id ?? null
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const isActive = enabled && userId != null
+
+  const readDraft = useCallback(
+    (stepId: string, patternId: string): string | null => {
+      if (!isActive || userId == null) return null
+      return readChallengeDraft(userId, stepId, patternId)
+    },
+    [isActive, userId],
+  )
+
+  const scheduleSave = useCallback(
+    (stepId: string, patternId: string, code: string) => {
+      if (!isActive || userId == null) return
+      if (timerRef.current != null) clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => {
+        writeChallengeDraft(userId, stepId, patternId, code)
+      }, AUTOSAVE_DEBOUNCE_MS)
+    },
+    [isActive, userId],
+  )
+
+  const clearDraft = useCallback(
+    (stepId: string, patternId: string) => {
+      if (timerRef.current != null) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+      if (userId == null) return
+      clearChallengeDraft(userId, stepId, patternId)
+    },
+    [userId],
+  )
+
+  // アンマウント時に保留中のデバウンスタイマーを破棄する
+  useEffect(() => {
+    return () => {
+      if (timerRef.current != null) clearTimeout(timerRef.current)
+    }
+  }, [])
+
+  return { readDraft, scheduleSave, clearDraft }
+}

--- a/apps/web/src/lib/__tests__/challengeDraft.test.ts
+++ b/apps/web/src/lib/__tests__/challengeDraft.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  buildChallengeDraftKey,
+  clearChallengeDraft,
+  readChallengeDraft,
+  writeChallengeDraft,
+} from '../challengeDraft'
+
+const USER = 'user-1'
+const STEP = 'usestate-basic'
+const PATTERN = 'usestate-like'
+
+describe('challengeDraft', () => {
+  afterEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('buildChallengeDraftKey は user/step/pattern を含むキーを生成する', () => {
+    expect(buildChallengeDraftKey(USER, STEP, PATTERN)).toBe(
+      'coden:challengeDraft:user-1:usestate-basic:usestate-like',
+    )
+  })
+
+  it('保存した draft を復元できる', () => {
+    writeChallengeDraft(USER, STEP, PATTERN, 'const x = 1')
+    expect(readChallengeDraft(USER, STEP, PATTERN)).toBe('const x = 1')
+  })
+
+  it('未保存の場合は null を返す', () => {
+    expect(readChallengeDraft(USER, STEP, PATTERN)).toBeNull()
+  })
+
+  it('clearChallengeDraft で削除できる', () => {
+    writeChallengeDraft(USER, STEP, PATTERN, 'draft code')
+    clearChallengeDraft(USER, STEP, PATTERN)
+    expect(readChallengeDraft(USER, STEP, PATTERN)).toBeNull()
+  })
+
+  it('user / step / pattern が異なるとキーが衝突しない', () => {
+    writeChallengeDraft(USER, STEP, PATTERN, 'A')
+    writeChallengeDraft('user-2', STEP, PATTERN, 'B')
+    writeChallengeDraft(USER, 'other-step', PATTERN, 'C')
+    writeChallengeDraft(USER, STEP, 'other-pattern', 'D')
+
+    expect(readChallengeDraft(USER, STEP, PATTERN)).toBe('A')
+    expect(readChallengeDraft('user-2', STEP, PATTERN)).toBe('B')
+    expect(readChallengeDraft(USER, 'other-step', PATTERN)).toBe('C')
+    expect(readChallengeDraft(USER, STEP, 'other-pattern')).toBe('D')
+  })
+
+  it('localStorage が例外を投げても read/write/clear は throw しない', () => {
+    const original = window.localStorage
+    const throwingStorage = {
+      getItem: () => {
+        throw new Error('blocked')
+      },
+      setItem: () => {
+        throw new Error('blocked')
+      },
+      removeItem: () => {
+        throw new Error('blocked')
+      },
+    }
+    Object.defineProperty(window, 'localStorage', { value: throwingStorage, configurable: true })
+
+    try {
+      expect(() => writeChallengeDraft(USER, STEP, PATTERN, 'x')).not.toThrow()
+      expect(readChallengeDraft(USER, STEP, PATTERN)).toBeNull()
+      expect(() => clearChallengeDraft(USER, STEP, PATTERN)).not.toThrow()
+    } finally {
+      Object.defineProperty(window, 'localStorage', { value: original, configurable: true })
+    }
+  })
+})

--- a/apps/web/src/lib/challengeDraft.ts
+++ b/apps/web/src/lib/challengeDraft.ts
@@ -1,0 +1,43 @@
+/**
+ * Challenge の途中コードを localStorage に保存・復元するための薄いラッパー。
+ *
+ * - key 形式: `coden:challengeDraft:${userId}:${stepId}:${patternId}`
+ * - userId / stepId / patternId の組ごとに独立し、衝突しない。
+ * - localStorage が使えない環境（プライベートモード等）でも例外を投げない。
+ * - 対象は PC の自由入力コード。モバイルパズルは対象外（呼び出し側で制御する）。
+ */
+
+const DRAFT_KEY_PREFIX = 'coden:challengeDraft'
+
+export function buildChallengeDraftKey(userId: string, stepId: string, patternId: string): string {
+  return `${DRAFT_KEY_PREFIX}:${userId}:${stepId}:${patternId}`
+}
+
+export function readChallengeDraft(userId: string, stepId: string, patternId: string): string | null {
+  try {
+    return window.localStorage.getItem(buildChallengeDraftKey(userId, stepId, patternId))
+  } catch {
+    return null
+  }
+}
+
+export function writeChallengeDraft(
+  userId: string,
+  stepId: string,
+  patternId: string,
+  code: string,
+): void {
+  try {
+    window.localStorage.setItem(buildChallengeDraftKey(userId, stepId, patternId), code)
+  } catch {
+    // localStorage が使えない環境でも入力自体は継続できるよう、保存失敗は握りつぶす
+  }
+}
+
+export function clearChallengeDraft(userId: string, stepId: string, patternId: string): void {
+  try {
+    window.localStorage.removeItem(buildChallengeDraftKey(userId, stepId, patternId))
+  } catch {
+    // 削除失敗も無視する
+  }
+}


### PR DESCRIPTION
## 概要

v6roadmap M5-4。Challenge の途中コードを `userId + stepId + patternId` 単位で localStorage に自動保存し、再訪時に復元、正解後に削除する。離脱でコードが消える問題を解消する。

関連: [v6roadmap02-implementation](docs/roadmaps/v6/v6roadmap02-implementation.md) の M5-4。依存: M5-3（#339 マージ済み）。

## 変更内容

- `lib/challengeDraft.ts`: draft の key 生成・保存・復元・削除の薄いラッパー。`window.localStorage` を try/catch でラップし、無効環境でも例外を投げない。
  - key 形式: `coden:challengeDraft:${userId}:${stepId}:${patternId}`
- `features/learning/hooks/useChallengeDraft.ts`: `useAuth` で userId を取得し、デバウンス（500ms）保存・復元・正解時削除を提供。`enabled=false`（モバイルパズル）/ 未認証時は no-op。
- `ChallengeMode`:
  - 初期コードを「draft があれば draft、無ければ starterCode」に
  - step 切替（`[stepId, task]`）時も draft 復元
  - 入力のたびにデバウンス自動保存
  - 正解確定時に draft 削除

## スコープ外（ロードマップ通り）

- モバイルパズル（組み立て式）の draft 保存 → PC自由入力を主対象とするため対象外
- 端末間同期 → v1.2.0 非スコープ

## テスト

- `lib/__tests__/challengeDraft.test.ts`: 保存/復元/未保存null/削除/**user・step・pattern でキー非衝突**/localStorage 例外耐性
- `ChallengeMode.test.tsx`: 自動保存（デバウンス）/初期コード復元/正解後削除

## 検証

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test`（95 files / 966 tests）
- [x] `npm run build`

## マージ判断

既存挙動（draft 無し時は starterCode）を維持し、未認証・モバイルパズル時は no-op。キー衝突防止とlocalStorage例外耐性をテストで担保。CI 4ゲート通過のため **マージ可**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)