### PR TITLE
feat: M5-5 Challenge判定補強と不正解フィードバック

### DIFF
--- a/apps/web/src/features/learning/ChallengeMode.tsx
+++ b/apps/web/src/features/learning/ChallengeMode.tsx
@@ -5,9 +5,10 @@ import { ErrorBanner } from '../../components/ErrorBanner'
 import { useIsMobile } from '../../hooks/useIsMobile'
 import { resolvePrimaryPattern, type ChallengePattern, type ChallengeTask } from '../../content/fundamentals/steps'
 import { JudgmentResult } from './components/JudgmentResult'
+import { SolutionDisclosure } from './components/SolutionDisclosure'
 import { useJudgmentAction } from './hooks/useJudgmentAction'
 import { useChallengeDraft } from './hooks/useChallengeDraft'
-import { judgeKeywords } from '../../lib/judge'
+import { judgeKeywordConditions, judgeKeywords, stripNonAuthoredCode } from '../../lib/judge'
 import { ChallengePuzzleMulti } from './ChallengePuzzle/ChallengePuzzleMulti'
 
 interface ChallengeModeProps {
@@ -40,16 +41,26 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
     setSubmissionError(null)
   }, [stepId, task])
 
+  // starterCode の TODO コメントや import 由来の誤合格を防ぐため、判定はサニタイズ後コードで行う
+  const judgeableCode = useMemo(() => stripNonAuthoredCode(code), [code])
+
   const judgement = useMemo(
     () =>
-      judgeKeywords(code, {
+      judgeKeywords(judgeableCode, {
         requiredKeywords: pattern.expectedKeywords,
         ngKeywords: pattern.ngKeywords,
         anyOf: pattern.anyOf,
         passThreshold: pattern.passThreshold,
       }),
-    [code, pattern.expectedKeywords, pattern.ngKeywords, pattern.anyOf, pattern.passThreshold],
+    [judgeableCode, pattern.expectedKeywords, pattern.ngKeywords, pattern.anyOf, pattern.passThreshold],
   )
+
+  // 条件メタ情報があれば、不足を日本語ラベルで表示するために条件単位でも判定する（表示専用）
+  const unsatisfiedConditions = useMemo(() => {
+    if (!pattern.conditions || pattern.conditions.length === 0) return []
+    return judgeKeywordConditions(judgeableCode, pattern.conditions).unsatisfiedConditions
+  }, [judgeableCode, pattern.conditions])
+
   const missingKeywords = judgement.missing
   const violations = judgement.violations
   const hasSatisfiedRequirements = judgement.passed
@@ -139,18 +150,33 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
 
       {checked && !isPassed ? (
         <div className="rounded-lg border border-rose-200 bg-rose-50 p-4" role="alert">
-          {missingKeywords.length > 0 && (
+          {unsatisfiedConditions.length > 0 ? (
+            // 条件メタ情報がある場合は、日本語ラベル + 説明で不足を提示する
             <>
-              <p className="text-sm font-semibold text-rose-800">以下の要件が未達成です:</p>
-              <ul className="mt-2 list-inside list-disc text-sm text-rose-700">
-                {missingKeywords.map((keyword) => (
-                  <li key={keyword}>{keyword}</li>
+              <p className="text-sm font-semibold text-rose-800">以下の条件を満たせているか確認しましょう:</p>
+              <ul className="mt-2 space-y-1.5 text-sm text-rose-700">
+                {unsatisfiedConditions.map((condition) => (
+                  <li key={condition.id}>
+                    <span className="font-semibold">{condition.label}</span>
+                    <span className="text-rose-600">: {condition.explanation}</span>
+                  </li>
                 ))}
               </ul>
             </>
+          ) : (
+            missingKeywords.length > 0 && (
+              <>
+                <p className="text-sm font-semibold text-rose-800">以下の要件が未達成です:</p>
+                <ul className="mt-2 list-inside list-disc text-sm text-rose-700">
+                  {missingKeywords.map((keyword) => (
+                    <li key={keyword}>{keyword}</li>
+                  ))}
+                </ul>
+              </>
+            )
           )}
           {violations.length > 0 && (
-            <div className={missingKeywords.length > 0 ? 'mt-3' : ''}>
+            <div className="mt-3">
               <p className="text-sm font-semibold text-amber-800">避けたい書き方が含まれています:</p>
               <ul className="mt-2 list-inside list-disc text-sm text-amber-700">
                 {violations.map((keyword) => (
@@ -164,6 +190,7 @@ export function ChallengeMode({ stepId, task, onComplete, onSubmitResult }: Chal
               ヒント: {pattern.hints[0]}
             </p>
           )}
+          {pattern.solutionCode ? <SolutionDisclosure solutionCode={pattern.solutionCode} /> : null}
         </div>
       ) : null}
     </section>

--- a/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/ChallengeMode.test.tsx
@@ -459,3 +459,99 @@ describe('ChallengeMode draft保存', () => {
     expect(window.localStorage.getItem(buildChallengeDraftKey(userId, 'step-a', 'pattern-1'))).toBeNull()
   })
 })
+
+describe('ChallengeMode 判定補強', () => {
+  afterEach(() => {
+    cleanup()
+    window.localStorage.clear()
+  })
+
+  it('starterCode のコメント・import だけでは合格しない（誤合格防止）', async () => {
+    const user = userEvent.setup()
+    const onComplete = vi.fn()
+    const starterTask: ChallengeTask = {
+      patterns: [
+        {
+          id: 'starter-pattern',
+          prompt: 'いいねボタンを作る',
+          requirements: ['useStateを使う'],
+          hints: ['useStateで状態を定義する'],
+          expectedKeywords: ['useState', 'onClick'],
+          starterCode:
+            "import { useState } from 'react';\n// TODO: button の onClick で setCount を呼ぶ\nexport function LikeButton() {\n  return <button>いいね 0</button>;\n}",
+        },
+      ],
+    }
+
+    render(<ChallengeMode stepId="step-starter" task={starterTask} onComplete={onComplete} />)
+
+    // 入力を変えずにそのまま判定
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+
+    expect(onComplete).not.toHaveBeenCalled()
+    expect(screen.getByRole('status').textContent).toContain('要件を満たしていません。')
+  })
+
+  it('conditions がある場合は不足条件を日本語ラベル・説明で表示する', async () => {
+    const user = userEvent.setup()
+    const conditionTask: ChallengeTask = {
+      patterns: [
+        {
+          id: 'condition-pattern',
+          prompt: '状態管理の課題',
+          requirements: ['useStateを使う'],
+          hints: ['useState'],
+          expectedKeywords: ['useState'],
+          conditions: [
+            {
+              id: 'c-state',
+              label: '状態を定義する',
+              requiredKeywords: ['useState'],
+              explanation: 'useStateで状態を定義しましょう',
+            },
+          ],
+          starterCode: '',
+        },
+      ],
+    }
+
+    render(<ChallengeMode stepId="step-cond" task={conditionTask} onComplete={vi.fn()} />)
+
+    const editor = await screen.findByLabelText('challenge-editor')
+    fireEvent.change(editor, { target: { value: 'const x = 1' } })
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+
+    expect(screen.getByText('以下の条件を満たせているか確認しましょう:')).toBeTruthy()
+    expect(screen.getByText('状態を定義する')).toBeTruthy()
+    expect(screen.getByText(/useStateで状態を定義しましょう/)).toBeTruthy()
+  })
+
+  it('solutionCode がある場合は「解答例を見る」で解答例を表示できる', async () => {
+    const user = userEvent.setup()
+    const solutionTask: ChallengeTask = {
+      patterns: [
+        {
+          id: 'solution-pattern',
+          prompt: '解答例つき課題',
+          requirements: ['useStateを使う'],
+          hints: ['useState'],
+          expectedKeywords: ['useState'],
+          solutionCode: 'const [count, setCount] = useState(0)',
+          starterCode: '',
+        },
+      ],
+    }
+
+    render(<ChallengeMode stepId="step-sol" task={solutionTask} onComplete={vi.fn()} />)
+
+    const editor = await screen.findByLabelText('challenge-editor')
+    fireEvent.change(editor, { target: { value: 'const x = 1' } })
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+
+    // 解答例は初期状態では隠れている
+    expect(screen.queryByText('const [count, setCount] = useState(0)')).toBeNull()
+
+    await user.click(screen.getByRole('button', { name: '解答例を見る' }))
+    expect(screen.getByText('const [count, setCount] = useState(0)')).toBeTruthy()
+  })
+})

--- a/apps/web/src/features/learning/components/SolutionDisclosure.tsx
+++ b/apps/web/src/features/learning/components/SolutionDisclosure.tsx
@@ -1,0 +1,36 @@
+import { useState } from 'react'
+
+interface SolutionDisclosureProps {
+  /** 表示する解答例コード */
+  solutionCode: string
+  /** 開閉ボタンのラベル（既定: 解答例） */
+  label?: string
+}
+
+/**
+ * 解答例を任意で開閉表示する小コンポーネント。
+ * 不正解時に「解答例を見る」を提示し、ユーザーが選んだときだけ中身を表示する。
+ * Challenge / Test / Practice で共通利用する。
+ */
+export function SolutionDisclosure({ solutionCode, label = '解答例' }: SolutionDisclosureProps) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <div className="mt-3">
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-expanded={isOpen}
+        className="text-sm font-semibold text-violet-700 underline underline-offset-2 transition-colors hover:text-violet-800 focus:outline-none focus:ring-2 focus:ring-violet-400/30"
+      >
+        {isOpen ? `${label}を隠す` : `${label}を見る`}
+      </button>
+
+      {isOpen ? (
+        <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-slate-900 p-3 text-xs leading-relaxed text-slate-100">
+          <code>{solutionCode}</code>
+        </pre>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/web/src/lib/__tests__/judge.test.ts
+++ b/apps/web/src/lib/__tests__/judge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { judgeKeywordConditions, judgeKeywords } from '../judge'
+import { judgeKeywordConditions, judgeKeywords, stripNonAuthoredCode } from '../judge'
 
 describe('judgeKeywords', () => {
   it('必須キーワードをすべて含めば passed: true / score 100', () => {
@@ -219,5 +219,74 @@ describe('judgeKeywordConditions', () => {
     expect(result.conditions).toEqual([])
     expect(result.satisfiedConditions).toEqual([])
     expect(result.unsatisfiedConditions).toEqual([])
+  })
+})
+
+describe('stripNonAuthoredCode', () => {
+  it('行コメントを除去する', () => {
+    const stripped = stripNonAuthoredCode('const x = 1 // useState を使う')
+    expect(stripped).not.toContain('useState')
+    expect(stripped).toContain('const x = 1')
+  })
+
+  it('ブロックコメントを除去する', () => {
+    const stripped = stripNonAuthoredCode('/* TODO: onClick を書く */\nconst x = 1')
+    expect(stripped).not.toContain('onClick')
+    expect(stripped).toContain('const x = 1')
+  })
+
+  it('JSXコメントを除去する', () => {
+    const stripped = stripNonAuthoredCode('<div>{/* setCount を呼ぶ */}</div>')
+    expect(stripped).not.toContain('setCount')
+  })
+
+  it('import 文を除去する（from 句あり）', () => {
+    const stripped = stripNonAuthoredCode("import { useState } from 'react';\nconst x = 1")
+    expect(stripped).not.toContain('useState')
+    expect(stripped).toContain('const x = 1')
+  })
+
+  it('複数行 import を除去する', () => {
+    const code = "import {\n  useState,\n  useEffect,\n} from 'react'\nconst x = 1"
+    const stripped = stripNonAuthoredCode(code)
+    expect(stripped).not.toContain('useState')
+    expect(stripped).not.toContain('useEffect')
+    expect(stripped).toContain('const x = 1')
+  })
+
+  it('副作用 import を除去する', () => {
+    const stripped = stripNonAuthoredCode("import './styles.css'\nconst x = 1")
+    expect(stripped).toContain('const x = 1')
+    expect(stripped).not.toContain('styles.css')
+  })
+
+  it('importData のような語は import 文として誤除去しない', () => {
+    const stripped = stripNonAuthoredCode('const data = importData()')
+    expect(stripped).toContain('importData()')
+  })
+
+  it('サニタイズ後はコメント/import由来のキーワードが matched に数えられない', () => {
+    const starterOnly = `import { useState } from 'react';
+
+export function LikeButton() {
+  // TODO: onClick で setCount を呼ぶ
+  return <button>いいね 0</button>;
+}`
+    const result = judgeKeywords(stripNonAuthoredCode(starterOnly), {
+      requiredKeywords: ['useState', 'setCount', 'onClick'],
+    })
+    expect(result.passed).toBe(false)
+    expect(result.matched).toEqual([])
+    expect(result.missing).toEqual(['useState', 'setCount', 'onClick'])
+  })
+
+  it('コメント内の ng キーワードは違反に数えられない', () => {
+    const code = stripNonAuthoredCode('items.map((item) => <li key={item.id}>{item}</li>) // key={index} は避ける')
+    const result = judgeKeywords(code, {
+      requiredKeywords: ['map', 'key='],
+      ngKeywords: ['key={index}'],
+    })
+    expect(result.violations).toEqual([])
+    expect(result.passed).toBe(true)
   })
 })

--- a/apps/web/src/lib/judge.ts
+++ b/apps/web/src/lib/judge.ts
@@ -82,6 +82,38 @@ export interface KeywordConditionsJudgeResult {
 }
 
 /**
+ * Challenge 判定用に「ユーザーが書いていない文字列」を除去する。
+ *
+ * starterCode には TODO コメントや `import { useState } from 'react'` のような
+ * 雛形が含まれており、これらがキーワード一致して誤合格を生む。判定前に
+ * 以下を除去し、コメント・import 由来のキーワードが matched / violations に
+ * 数えられないようにする（v6roadmap M5-5 の誤合格防止の最低条件）。
+ *
+ * - 行コメント `// ...`
+ * - ブロックコメント `/* ... *\/`
+ * - JSX コメント `{/* ... *\/}`
+ * - import 文（`import ...` の行、`from '...'` までを含む複数行 import も対象）
+ *
+ * 注意: 共有の `judgeKeywords` 自体は変更せず、Challenge 判定経路でのみ
+ * 前処理として適用する（Test / Code Doctor / Mini Project の挙動を変えないため）。
+ */
+export function stripNonAuthoredCode(code: string): string {
+  return (
+    code
+      // JSX コメント {/* ... */}（ブロックコメントより先に処理）
+      .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, ' ')
+      // ブロックコメント /* ... */
+      .replace(/\/\*[\s\S]*?\*\//g, ' ')
+      // 行コメント // ...（行末まで）
+      .replace(/\/\/[^\n]*/g, ' ')
+      // import ... from '...'（単一行・複数行 import を from 句まで除去）
+      .replace(/^\s*import\b[\s\S]*?from\s*['"][^'"]+['"]\s*;?/gm, ' ')
+      // 副作用 import 'module'
+      .replace(/^\s*import\s+['"][^'"]+['"]\s*;?/gm, ' ')
+  )
+}
+
+/**
  * キーワードベースでコードを判定する（大文字小文字を区別しない）。
  *
  * - `matched`: 有効な必須要件のうちコードに含まれるもの


### PR DESCRIPTION
## 概要

v6roadmap M5-5。Challenge の誤合格を防ぎ、不正解時のフィードバック（不足条件・避けたい書き方・解答例）を整える。

関連: [v6roadmap02-implementation](docs/roadmaps/v6/v6roadmap02-implementation.md) M5-5。依存: M5-1（型・判定基盤）/ M5-3（代表固定）いずれも merged。

## 変更内容

### 誤合格防止
- `lib/judge.ts` に `stripNonAuthoredCode` を追加。判定前にコメント（行/ブロック/JSX）と import 文を除去し、starterCode の TODO コメントや `import { useState }` 由来のキーワード一致が matched / violations に数えられないようにする。
- `ChallengeMode` の判定を `judgeKeywords(stripNonAuthoredCode(code), …)` に変更。
- **共有 `judgeKeywords` は不変**。Challenge 判定経路でのみ前処理として適用（Test / Code Doctor / Mini Project の挙動は変えない）。
- 合否基準は従来通り `expectedKeywords`。提出履歴に保存する `code` は生コードのまま。

### 不正解フィードバック
- `conditions` がある場合は不足条件を**日本語ラベル + 説明**で表示（無ければ従来の不足キーワード表示にフォールバック）。
- 「避けたい書き方（violations）」もサニタイズ後コードで判定。
- `solutionCode` がある場合に「解答例を見る」で任意開示する `SolutionDisclosure` を新設（M5-6/M5-7 でも再利用予定）。

## スコープ外

- 全40Stepの `conditions` / `solutionCode` 実データ投入 → **M5-8**
- starterCode との差分ベース厳格判定 → フォローアップ **#342**（将来課題）

## テスト

- `lib/judge.test.ts`: `stripNonAuthoredCode`（行/ブロック/JSXコメント・単一/複数行 import・副作用 import 除去、`importData` 誤除去なし、コメント/import由来キーワードが matched/violation に数えられない）
- `ChallengeMode.test.tsx`: starterのコメント+importのみでは不合格（誤合格防止）/ conditions の日本語不足表示 / 「解答例を見る」開示

## 検証

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test`（95 files / 978 tests）
- [x] `npm run build`

## マージ判断

誤合格の最低条件（コメント/import除去）を満たし、共有判定関数は不変で他モード回帰なし。conditions/solutionCode は「あれば使う」フォールバック設計で既存挙動を維持。CI 4ゲート通過のため **マージ可**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)