### PR TITLE
feat: M5-7 Practice基本/応用ラベルと不正解フィードバック

### DIFF
--- a/apps/web/src/features/learning/PracticeMode.tsx
+++ b/apps/web/src/features/learning/PracticeMode.tsx
@@ -1,8 +1,14 @@
 import { useMemo, useState } from 'react'
 import { Button } from '../../components/Button'
 import type { PracticeQuestion } from '../../content/fundamentals/steps'
+import { SolutionDisclosure } from './components/SolutionDisclosure'
 import { useJudgmentAction, type ReviewPayload } from './hooks/useJudgmentAction'
 import { useStepReset } from './hooks/useStepReset'
+
+const LEVEL_BADGE: Record<NonNullable<PracticeQuestion['level']>, { label: string; className: string }> = {
+  basic: { label: '基本', className: 'border-slate-300 bg-slate-100 text-slate-600' },
+  applied: { label: '応用', className: 'border-violet-300 bg-violet-100 text-violet-700' },
+}
 
 interface PracticeModeProps {
   stepId: string
@@ -77,12 +83,20 @@ export function PracticeMode({ stepId, questions, onComplete }: PracticeModeProp
       {questions.map((question, index) => {
         const answer = answers[question.id] ?? ''
         const isCorrect = answer.length > 0 && isPracticeAnswerCorrect(question, answer)
-        const showExplanation = isJudged && !isCorrect && question.explanation
+        const showIncorrectFeedback = isJudged && !isCorrect
+        const badge = question.level ? LEVEL_BADGE[question.level] : null
 
         return (
           <article key={question.id} className="space-y-3 rounded-lg border border-slate-200 bg-slate-50 p-3 sm:p-4">
             <p className="text-sm font-medium text-slate-700">
-              Q{index + 1}. {question.prompt}
+              <span className="inline-flex flex-wrap items-center gap-2">
+                {badge ? (
+                  <span className={`inline-block rounded-full border px-2 py-0.5 text-xs font-semibold ${badge.className}`}>
+                    {badge.label}
+                  </span>
+                ) : null}
+                <span>Q{index + 1}. {question.prompt}</span>
+              </span>
             </p>
             {question.choices ? (
               <div className="flex flex-wrap gap-2" role="radiogroup" aria-label={`Q${index + 1} 選択肢`}>
@@ -140,10 +154,23 @@ export function PracticeMode({ stepId, questions, onComplete }: PracticeModeProp
                 {isCorrect ? '正解です。' : '不正解です。もう一度試してください。'}
               </p>
             ) : null}
-            {showExplanation ? (
-              <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2">
-                <p className="text-xs font-semibold text-amber-700">解説</p>
-                <p className="mt-0.5 text-sm text-amber-900">{question.explanation}</p>
+            {showIncorrectFeedback ? (
+              <div className="space-y-2">
+                {question.testedConcept ? (
+                  <div className="rounded-md border border-rose-200 bg-rose-50 px-3 py-2">
+                    <p className="text-xs font-semibold text-rose-700">確認すること</p>
+                    <p className="mt-0.5 text-sm text-rose-900">{question.testedConcept}</p>
+                  </div>
+                ) : null}
+                {question.explanation ? (
+                  <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2">
+                    <p className="text-xs font-semibold text-amber-700">解説</p>
+                    <p className="mt-0.5 text-sm text-amber-900">{question.explanation}</p>
+                  </div>
+                ) : null}
+                {question.solutionText ? (
+                  <SolutionDisclosure solutionCode={question.solutionText} mono={false} />
+                ) : null}
               </div>
             ) : null}
             <button

--- a/apps/web/src/features/learning/__tests__/PracticeMode.test.tsx
+++ b/apps/web/src/features/learning/__tests__/PracticeMode.test.tsx
@@ -189,3 +189,76 @@ describe('PracticeMode', () => {
     expect(screen.getByText('Q1. 次の質問')).toBeTruthy()
   })
 })
+
+describe('PracticeMode フィードバック拡張', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  beforeEach(() => {
+    recordWrongAnswer.mockReset()
+    resolveReviewItem.mockReset()
+    trackLearningEvent.mockReset()
+    recordWrongAnswer.mockResolvedValue(undefined)
+    resolveReviewItem.mockResolvedValue(undefined)
+  })
+
+  it('level に応じて 基本 / 応用 バッジを表示する', () => {
+    const leveledQuestions: PracticeQuestion[] = [
+      { id: 'q-basic', prompt: '基本問題', answer: 'A', hint: 'h', level: 'basic' },
+      { id: 'q-applied', prompt: '応用問題', answer: 'B', hint: 'h', level: 'applied' },
+    ]
+    render(<PracticeMode stepId="step-level" questions={leveledQuestions} onComplete={vi.fn()} />)
+
+    expect(screen.getByText('基本')).toBeTruthy()
+    expect(screen.getByText('応用')).toBeTruthy()
+  })
+
+  it('level 未設定の問題はバッジを表示しない', () => {
+    render(<PracticeMode stepId="step-nolevel" questions={firstQuestions} onComplete={vi.fn()} />)
+
+    expect(screen.queryByText('基本')).toBeNull()
+    expect(screen.queryByText('応用')).toBeNull()
+  })
+
+  it('不正解時に testedConcept（確認すること）を表示する', async () => {
+    const user = userEvent.setup()
+    const conceptQuestions: PracticeQuestion[] = [
+      {
+        id: 'q-concept',
+        prompt: '確認事項つき問題',
+        answer: '正解',
+        hint: 'h',
+        testedConcept: 'setterで状態を更新できているか',
+      },
+    ]
+    render(<PracticeMode stepId="step-concept" questions={conceptQuestions} onComplete={vi.fn()} />)
+
+    await user.type(screen.getByLabelText('Q1 回答欄'), 'ちがう')
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+
+    expect(screen.getByText('確認すること')).toBeTruthy()
+    expect(screen.getByText('setterで状態を更新できているか')).toBeTruthy()
+  })
+
+  it('solutionText がある場合「解答例を見る」で解答例を表示できる', async () => {
+    const user = userEvent.setup()
+    const solutionQuestions: PracticeQuestion[] = [
+      {
+        id: 'q-sol',
+        prompt: '解答例つき問題',
+        answer: '正解',
+        hint: 'h',
+        solutionText: '答えは「正解」です。理由は…',
+      },
+    ]
+    render(<PracticeMode stepId="step-sol" questions={solutionQuestions} onComplete={vi.fn()} />)
+
+    await user.type(screen.getByLabelText('Q1 回答欄'), 'ちがう')
+    await user.click(screen.getByRole('button', { name: '判定する' }))
+
+    expect(screen.queryByText('答えは「正解」です。理由は…')).toBeNull()
+    await user.click(screen.getByRole('button', { name: '解答例を見る' }))
+    expect(screen.getByText('答えは「正解」です。理由は…')).toBeTruthy()
+  })
+})

--- a/apps/web/src/features/learning/components/SolutionDisclosure.tsx
+++ b/apps/web/src/features/learning/components/SolutionDisclosure.tsx
@@ -1,10 +1,15 @@
 import { useState } from 'react'
 
 interface SolutionDisclosureProps {
-  /** 表示する解答例コード */
+  /** 表示する解答例（コードまたは文章） */
   solutionCode: string
   /** 開閉ボタンのラベル（既定: 解答例） */
   label?: string
+  /**
+   * コード表示（ダークな等幅 pre）にするか（既定: true）。
+   * Practice の文章解答など、コードでない場合は false にして読みやすい本文表示にする。
+   */
+  mono?: boolean
 }
 
 /**
@@ -12,7 +17,7 @@ interface SolutionDisclosureProps {
  * 不正解時に「解答例を見る」を提示し、ユーザーが選んだときだけ中身を表示する。
  * Challenge / Test / Practice で共通利用する。
  */
-export function SolutionDisclosure({ solutionCode, label = '解答例' }: SolutionDisclosureProps) {
+export function SolutionDisclosure({ solutionCode, label = '解答例', mono = true }: SolutionDisclosureProps) {
   const [isOpen, setIsOpen] = useState(false)
 
   return (
@@ -27,9 +32,15 @@ export function SolutionDisclosure({ solutionCode, label = '解答例' }: Soluti
       </button>
 
       {isOpen ? (
-        <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-slate-900 p-3 text-xs leading-relaxed text-slate-100">
-          <code>{solutionCode}</code>
-        </pre>
+        mono ? (
+          <pre className="mt-2 overflow-x-auto whitespace-pre-wrap break-words rounded-md bg-slate-900 p-3 text-xs leading-relaxed text-slate-100">
+            <code>{solutionCode}</code>
+          </pre>
+        ) : (
+          <p className="mt-2 whitespace-pre-wrap break-words rounded-md border border-violet-200 bg-violet-50 px-3 py-2 text-sm leading-relaxed text-slate-800">
+            {solutionCode}
+          </p>
+        )
       ) : null}
     </div>
   )


### PR DESCRIPTION
## 概要

v6roadmap M5-7。Practice に基本/応用ラベルを表示し、不正解時に確認事項・解説・解答例で立て直せるようにする。

関連: [v6roadmap02-implementation](docs/roadmaps/v6/v6roadmap02-implementation.md) M5-7。依存: M5-1（型）。M5-5 の `SolutionDisclosure` を再利用。

## 変更内容

- `PracticeMode`:
  - 各問に `level` に応じた **`基本` / `応用` バッジ**を表示（`level` 未設定なら表示なし）
  - 不正解時に `testedConcept`（**確認すること**）を表示、既存 `explanation`（解説）は維持
  - `solutionText` があれば「解答例を見る」で任意開示
- `SolutionDisclosure` に `mono?: boolean`（既定 `true`）を追加。
  - `mono=false` で文章向けの明るい本文表示（Practice の `solutionText` 用）
  - 既存の Challenge / Test 呼び出しは引数そのままで**挙動不変**
- 正誤判定ロジック（`isPracticeAnswerCorrect`）は不変。追加フィールドはすべて optional フォールバック。

## スコープ外

- 全40Step×5問の `level` / `testedConcept` / `solutionText` 実データ投入 → **M5-8**
- 問題プール化・大量追加 → 非スコープ

## テスト

- `PracticeMode.test.tsx`: 基本/応用バッジ表示 / level 未設定はバッジなし / 不正解時の `testedConcept` 表示 / `solutionText` の「解答例を見る」開示
- 既存の正誤判定・選択式・別解・完了・リセットのテストは緑のまま

## 検証

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test`（95 files / 985 tests）
- [x] `npm run build`

## マージ判断

判定ロジック不変、追加表示は optional フォールバック、`SolutionDisclosure` 拡張は後方互換。CI 4ゲート通過のため **マージ可**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)