### PR TITLE
feat: M5-8a fundamentals/intermediate のコンテンツ反映

### DIFF
--- a/apps/web/src/content/fundamentals/steps.ts
+++ b/apps/web/src/content/fundamentals/steps.ts
@@ -171,6 +171,21 @@ export function Counter() {
 - **\`[count, setCount]\`**: 配列の分割代入です。1つ目が現在の値 (\`state\`)、2つ目が更新用の関数 (\`setter\`) です。
 
 setter関数（\`setCount\`など）を呼び出すことで、Reactはそのコンポーネントの新しい状態を認識し、画面を最新の状態に更新（再レンダリング）します。
+
+## Hookのルール
+
+\`useState\` のような Hook には、呼び出す場所のルールがあります。**Hook は必ずコンポーネントのトップレベルで呼び出します**。\`if\` 文・ループ・ネストした関数の中では呼び出せません。
+
+\`\`\`tsx
+function Counter({ enabled }) {
+  if (enabled) {
+    const [count, setCount] = useState(0); // NG: 条件分岐の中では呼べない
+  }
+  // ...
+}
+\`\`\`
+
+これは、Reactが「何番目に呼ばれた Hook か」で各 state を区別しているためです。呼び出し順が毎回変わると state が正しく対応づけられません。常にトップレベルで、同じ順番で呼び出してください。
 `,
     practiceQuestions: [
       {
@@ -218,9 +233,26 @@ setter関数（\`setCount\`など）を呼び出すことで、Reactはそのコ
       starterCode: `const [count, setCount] = useState(10)
 return <button onClick={() => ____}>-1 ({count})</button>`,
       expectedKeywords: ['setCount', 'count - 1'],
+      conditions: [
+        {
+          id: 'call-setter',
+          label: '更新関数 setCount を呼び出している',
+          requiredKeywords: ['setCount'],
+          explanation: '状態を変えるには更新関数 setCount を呼び出す必要があります。',
+        },
+        {
+          id: 'decrement',
+          label: '現在値から1引いた値を渡している',
+          requiredKeywords: ['count - 1'],
+          explanation: 'setCount に count - 1 を渡すと、現在値より1小さい値がセットされます。',
+        },
+      ],
       explanation: 'setCount に count - 1 を渡します。setCount(count - 1) と書くと、現在値より1小さい値がセットされます。',
+      solutionCode: `const [count, setCount] = useState(10)
+return <button onClick={() => setCount(count - 1)}>-1 ({count})</button>`,
     },
     challengeTask: {
+      primaryPatternId: 'usestate-like',
       patterns: [
         {
           id: 'usestate-like',
@@ -228,6 +260,21 @@ return <button onClick={() => ____}>-1 ({count})</button>`,
           requirements: ['初期値0から開始する', 'クリックで+1される', '現在値を表示する'],
           hints: ['まず state を 1 つ定義する', 'イベントハンドラで setter を呼ぶ'],
           expectedKeywords: ['useState', 'setCount', 'onClick'],
+          conditions: [
+            {
+              id: 'define-state',
+              label: 'state を定義している',
+              requiredKeywords: ['useState'],
+              explanation: 'useState でいいね数の状態（count）と更新関数（setCount）を定義します。',
+            },
+            {
+              id: 'update-on-click',
+              label: 'クリックで更新関数を呼んでいる',
+              requiredKeywords: ['setCount', 'onClick'],
+              explanation: 'button の onClick で setCount を呼び、count を増やします。',
+            },
+          ],
+          solutionCode: `import { useState } from 'react';\n\nexport function LikeButton() {\n  const [count, setCount] = useState(0);\n\n  return (\n    <button onClick={() => setCount(count + 1)}>\n      いいね {count}\n    </button>\n  );\n}`,
           starterCode: `import { useState } from 'react';\n\nexport function LikeButton() {\n  // TODO: useStateを使って、いいね数(count)と更新関数(setCount)を定義してください。\n  // 初期値は 0 にします。\n\n  return (\n    // TODO: buttonのonClickに、クリックされたら count を +1 する処理を書いてください。\n    <button>\n      {/* TODO: ここに現在のいいね数(count)を表示してください */}\n      いいね 0\n    </button>\n  );\n}`,
           mobilePuzzle: {
             type: 'multi',
@@ -410,9 +457,19 @@ export function SearchForm() {
       instruction: 'input要素に文字が入力されたときに実行されるイベントプロパティを空欄に埋めてください。',
       starterCode: `<input value={name} ____={(e) => setName(e.target.value)} />`,
       expectedKeywords: ['onChange'],
+      conditions: [
+        {
+          id: 'use-onchange',
+          label: 'input に onChange を指定している',
+          requiredKeywords: ['onChange'],
+          explanation: 'input の値変化を検知するイベントプロパティは onChange です。',
+        },
+      ],
       explanation: 'input要素の値変化を検知するにはonChangeを使います。e.target.valueで入力テキストを取得できます。',
+      solutionCode: `<input value={name} onChange={(e) => setName(e.target.value)} />`,
     },
     challengeTask: {
+      primaryPatternId: 'events-preview',
       patterns: [
         {
           id: 'events-preview',
@@ -420,6 +477,21 @@ export function SearchForm() {
           requirements: ['入力欄を1つ置く', '入力値を下に表示する', '表示は即時反映される'],
           hints: ['onChange で値を受け取る', 'useStateで保持する'],
           expectedKeywords: ['onChange', 'target.value', 'useState'],
+          conditions: [
+            {
+              id: 'define-state',
+              label: '入力値を保持する state を定義している',
+              requiredKeywords: ['useState'],
+              explanation: 'useState で入力文字列を保持する state を作ります。',
+            },
+            {
+              id: 'handle-change',
+              label: 'onChange で入力値を取得している',
+              requiredKeywords: ['onChange', 'target.value'],
+              explanation: 'input の onChange で e.target.value を受け取り、state を更新します。',
+            },
+          ],
+          solutionCode: `import { useState } from 'react';\n\nexport function LiveInput() {\n  const [text, setText] = useState('');\n\n  return (\n    <div>\n      <input\n        placeholder="入力してください"\n        value={text}\n        onChange={(e) => setText(e.target.value)}\n      />\n      <p>入力内容: {text}</p>\n    </div>\n  );\n}`,
           starterCode: `import { useState } from 'react';\n\nexport function LiveInput() {\n  // TODO: 入力文字列を保持する text というstateを作成してください。\n  \n  return (\n    <div>\n      {/* TODO: inputにonChangeイベントを設定し、入力値(e.target.value)で text を更新してください */}\n      <input placeholder="入力してください" />\n      <p>入力内容: {/* TODO: text変数をここに表示してください */}</p>\n    </div>\n  );\n}`,
           mobilePuzzle: {
             type: 'multi',
@@ -574,8 +646,10 @@ function Notifications({ unreadCount }) {
         id: 'q5',
         prompt: '`unreadCount > 0 && <p>New Message</p>` というコードにおいて、短絡評価と呼ばれる性質により、左辺が false の場合、右辺はどう評価されますか？',
         answer: '無視される',
+        level: 'applied',
+        testedConcept: '&& の短絡評価（左辺が false なら右辺は評価されない）',
         hint: '左辺がfalseであれば、全体もfalseになることが確定するため、右辺の評価はスキップされます。',
-        explanation: '&& の短絡評価：左辺がfalseなら全体の結果がfalseで確定するため、右辺は評価されず何も表示されません。',
+        explanation: '&& の短絡評価：左辺がfalseなら全体の結果がfalseで確定するため、右辺は評価されず何も表示されません。なお左辺が 0 のような falsy な数値だと、その 0 が画面に表示される落とし穴があるため、左辺は boolean にするのが安全です。',
         choices: ['無視される', '実行される', 'エラーになる', 'nullが返る'],
       },
     ],
@@ -583,9 +657,19 @@ function Notifications({ unreadCount }) {
       instruction: 'isLoggedIn が true の時だけ「Welcome」というパラグラフを表示したいです。最適な演算子を埋めてください。',
       starterCode: `{isLoggedIn ____ <p>Welcome</p>}`,
       expectedKeywords: ['&&'],
+      conditions: [
+        {
+          id: 'use-and',
+          label: '&& 演算子を使っている',
+          requiredKeywords: ['&&'],
+          explanation: 'trueのときだけ表示し、falseなら何も表示しない場合は && を使います。',
+        },
+      ],
       explanation: '「trueのときだけ表示、falseなら何も表示しない」には && を使います。三項演算子では falseのとき に null を返す必要があり冗長になります。',
+      solutionCode: `{isLoggedIn && <p>Welcome</p>}`,
     },
     challengeTask: {
+      primaryPatternId: 'conditional-login',
       patterns: [
         {
           id: 'conditional-login',
@@ -593,6 +677,21 @@ function Notifications({ unreadCount }) {
           requirements: ['trueなら「ようこそ」を描画', 'falseならログインボタンを描画', '三項演算子を使う'],
           hints: ['isLoggedIn ? A : B を使う'],
           expectedKeywords: ['isLoggedIn', '?', ':'],
+          conditions: [
+            {
+              id: 'use-ternary',
+              label: '三項演算子で分岐している',
+              requiredKeywords: ['?', ':'],
+              explanation: '三項演算子 条件 ? A : B を使って表示内容を切り替えます。',
+            },
+            {
+              id: 'branch-on-login',
+              label: 'ログイン状態で切り替えている',
+              requiredKeywords: ['isLoggedIn'],
+              explanation: 'isLoggedIn の真偽で「ようこそ」とログインボタンを切り替えます。',
+            },
+          ],
+          solutionCode: `import { useState } from 'react';\n\nexport function AuthPanel() {\n  const [isLoggedIn, setIsLoggedIn] = useState(false);\n\n  return (\n    <div>\n      {isLoggedIn ? (\n        <p>ようこそ！</p>\n      ) : (\n        <button onClick={() => setIsLoggedIn(true)}>ログイン</button>\n      )}\n    </div>\n  );\n}`,
           starterCode: `import { useState } from 'react';\n\nexport function AuthPanel() {\n  const [isLoggedIn, setIsLoggedIn] = useState(false);\n\n  return (\n    <div>\n      {/* TODO: 以下のコメント部分を三項演算子(?と:)に置き換え、\n          isLoggedInが true なら <p>ようこそ！</p> を、\n          false なら <button onClick={() => setIsLoggedIn(true)}>ログイン</button> を表示してください。 \n      */}\n      {/* ここに三項演算子を書く */}\n    </div>\n  );\n}`,
           mobilePuzzle: {
             type: 'multi',
@@ -680,6 +779,16 @@ export function List() {
 **keyの選び方**
 - **データのIDを使う:** データベースのレコードIDなど、安定した一意の値が最適です。
 - **indexを避ける:** 配列のインデックス（\`0\`, \`1\`, \`2\`...）を \`key\` に使用すると、後からアイテムの順序が変わった場合（並び替えや先頭追加など）に React が要素を取り違えてしまい、予期せぬバグの温床になります。
+
+## 絞り込んで描画する（filter().map()）
+
+「条件に合うものだけ表示したい」場合は、\`map()\` の前に \`filter()\` で配列を絞り込みます。\`filter()\` は条件を満たす要素だけの新しい配列を返すので、\`filter().map()\` とつなげると「絞り込み → 変換」が一度に書けます。
+
+\`\`\`tsx
+{todos
+  .filter(todo => todo.isCompleted)
+  .map(todo => <li key={todo.id}>{todo.title}</li>)}
+\`\`\`
 `,
     practiceQuestions: [
       {
@@ -724,9 +833,25 @@ export function List() {
       instruction: 'ユーザーのリスト (users) を描画するため、map() の要素の li タグに最適な属性を書いてください。',
       starterCode: `{users.map(user => <li ____>{user.name}</li>)}`,
       expectedKeywords: ['key={user.id}'],
+      conditions: [
+        {
+          id: 'specify-key',
+          label: 'key プロパティを指定している',
+          requiredKeywords: ['key='],
+          explanation: 'リストの各要素には key を指定する必要があります。',
+        },
+        {
+          id: 'use-id-not-index',
+          label: 'index ではなく user.id を使っている',
+          requiredKeywords: ['user.id'],
+          explanation: 'key には並び替えても変わらない一意の値（user.id）を使います。',
+        },
+      ],
       explanation: 'key={user.id} のようにデータの一意な値を渡します。keyは文字列または数値で、インデックスは推奨されません。',
+      solutionCode: `{users.map(user => <li key={user.id}>{user.name}</li>)}`,
     },
     challengeTask: {
+      primaryPatternId: 'lists-todo',
       patterns: [
         {
           id: 'lists-todo',
@@ -736,6 +861,21 @@ export function List() {
           expectedKeywords: ['map', 'key=', 'todo.id'],
           // 配列インデックスを key にするアンチパターンを抑止する
           ngKeywords: ['key={index}', 'key={i}'],
+          conditions: [
+            {
+              id: 'use-map',
+              label: 'map で配列を描画している',
+              requiredKeywords: ['map'],
+              explanation: 'todos.map((todo) => ...) で各要素を <li> に変換します。',
+            },
+            {
+              id: 'unique-key',
+              label: '一意な key を指定している',
+              requiredKeywords: ['key=', 'todo.id'],
+              explanation: '各 <li> に key={todo.id} を渡して一意に識別します。',
+            },
+          ],
+          solutionCode: `export function TodoList() {\n  const todos = [\n    { id: 1, title: 'Reactを学ぶ' },\n    { id: 2, title: 'TypeScriptを学ぶ' },\n  ];\n\n  return (\n    <ul>\n      {todos.map((todo) => (\n        <li key={todo.id}>{todo.title}</li>\n      ))}\n    </ul>\n  );\n}`,
           starterCode: `export function TodoList() {\n  const todos = [\n    { id: 1, title: 'Reactを学ぶ' },\n    { id: 2, title: 'TypeScriptを学ぶ' },\n  ];\n\n  return (\n    <ul>\n      {/* TODO: todos を map し、それぞれ <li> タグとして描画してください。\n          <li> には必ず key に todo.id を指定し、中身に todo.title を表示してください。 \n      */}\n      \n    </ul>\n  );\n}`,
           mobilePuzzle: {
             type: 'multi',

--- a/apps/web/src/content/intermediate/steps.ts
+++ b/apps/web/src/content/intermediate/steps.ts
@@ -91,9 +91,19 @@ export function Timer() {
             instruction: '初回描画時のみ alert("Hello!") が実行されるように空欄を埋めてください。',
             starterCode: `useEffect(() => {\n  alert('Hello!')\n}, ____)`,
             expectedKeywords: ['[]'],
+            conditions: [
+                {
+                    id: 'empty-deps',
+                    label: '第二引数に空配列 [] を渡している',
+                    requiredKeywords: ['[]'],
+                    explanation: '依存配列に [] を渡すと、初回マウント時にのみ実行されます。',
+                },
+            ],
             explanation: '空の依存配列[]を渡すと初回マウント時にのみ実行されます。[]を省略すると毎回実行されてしまいます。',
+            solutionCode: `useEffect(() => {\n  alert('Hello!')\n}, [])`,
         },
         challengeTask: {
+            primaryPatternId: 'useeffect-timer',
             patterns: [
                 {
                     id: 'useeffect-timer',
@@ -101,6 +111,27 @@ export function Timer() {
                     requirements: ['useEffect を使う', 'setInterval で毎秒ログを出す', 'クリーンアップ関数で clearInterval する', '初回のみセットする依存配列にする'],
                     hints: ['useEffect(() => { const id = setInterval(...); return () => clearInterval(id); }, []);'],
                     expectedKeywords: ['useEffect', 'setInterval', 'clearInterval', 'return ()'],
+                    conditions: [
+                        {
+                            id: 'use-effect',
+                            label: 'useEffect で副作用を扱っている',
+                            requiredKeywords: ['useEffect'],
+                            explanation: 'マウント時の処理は useEffect の中に書きます。',
+                        },
+                        {
+                            id: 'set-interval',
+                            label: 'setInterval でタイマーを設定している',
+                            requiredKeywords: ['setInterval'],
+                            explanation: 'setInterval で毎秒の処理を登録します。',
+                        },
+                        {
+                            id: 'cleanup',
+                            label: 'クリーンアップで clearInterval している',
+                            requiredKeywords: ['clearInterval', 'return ()'],
+                            explanation: 'return でクリーンアップ関数を返し、clearInterval でタイマーを解除します。',
+                        },
+                    ],
+                    solutionCode: `import { useEffect } from 'react';\n\nexport function LogTimer() {\n  useEffect(() => {\n    const id = setInterval(() => console.log('tick'), 1000);\n    return () => clearInterval(id);\n  }, []);\n\n  return <div>Check console for ticks!</div>;\n}`,
                     starterCode: `import { useEffect } from 'react';\n\nexport function LogTimer() {\n  // TODO: useEffectを使って、毎秒 (1000ms間隔) console.log('tick') を実行するようにしてください。\n  // TODO: 第二引数を適切に設定し、初回マウント時だけタイマーが作動するようにしてください。\n  // TODO: クリーンアップ関数を返し、その中で clearInterval(タイマーID) を実行してメモリリークを防いでください。\n\n  return <div>Check console for ticks!</div>;\n}`,
                     mobilePuzzle: {
                         type: 'multi',
@@ -243,9 +274,19 @@ SPA (Single Page Application) であるReactではこれを防ぐため、必ず
             instruction: 'ユーザーの入力が3文字未満の時はボタンを非活性(disabled)にするよう空欄を埋めてください。',
             starterCode: `<button ____={text.length < 3}>送信</button>`,
             expectedKeywords: ['disabled'],
+            conditions: [
+                {
+                    id: 'use-disabled',
+                    label: 'button に disabled を指定している',
+                    requiredKeywords: ['disabled'],
+                    explanation: 'button の disabled に真偽値を渡すと、true のとき押せなくなります。',
+                },
+            ],
             explanation: 'disabled プロパティにboolean式を渡します。text.length < 3 が true のときボタンが押せなくなります。',
+            solutionCode: `<button disabled={text.length < 3}>送信</button>`,
         },
         challengeTask: {
+            primaryPatternId: 'forms-controlled',
             patterns: [
                 {
                     id: 'forms-controlled',
@@ -253,6 +294,27 @@ SPA (Single Page Application) であるReactではこれを防ぐため、必ず
                     requirements: ['制御された input を実装', 'onChange で state を同期', '文字数による disabled 制御'],
                     hints: ['value に state を、onChange で setState にイベント値を渡す'],
                     expectedKeywords: ['useState', 'value=', 'onChange', 'disabled='],
+                    conditions: [
+                        {
+                            id: 'define-state',
+                            label: '入力値の state を定義している',
+                            requiredKeywords: ['useState'],
+                            explanation: 'useState で入力文字列を保持する state を定義します。',
+                        },
+                        {
+                            id: 'controlled-input',
+                            label: 'input を制御している',
+                            requiredKeywords: ['value=', 'onChange'],
+                            explanation: 'input に value と onChange を渡して制御されたコンポーネントにします。',
+                        },
+                        {
+                            id: 'disabled-control',
+                            label: '文字数で disabled を制御している',
+                            requiredKeywords: ['disabled='],
+                            explanation: 'text の長さに応じて button の disabled を切り替えます。',
+                        },
+                    ],
+                    solutionCode: `import { useState } from 'react';\n\nexport function ValidationForm() {\n  const [text, setText] = useState('');\n\n  return (\n    <form>\n      <input\n        placeholder="5文字以上入力"\n        value={text}\n        onChange={(e) => setText(e.target.value)}\n      />\n      <button type="submit" disabled={text.length < 5}>送信</button>\n    </form>\n  );\n}`,
                     starterCode: `import { useState } from 'react';\n\nexport function ValidationForm() {\n  // TODO: 文字列の state (text) を定義してください\n  \n  return (\n    <form>\n      {/* TODO: 制御されたコンポーネントとして input を実装してください */}\n      <input placeholder="5文字以上入力" />\n      {/* TODO: text の長さが 5 文字未満の場合、disabled になるボタンを実装してください */}\n      <button type="submit">送信</button>\n    </form>\n  );\n}`,
                     mobilePuzzle: {
                         type: 'multi',
@@ -403,9 +465,19 @@ SPA (Single Page Application) であるReactではこれを防ぐため、必ず
             instruction: 'ThemeContextから値を取り出し、theme変数に格納するように空欄を埋めてください。',
             starterCode: `const theme = ____(ThemeContext);`,
             expectedKeywords: ['useContext'],
+            conditions: [
+                {
+                    id: 'call-usecontext',
+                    label: 'useContext を呼び出している',
+                    requiredKeywords: ['useContext'],
+                    explanation: 'useContext(ThemeContext) で最も近い Provider の value を取得します。',
+                },
+            ],
             explanation: 'useContext(ThemeContext) と書くことで、最も近い ThemeContext.Provider の value 値を取得できます。',
+            solutionCode: `const theme = useContext(ThemeContext);`,
         },
         challengeTask: {
+            primaryPatternId: 'usecontext-basic',
             patterns: [
                 {
                     id: 'usecontext-basic',
@@ -413,6 +485,27 @@ SPA (Single Page Application) であるReactではこれを防ぐため、必ず
                     requirements: ['useContext を使用する', 'UserContext から値を取り出す', '取得した値を画面に表示する'],
                     hints: ['useContext(UserContext) で Context の値を取得できます', '取得した変数を JSX で描画します'],
                     expectedKeywords: ['useContext', 'UserContext'],
+                    conditions: [
+                        {
+                            id: 'use-usecontext',
+                            label: 'useContext で値を取得している',
+                            requiredKeywords: ['useContext'],
+                            explanation: 'useContext を使って Context の値を取り出します。',
+                        },
+                        {
+                            id: 'from-usercontext',
+                            label: 'UserContext から取り出している',
+                            requiredKeywords: ['UserContext'],
+                            explanation: 'useContext(UserContext) で UserContext の値を取得します。',
+                        },
+                        {
+                            id: 'show-user',
+                            label: '取得した user を表示している',
+                            requiredKeywords: ['{user}'],
+                            explanation: '取得した user を JSX 内に {user} の形で表示します。',
+                        },
+                    ],
+                    solutionCode: `import { createContext, useContext } from 'react';\n\nexport const UserContext = createContext('Guest');\n\nexport function Greeting() {\n  const user = useContext(UserContext);\n\n  return (\n    <div>\n      こんにちは、{user}！\n    </div>\n  );\n}`,
                     starterCode: `import { createContext, useContext } from 'react';\n\nexport const UserContext = createContext('Guest');\n\nexport function Greeting() {\n  // TODO: useContext を使って UserContext から値を取り出し、変数 user に格納してください。\n  \n  return (\n    <div>\n      {/* TODO: user 変数を表示してください */}\n      こんにちは、！\n    </div>\n  );\n}`,
                     mobilePuzzle: {
                         type: 'multi',
@@ -553,9 +646,25 @@ export function CounterApp() {
             instruction: 'ユーザーがリセットボタンを押すと actionの type を "RESET" にして dispatch する空欄を埋めてください。',
             starterCode: `<button onClick={() => ____({ type: 'RESET' })}>Reset</button>`,
             expectedKeywords: ['dispatch'],
+            conditions: [
+                {
+                    id: 'call-dispatch',
+                    label: 'dispatch を呼び出している',
+                    requiredKeywords: ['dispatch'],
+                    explanation: 'dispatch にアクションオブジェクトを渡すと Reducer が実行されます。',
+                },
+                {
+                    id: 'keep-reset-type',
+                    label: 'action の type が "RESET" になっている',
+                    requiredKeywords: ['RESET'],
+                    explanation: "リセット動作のため type: 'RESET' のアクションを送ります。",
+                },
+            ],
             explanation: 'dispatchはuseReducerから返される関数です。dispatchにactionオブジェクトを渡すとReducerが実行されます。',
+            solutionCode: `<button onClick={() => dispatch({ type: 'RESET' })}>Reset</button>`,
         },
         challengeTask: {
+            primaryPatternId: 'usereducer-calc',
             patterns: [
                 {
                     id: 'usereducer-calc',
@@ -563,6 +672,21 @@ export function CounterApp() {
                     requirements: ['switch文に STEP_UP 用の case を追加する', '現在の count に 5 加算して返す'],
                     hints: ['case "STEP_UP": return { count: state.count + 5 };'],
                     expectedKeywords: ['case', 'STEP_UP', 'state.count + 5'],
+                    conditions: [
+                        {
+                            id: 'add-case',
+                            label: 'STEP_UP の case を追加している',
+                            requiredKeywords: ['case', 'STEP_UP'],
+                            explanation: "switch 文に case 'STEP_UP' を追加します。",
+                        },
+                        {
+                            id: 'add-five',
+                            label: '現在値に 5 を加えて返している',
+                            requiredKeywords: ['state.count + 5'],
+                            explanation: 'STEP_UP のとき { count: state.count + 5 } を返します。',
+                        },
+                    ],
+                    solutionCode: `function reducer(state, action) {\n  switch (action.type) {\n    case 'INCREMENT':\n      return { count: state.count + 1 };\n    case 'STEP_UP':\n      return { count: state.count + 5 };\n    default:\n      return state;\n  }\n}`,
                     starterCode: `function reducer(state, action) {\n  switch (action.type) {\n    case 'INCREMENT':\n      return { count: state.count + 1 };\n    // TODO: ここに 'STEP_UP' アクションを受け取った場合、\n    // state.count に 5 を足した新しいオブジェクトを返す case ブロックを追記してください\n\n    default:\n      return state;\n  }\n}`,
                     mobilePuzzle: {
                         type: 'multi',


### PR DESCRIPTION
## 概要

v6roadmap M5-8（コンテンツ反映）の分割PR その1。M4棚卸し（`v6content-audit.md`）に沿って **fundamentals(4) + intermediate(4) の8ステップ**へ実データを反映する。

対象: usestate-basic / events / conditional / lists / useeffect / forms / usecontext / usereducer

## 変更内容（8ステップ共通）

- **代表固定**: 各 `challengeTask.primaryPatternId` を棚卸しの代表候補に設定
- **Test条件**: 各 `testTask` に `conditions`（日本語ラベル＋説明）と `solutionCode` を追加
- **Challenge補強**: 代表 pattern に `conditions` と `solutionCode` を追加
- **Practice**: `conditional` q5 に応用ラベル＋短絡評価の解説強化
- **Read補足**: `usestate-basic` に「Hookのルール」、`lists` に「filter().map()」を追加（q5 の Read 接続）
- **usecontext-basic**: user 表示の条件を追加（表示専用。誤合格防止は M5-5 の `stripNonAuthoredCode` で担保）

判定の合否基準は従来どおり `expectedKeywords`。`conditions` は表示専用で、モバイル `CodePuzzle` 互換も不変。

## 誤合格防止の確認

各代表 pattern の starterCode は、コメント・import を除去（M5-5）すると必須キーワードが残らないため、未編集では合格しません（例: usecontext-basic は `UserContext` の定義が残るが `useContext` は import/コメントのみのため不合格）。

## スコープ

- 本PRは fundamentals + intermediate のみ。残りは M5-8b〜d、全体整合のガードテストは M5-8e。
- 対象8ステップの `v6content-audit.md` M5送り 28項目を `[x]` 化（ローカル管理ドキュメント）。

## 検証

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test`（95 files / 985 tests）
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)