### PR TITLE
feat: M5-6 Test不正解時の不足条件・解答例表示

### DIFF
--- a/apps/web/src/features/learning/TestMode.tsx
+++ b/apps/web/src/features/learning/TestMode.tsx
@@ -5,10 +5,12 @@ import { useIsMobile } from '../../hooks/useIsMobile'
 import type { TestTask } from '../../content/fundamentals/steps'
 import { CodePuzzle } from './CodePuzzle/CodePuzzle'
 import { JudgmentResult } from './components/JudgmentResult'
+import { SolutionDisclosure } from './components/SolutionDisclosure'
 import { useJudgmentAction } from './hooks/useJudgmentAction'
 import { useStepReset } from './hooks/useStepReset'
 import { previewByStepId } from './testModePreview'
 import { checkAllKeywords } from './utils/keywordMatcher'
+import { judgeKeywordConditions } from '../../lib/judge'
 import { previewComponentByStepId } from './previews'
 
 interface TestModeProps {
@@ -33,6 +35,12 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
     () => blankInput.length > 0 && checkAllKeywords(mergedCode, task.expectedKeywords),
     [blankInput, mergedCode, task.expectedKeywords],
   )
+
+  // 条件メタ情報があれば、不足を日本語ラベルで表示するために条件単位でも判定する（表示専用）
+  const unsatisfiedConditions = useMemo(() => {
+    if (!task.conditions || task.conditions.length === 0) return []
+    return judgeKeywordConditions(mergedCode, task.conditions).unsatisfiedConditions
+  }, [mergedCode, task.conditions])
 
   const getReviewPayload = useCallback((userInput: string) => {
     return {
@@ -108,16 +116,36 @@ export function TestMode({ stepId, task, onComplete }: TestModeProps) {
               <JudgmentResult
                 isPassed={isPassed}
                 passedMessage="テスト合格！ ライブプレビューが解禁されました。"
-                failedMessage="必要キーワードを満たしていません。"
-                failedHint="コードを見直して、もう一度試してください。"
+                failedMessage="もう少しです。条件を確認してみましょう。"
+                failedHint="下記の不足している条件を見直して、もう一度試してください。"
               />
             )}
           </div>
 
-          {isJudged && !isPassed && task.explanation ? (
-            <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2">
-              <p className="text-xs font-semibold text-amber-700">解説</p>
-              <p className="mt-0.5 text-sm text-amber-900">{task.explanation}</p>
+          {isJudged && !isPassed ? (
+            <div className="space-y-2">
+              {unsatisfiedConditions.length > 0 ? (
+                <div className="rounded-md border border-rose-200 bg-rose-50 px-3 py-2" role="alert">
+                  <p className="text-sm font-semibold text-rose-800">以下の条件を満たせているか確認しましょう:</p>
+                  <ul className="mt-2 space-y-1.5 text-sm text-rose-700">
+                    {unsatisfiedConditions.map((condition) => (
+                      <li key={condition.id}>
+                        <span className="font-semibold">{condition.label}</span>
+                        <span className="text-rose-600">: {condition.explanation}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+
+              {task.explanation ? (
+                <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2">
+                  <p className="text-xs font-semibold text-amber-700">解説</p>
+                  <p className="mt-0.5 text-sm text-amber-900">{task.explanation}</p>
+                </div>
+              ) : null}
+
+              {task.solutionCode ? <SolutionDisclosure solutionCode={task.solutionCode} /> : null}
             </div>
           ) : null}
         </>

--- a/apps/web/src/features/learning/__tests__/TestMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/TestMode.test.tsx
@@ -135,3 +135,74 @@ describe('TestMode', () => {
     ).toBeTruthy()
   })
 })
+
+describe('TestMode 不正解フィードバック', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  beforeEach(() => {
+    recordWrongAnswer.mockReset()
+    resolveReviewItem.mockReset()
+    trackLearningEvent.mockReset()
+    recordWrongAnswer.mockResolvedValue(undefined)
+    resolveReviewItem.mockResolvedValue(undefined)
+  })
+
+  it('conditions がある場合、不正解時に不足条件を日本語ラベル・説明で表示する', async () => {
+    const user = userEvent.setup()
+    const conditionTask: TestTask = {
+      instruction: '条件付き問題',
+      starterCode: 'const x = ____',
+      expectedKeywords: ['setName'],
+      conditions: [
+        {
+          id: 'c-update',
+          label: '状態を更新する',
+          requiredKeywords: ['setName'],
+          explanation: 'setNameで名前を更新しましょう',
+        },
+      ],
+    }
+
+    render(<TestMode stepId="step-cond" task={conditionTask} onComplete={vi.fn()} />)
+
+    await user.type(screen.getByLabelText('コードの空欄を入力'), 'foo')
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+
+    expect(screen.getByText('以下の条件を満たせているか確認しましょう:')).toBeTruthy()
+    expect(screen.getByText('状態を更新する')).toBeTruthy()
+    expect(screen.getByText(/setNameで名前を更新しましょう/)).toBeTruthy()
+  })
+
+  it('solutionCode がある場合、「解答例を見る」で解答例を表示できる', async () => {
+    const user = userEvent.setup()
+    const solutionTask: TestTask = {
+      instruction: '解答例つき問題',
+      starterCode: 'const x = ____',
+      expectedKeywords: ['setName'],
+      solutionCode: 'const [name, setName] = useState("")',
+    }
+
+    render(<TestMode stepId="step-sol" task={solutionTask} onComplete={vi.fn()} />)
+
+    await user.type(screen.getByLabelText('コードの空欄を入力'), 'foo')
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+
+    expect(screen.queryByText('const [name, setName] = useState("")')).toBeNull()
+    await user.click(screen.getByRole('button', { name: '解答例を見る' }))
+    expect(screen.getByText('const [name, setName] = useState("")')).toBeTruthy()
+  })
+
+  it('conditions が無い場合は従来どおり explanation を表示する（後方互換）', async () => {
+    const user = userEvent.setup()
+
+    render(<TestMode stepId="step-a" task={firstTask} onComplete={vi.fn()} />)
+
+    await user.type(screen.getByLabelText('コードの空欄を入力'), 'foo')
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+
+    expect(screen.getByText('解説1')).toBeTruthy()
+    expect(screen.queryByText('以下の条件を満たせているか確認しましょう:')).toBeNull()
+  })
+})


### PR DESCRIPTION
## 概要

v6roadmap M5-6。Test の不正解時に「どの条件が足りないか」を日本語で示し、解答例を任意で開けるようにする。

関連: [v6roadmap02-implementation](docs/roadmaps/v6/v6roadmap02-implementation.md) M5-6。依存: M5-1（型・判定基盤）。M5-5 の `SolutionDisclosure` を再利用。

## 変更内容

- `TestMode`（desktop 自由入力経路）の不正解表示を拡張:
  - `conditions` があれば `judgeKeywordConditions(mergedCode, conditions)` で不足条件を**日本語ラベル + 説明**表示（確認型文言）
  - 既存 `explanation`（解説）表示は維持
  - `solutionCode` があれば `SolutionDisclosure` で任意開示
- 失敗メッセージ/ヒントを確認型に調整（「もう少しです。条件を確認してみましょう。」）
- 合否基準は従来通り `expectedKeywords`（`checkAllKeywords`）。conditions は表示専用。
- **モバイル `CodePuzzle` 経路は変更なし**（`expectedKeywords` 互換維持）。

## スコープ外

- 全40Stepの `conditions` / `solutionCode` 実データ投入 → **M5-8**
- Test 複数問化 / Lint・Preview 補助 → 非スコープ（#336）

## テスト

- `TestMode.test.tsx`: conditions の日本語不足表示 / 「解答例を見る」開示 / conditions 無し時は従来 explanation 表示（後方互換）
- 既存の合格・プレビュー・リセットのテストは緑のまま（合否ロジック不変）

## 検証

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test`（95 files / 981 tests）
- [x] `npm run build`

## マージ判断

合否ロジックは `expectedKeywords` のまま、conditions/solutionCode は「あれば使う」フォールバック設計でモバイル含め既存挙動を維持。CI 4ゲート通過のため **マージ可**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)