### PR TITLE
feat: M5-8c TypeScript系のコンテンツ反映

### DIFF
--- a/apps/web/src/content/typescript-react/steps/ts-react-events.ts
+++ b/apps/web/src/content/typescript-react/steps/ts-react-events.ts
@@ -150,6 +150,8 @@ const handleSubmit: FormEventHandler<HTMLFormElement> = (e) => {
       hint: 'react から import できるハンドラ型エイリアスです。',
       explanation: 'ChangeEventHandler<T> は React.ChangeEventHandler の型エイリアスです。import type { ChangeEventHandler } from "react" で import できます。',
       choices: ['ChangeEventHandler', 'ChangeHandler', 'InputHandler', 'EventHandler'],
+      level: 'applied',
+      testedConcept: 'Reactイベントハンドラ型エイリアス',
     },
   ],
   testTask: {
@@ -166,9 +168,35 @@ function TextInput() {
   return <input value={value} onChange={handleChange} />
 }`,
     expectedKeywords: ['HTMLInputElement'],
+    conditions: [
+      {
+        id: 'change-event-type',
+        label: 'ChangeEvent<HTMLInputElement> を使っている',
+        requiredKeywords: ['HTMLInputElement'],
+        explanation: 'input の onChange では HTMLInputElement を型引数にした ChangeEvent を使います。',
+      },
+      {
+        id: 'target-value',
+        label: 'e.target.value を state に反映している',
+        requiredKeywords: ['target.value'],
+        explanation: '入力値は e.target.value から取得して setValue に渡します。',
+      },
+    ],
     explanation: 'input 要素の onChange ハンドラの引数は React.ChangeEvent<HTMLInputElement> 型です。e.target.value で入力値を取得できます。',
+    solutionCode: `import { useState } from 'react'
+
+function TextInput() {
+  const [value, setValue] = useState('')
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value)
+  }
+
+  return <input value={value} onChange={handleChange} />
+}`,
   },
   challengeTask: {
+    primaryPatternId: 'ts-react-events-1',
     patterns: [
       {
         id: 'ts-react-events-1',
@@ -186,6 +214,55 @@ function TextInput() {
           'e.target.name as keyof FormData でキーの型安全性を確保できます',
         ],
         expectedKeywords: ['FormData', 'ChangeEvent', 'FormEvent', 'preventDefault', 'useState'],
+        conditions: [
+          {
+            id: 'form-data',
+            label: 'FormData interface を定義している',
+            requiredKeywords: ['FormData', 'name', 'email'],
+            explanation: 'フォームで扱う name と email を interface として定義します。',
+          },
+          {
+            id: 'change-handler',
+            label: 'ChangeEvent<HTMLInputElement> の onChange を実装している',
+            requiredKeywords: ['ChangeEvent', 'HTMLInputElement', 'setForm'],
+            explanation: 'input の変更イベントを型付きで受け取り、フォームstateを部分更新します。',
+          },
+          {
+            id: 'submit-handler',
+            label: 'FormEvent<HTMLFormElement> の onSubmit を実装している',
+            requiredKeywords: ['FormEvent', 'HTMLFormElement', 'preventDefault'],
+            explanation: 'フォーム送信イベントを型付きで受け取り、preventDefault でページ遷移を防ぎます。',
+          },
+        ],
+        solutionCode: `import { useState } from 'react'
+import type { ChangeEvent, FormEvent } from 'react'
+
+interface FormData {
+  name: string
+  email: string
+}
+
+function ContactForm() {
+  const [form, setForm] = useState<FormData>({ name: '', email: '' })
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const key = e.target.name as keyof FormData
+    setForm((prev) => ({ ...prev, [key]: e.target.value }))
+  }
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    console.log(form)
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input name="name" value={form.name} onChange={handleChange} />
+      <input name="email" value={form.email} onChange={handleChange} />
+      <button type="submit">送信</button>
+    </form>
+  )
+}`,
         starterCode: `import { useState } from 'react'
 
 // TODO: FormData interface を定義してください

--- a/apps/web/src/content/typescript-react/steps/ts-react-hooks.ts
+++ b/apps/web/src/content/typescript-react/steps/ts-react-hooks.ts
@@ -183,6 +183,8 @@ function Form() {
       hint: 'forwardRef は ref 型と Props 型の2つを受け取ります。',
       explanation: 'forwardRef<T, P> の T は ref.current の型（DOM要素型）、P はコンポーネントの Props 型です。',
       choices: ['ref の参照先DOM型 / コンポーネントのProps型', 'Props型 / ref の参照先DOM型', '親コンポーネント型 / 子コンポーネント型', '戻り値型 / 引数型'],
+      level: 'applied',
+      testedConcept: 'forwardRef の型引数順序',
     },
   ],
   testTask: {
@@ -199,9 +201,35 @@ function AutoFocusInput() {
   return <input ref={ref} placeholder="自動フォーカス" />
 }`,
     expectedKeywords: ['HTMLInputElement'],
+    conditions: [
+      {
+        id: 'input-ref-type',
+        label: 'useRef<HTMLInputElement> を使っている',
+        requiredKeywords: ['HTMLInputElement'],
+        explanation: 'input 要素への ref には HTMLInputElement を型引数として渡します。',
+      },
+      {
+        id: 'focus-current',
+        label: 'ref.current?.focus() を呼んでいる',
+        requiredKeywords: ['focus'],
+        explanation: 'current が null の可能性に配慮しながら focus を呼びます。',
+      },
+    ],
     explanation: 'input 要素への ref は useRef<HTMLInputElement>(null) で定義します。useEffect 内で ref.current?.focus() を呼ぶと、マウント時に自動フォーカスされます。',
+    solutionCode: `import { useRef, useEffect } from 'react'
+
+function AutoFocusInput() {
+  const ref = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    ref.current?.focus()
+  }, [])
+
+  return <input ref={ref} placeholder="自動フォーカス" />
+}`,
   },
   challengeTask: {
+    primaryPatternId: 'ts-react-hooks-1',
     patterns: [
       {
         id: 'ts-react-hooks-1',
@@ -218,6 +246,51 @@ function AutoFocusInput() {
           'useState<"light" | "dark"> で theme を管理します',
         ],
         expectedKeywords: ['ThemeContextType', 'createContext', 'useTheme', 'ThemeProvider', 'toggleTheme'],
+        conditions: [
+          {
+            id: 'theme-context-type',
+            label: 'ThemeContextType を定義している',
+            requiredKeywords: ['ThemeContextType', 'theme', 'toggleTheme'],
+            explanation: 'theme と toggleTheme を持つコンテキスト値の型を interface で表します。',
+          },
+          {
+            id: 'create-context',
+            label: 'createContext<ThemeContextType | null> を使っている',
+            requiredKeywords: ['createContext', 'ThemeContextType', 'null'],
+            explanation: 'Provider 外利用を検知できるように null 初期値の型付き Context を作ります。',
+          },
+          {
+            id: 'use-theme-provider',
+            label: 'useTheme と ThemeProvider を実装している',
+            requiredKeywords: ['useTheme', 'ThemeProvider', 'toggleTheme'],
+            explanation: 'null チェック付きのカスタムフックと、値を提供する Provider を実装します。',
+          },
+        ],
+        solutionCode: `import { createContext, useContext, useState } from 'react'
+import type { ReactNode } from 'react'
+
+interface ThemeContextType {
+  theme: 'light' | 'dark'
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextType | null>(null)
+
+function useTheme(): ThemeContextType {
+  const ctx = useContext(ThemeContext)
+  if (ctx === null) throw new Error('ThemeProvider の外で useTheme を使っています')
+  return ctx
+}
+
+function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light')
+  const toggleTheme = () => setTheme((t) => (t === 'light' ? 'dark' : 'light'))
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}`,
         starterCode: `import { createContext, useContext, useState } from 'react'
 import type { ReactNode } from 'react'
 

--- a/apps/web/src/content/typescript-react/steps/ts-react-props.ts
+++ b/apps/web/src/content/typescript-react/steps/ts-react-props.ts
@@ -141,6 +141,8 @@ function SearchBar({ onSearch, onClear }: SearchProps) {
       hint: 'HTML要素名を文字列で渡します。',
       explanation: "ComponentProps<'div'> のようにHTML要素名を文字列で指定すると、そのネイティブ要素のProps型（className, id, style など）を取得できます。",
       choices: ["'div'", "'Div'", 'div', 'HTMLDivElement'],
+      level: 'applied',
+      testedConcept: 'ComponentProps によるネイティブ要素Propsの継承',
     },
   ],
   testTask: {
@@ -154,9 +156,32 @@ function Button({ label, onClick }: ButtonProps) {
   return <button onClick={onClick}>{label}</button>
 }`,
     expectedKeywords: ['label'],
+    conditions: [
+      {
+        id: 'label-string',
+        label: 'label を string 型にしている',
+        requiredKeywords: ['label', 'string'],
+        explanation: 'ボタンに表示する label は文字列として定義します。',
+      },
+      {
+        id: 'onclick-callback',
+        label: 'onClick をコールバック型にしている',
+        requiredKeywords: ['onClick', '() => void'],
+        explanation: 'クリック時に呼ばれる関数は () => void 型で表します。',
+      },
+    ],
     explanation: 'label は string 型、onClick は () => void 型として定義します。interface で Props を定義することでコンポーネントの入力仕様が明確になります。',
+    solutionCode: `interface ButtonProps {
+  label: string
+  onClick: () => void
+}
+
+function Button({ label, onClick }: ButtonProps) {
+  return <button onClick={onClick}>{label}</button>
+}`,
   },
   challengeTask: {
+    primaryPatternId: 'ts-react-props-1',
     patterns: [
       {
         id: 'ts-react-props-1',
@@ -172,6 +197,43 @@ function Button({ label, onClick }: ButtonProps) {
           '条件付きレンダリングは `{prop && <element />}` パターンが便利です',
         ],
         expectedKeywords: ['CardProps', 'title', 'description', 'children', 'ReactNode'],
+        conditions: [
+          {
+            id: 'card-props',
+            label: 'CardProps interface を定義している',
+            requiredKeywords: ['CardProps', 'title', 'description?', 'children?', 'ReactNode'],
+            explanation: 'title は必須、description と children は省略可能な Props として定義します。',
+          },
+          {
+            id: 'card-component',
+            label: 'CardProps を使って Card を実装している',
+            requiredKeywords: ['function Card', 'CardProps'],
+            explanation: 'Card コンポーネントの引数に CardProps を指定して型安全にします。',
+          },
+          {
+            id: 'conditional-description',
+            label: 'description を条件付きで表示している',
+            requiredKeywords: ['description', '<p>'],
+            explanation: 'description がある場合だけ p 要素を描画します。',
+          },
+        ],
+        solutionCode: `import type { ReactNode } from 'react'
+
+interface CardProps {
+  title: string
+  description?: string
+  children?: ReactNode
+}
+
+function Card({ title, description, children }: CardProps) {
+  return (
+    <div>
+      <h2>{title}</h2>
+      {description && <p>{description}</p>}
+      {children}
+    </div>
+  )
+}`,
         starterCode: `import type { ReactNode } from 'react'
 
 // TODO: CardProps interface を定義してください

--- a/apps/web/src/content/typescript-react/steps/ts-react-state.ts
+++ b/apps/web/src/content/typescript-react/steps/ts-react-state.ts
@@ -168,9 +168,28 @@ function UserProfile() {
   return <div>{user ? user.name : '未ログイン'}</div>
 }`,
     expectedKeywords: ['User'],
+    conditions: [
+      {
+        id: 'user-null-state',
+        label: 'useState<User | null> を使っている',
+        requiredKeywords: ['User', 'null'],
+        explanation: '未ログイン状態を表すために User | null のユニオン型を指定します。',
+      },
+    ],
     explanation: '`useState<User | null>(null)` とすることで、ユーザー情報がない状態（null）とある状態（User）を型安全に扱えます。',
+    solutionCode: `interface User {
+  id: number
+  name: string
+}
+
+function UserProfile() {
+  const [user, setUser] = useState<User | null>(null)
+
+  return <div>{user ? user.name : '未ログイン'}</div>
+}`,
   },
   challengeTask: {
+    primaryPatternId: 'ts-react-state-1',
     patterns: [
       {
         id: 'ts-react-state-1',
@@ -187,6 +206,51 @@ function UserProfile() {
           'setUser(userData) でログイン、setUser(null) でログアウトします',
         ],
         expectedKeywords: ['User', 'useState', 'null', 'setUser'],
+        conditions: [
+          {
+            id: 'user-interface',
+            label: 'User interface を定義している',
+            requiredKeywords: ['User', 'id', 'name', 'email'],
+            explanation: 'ログインユーザーの id, name, email を interface で定義します。',
+          },
+          {
+            id: 'nullable-state',
+            label: 'User | null の state を宣言している',
+            requiredKeywords: ['useState', 'User | null', 'null'],
+            explanation: '未ログイン時は null、ログイン後は User を保持できる state にします。',
+          },
+          {
+            id: 'login-logout',
+            label: 'login/logout で setUser を呼んでいる',
+            requiredKeywords: ['setUser', 'null'],
+            explanation: 'ログイン時にユーザーをセットし、ログアウト時に null へ戻します。',
+          },
+        ],
+        solutionCode: `interface User {
+  id: number
+  name: string
+  email: string
+}
+
+function UserProfile() {
+  const [user, setUser] = useState<User | null>(null)
+
+  function handleLogin() {
+    setUser({ id: 1, name: 'Alice', email: 'alice@example.com' })
+  }
+
+  function handleLogout() {
+    setUser(null)
+  }
+
+  return (
+    <div>
+      {user ? <p>{user.name} ({user.email})</p> : <p>ログインしてください</p>}
+      <button onClick={handleLogin}>ログイン</button>
+      <button onClick={handleLogout}>ログアウト</button>
+    </div>
+  )
+}`,
         starterCode: `// TODO: User interface を定義してください
 
 function UserProfile() {

--- a/apps/web/src/content/typescript/steps/ts-functions.ts
+++ b/apps/web/src/content/typescript/steps/ts-functions.ts
@@ -148,9 +148,22 @@ function formatValue(value: string | number): string {
   return a - b;
 }`,
     expectedKeywords: ['add', 'sub'],
+    conditions: [
+      {
+        id: 'literal-union',
+        label: 'operation を add/sub のユニオン型にしている',
+        requiredKeywords: ['add', 'sub'],
+        explanation: 'operation には "add" または "sub" だけを受け付けるリテラルユニオン型を指定します。',
+      },
+    ],
     explanation: '`"add" | "sub"` というリテラルユニオン型を使います。これで operation に無効な文字列を渡すとコンパイルエラーになります。',
+    solutionCode: `function calculate(a: number, b: number, operation: 'add' | 'sub'): number {
+  if (operation === 'add') return a + b;
+  return a - b;
+}`,
   },
   challengeTask: {
+    primaryPatternId: 'ts-functions-1',
     patterns: [
       {
         id: 'ts-functions-1',
@@ -165,6 +178,29 @@ function formatValue(value: string | number): string {
           'predicate は「条件判定関数」という意味。(item: T) => boolean の型を持ちます',
         ],
         expectedKeywords: ['filterByCondition', 'predicate', 'boolean', 'filter'],
+        conditions: [
+          {
+            id: 'generic-signature',
+            label: 'ジェネリックな関数シグネチャになっている',
+            requiredKeywords: ['filterByCondition', '<T>', 'arr: T[]', ': T[]'],
+            explanation: '配列の要素型を T として受け取り、同じ T[] を返す関数にします。',
+          },
+          {
+            id: 'predicate-type',
+            label: 'predicate の型を定義している',
+            requiredKeywords: ['predicate', '(item: T) => boolean'],
+            explanation: 'predicate は各要素を受け取り true/false を返す条件関数です。',
+          },
+          {
+            id: 'use-filter',
+            label: 'arr.filter(predicate) を返している',
+            requiredKeywords: ['filter', 'predicate'],
+            explanation: '実装本体では標準の filter に predicate を渡して結果を返します。',
+          },
+        ],
+        solutionCode: `function filterByCondition<T>(arr: T[], predicate: (item: T) => boolean): T[] {
+  return arr.filter(predicate);
+}`,
         starterCode: `// TODO: filterByCondition 関数に型注釈を追加して実装してください
 function filterByCondition(arr, predicate) {
   return arr.filter(predicate);

--- a/apps/web/src/content/typescript/steps/ts-generics.ts
+++ b/apps/web/src/content/typescript/steps/ts-generics.ts
@@ -145,6 +145,8 @@ getProperty(user, "xyz");  // エラー！user に xyz プロパティはない
       hint: 'obj に存在しないキーを渡したときにコンパイルエラーにできます。',
       explanation: 'K extends keyof T とすることで、key に T のプロパティ名以外を渡すとコンパイルエラーになります。タイポによるバグを防げます。',
       choices: ['存在しないプロパティへのアクセス', 'null参照エラー', '無限ループ', '型の循環参照'],
+      level: 'applied',
+      testedConcept: 'keyof 制約による安全なプロパティアクセス',
     },
   ],
   testTask: {
@@ -153,9 +155,27 @@ getProperty(user, "xyz");  // エラー！user に xyz プロパティはない
   return arr[0];
 }`,
     expectedKeywords: ['T[]', 'T'],
+    conditions: [
+      {
+        id: 'array-argument',
+        label: '引数を T[] 型にしている',
+        requiredKeywords: ['T[]'],
+        explanation: 'getFirst は任意の要素型 T を持つ配列を受け取ります。',
+      },
+      {
+        id: 'return-element',
+        label: '戻り値を T 型にしている',
+        requiredKeywords: ['): T'],
+        explanation: '配列から取り出す1要素は T 型なので、戻り値にも T を指定します。',
+      },
+    ],
     explanation: '引数は T[] 型の配列、戻り値は T 型の要素です。これで getFirst([1,2,3]) の戻り値が number と推論されるようになります。',
+    solutionCode: `function getFirst<T>(arr: T[]): T {
+  return arr[0];
+}`,
   },
   challengeTask: {
+    primaryPatternId: 'ts-generics-1',
     patterns: [
       {
         id: 'ts-generics-1',
@@ -172,6 +192,44 @@ getProperty(user, "xyz");  // エラー！user に xyz プロパティはない
           'ok が true のブランチでは result.value が T 型として使えます',
         ],
         expectedKeywords: ['Result', 'succeed', 'fail', 'unwrap', 'ok'],
+        conditions: [
+          {
+            id: 'result-union',
+            label: 'Result<T> を判別共用体で定義している',
+            requiredKeywords: ['Result', '<T>', 'ok', 'value', 'error'],
+            explanation: '成功時は value、失敗時は error を持つジェネリックな結果型にします。',
+          },
+          {
+            id: 'success-fail-helpers',
+            label: 'succeed/fail を実装している',
+            requiredKeywords: ['succeed', 'fail', 'Result<T>'],
+            explanation: '成功と失敗を作る関数を用意すると、Result<T> を一貫して返せます。',
+          },
+          {
+            id: 'unwrap-result',
+            label: 'unwrap で失敗時に Error を投げている',
+            requiredKeywords: ['unwrap', 'throw', 'Error'],
+            explanation: 'ok が false のときは error を使って例外を投げ、成功時だけ value を返します。',
+          },
+        ],
+        solutionCode: `type Result<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string };
+
+function succeed<T>(value: T): Result<T> {
+  return { ok: true, value };
+}
+
+function fail<T>(error: string): Result<T> {
+  return { ok: false, error };
+}
+
+function unwrap<T>(result: Result<T>): T {
+  if (!result.ok) {
+    throw new Error(result.error);
+  }
+  return result.value;
+}`,
         starterCode: `// TODO: Result<T> 型を定義してください
 
 // TODO: succeed, fail, unwrap を実装してください

--- a/apps/web/src/content/typescript/steps/ts-objects.ts
+++ b/apps/web/src/content/typescript/steps/ts-objects.ts
@@ -177,9 +177,24 @@ const tuple: [string, number] = ["x", 1]; // 2要素固定、型が異なる
 const user: User = { id: 1, name: "Alice" };
 // user.id = 2; // これがコンパイルエラーになることを確認`,
     expectedKeywords: ['readonly'],
+    conditions: [
+      {
+        id: 'readonly-id',
+        label: 'id を readonly にしている',
+        requiredKeywords: ['readonly', 'id'],
+        explanation: '一度作成したユーザーIDを変更できないように readonly を付けます。',
+      },
+    ],
     explanation: 'readonlyを付けることで、一度設定したidを後から変更できなくなります。これはデータの不変性を保証するために使われます。',
+    solutionCode: `interface User {
+  readonly id: number;
+  name: string;
+}
+
+const user: User = { id: 1, name: "Alice" };`,
   },
   challengeTask: {
+    primaryPatternId: 'ts-objects-1',
     patterns: [
       {
         id: 'ts-objects-1',
@@ -194,6 +209,42 @@ const user: User = { id: 1, name: "Alice" };
           'オプショナルプロパティは返り値オブジェクトに含めなくてもOKです',
         ],
         expectedKeywords: ['Article', 'readonly', 'id', 'title', 'content', 'tags', 'createDraft'],
+        conditions: [
+          {
+            id: 'article-interface',
+            label: 'Article interface を定義している',
+            requiredKeywords: ['Article', 'readonly', 'id', 'title', 'content', 'tags', 'publishedAt?'],
+            explanation: '記事の固定ID、本文、タグ、任意の公開日時を interface として表します。',
+          },
+          {
+            id: 'create-draft',
+            label: 'createDraft 関数を実装している',
+            requiredKeywords: ['createDraft', 'Date.now', 'tags'],
+            explanation: '下書き作成時に id を生成し、tags を空配列で初期化します。',
+          },
+          {
+            id: 'omit-published-at',
+            label: 'publishedAt を省略可能にしている',
+            requiredKeywords: ['publishedAt?'],
+            explanation: '下書きでは公開日時がないため、publishedAt はオプショナルにします。',
+          },
+        ],
+        solutionCode: `interface Article {
+  readonly id: number;
+  title: string;
+  content: string;
+  tags: string[];
+  publishedAt?: Date;
+}
+
+function createDraft(title: string, content: string): Article {
+  return {
+    id: Date.now(),
+    title,
+    content,
+    tags: [],
+  };
+}`,
         starterCode: `// TODO: Article interface を定義してください
 
 // TODO: createDraft 関数を実装してください

--- a/apps/web/src/content/typescript/steps/ts-types.ts
+++ b/apps/web/src/content/typescript/steps/ts-types.ts
@@ -139,9 +139,27 @@ let userStatus: Status = "active";
   return "Hello, " + name;
 }`,
     expectedKeywords: ['string'],
+    conditions: [
+      {
+        id: 'argument-type',
+        label: '引数 name を string 型にしている',
+        requiredKeywords: ['name: string'],
+        explanation: 'greet は文字列の名前を受け取るため、引数には string 型を指定します。',
+      },
+      {
+        id: 'return-type',
+        label: '戻り値を string 型にしている',
+        requiredKeywords: ['): string'],
+        explanation: '返す値も文字列なので、関数の戻り値型を string と明示します。',
+      },
+    ],
     explanation: '引数 name は string 型、戻り値も string 型です。戻り値型は推論に任せることもできますが、明示することで意図が明確になります。',
+    solutionCode: `function greet(name: string): string {
+  return "Hello, " + name;
+}`,
   },
   challengeTask: {
+    primaryPatternId: 'ts-types-1',
     patterns: [
       {
         id: 'ts-types-1',
@@ -158,6 +176,36 @@ let userStatus: Status = "active";
           'inStock が false の場合の条件分岐を忘れずに',
         ],
         expectedKeywords: ['Product', 'string', 'number', 'boolean', 'formatProduct'],
+        conditions: [
+          {
+            id: 'define-product',
+            label: 'Product 型を定義している',
+            requiredKeywords: ['Product', 'name', 'string', 'price', 'number', 'inStock', 'boolean'],
+            explanation: '商品データの形として name, price, inStock を持つ Product 型を定義します。',
+          },
+          {
+            id: 'format-function',
+            label: 'formatProduct 関数を実装している',
+            requiredKeywords: ['formatProduct', 'product: Product', 'string'],
+            explanation: 'Product を受け取り、表示用の文字列を返す関数にします。',
+          },
+          {
+            id: 'sold-out-label',
+            label: '在庫なしの表示を分岐している',
+            requiredKeywords: ['inStock', '在庫なし'],
+            explanation: 'inStock が false の場合だけ末尾に在庫なし表示を追加します。',
+          },
+        ],
+        solutionCode: `type Product = {
+  name: string;
+  price: number;
+  inStock: boolean;
+};
+
+function formatProduct(product: Product): string {
+  const base = \`商品名: \${product.name}, 価格: ¥\${product.price}\`;
+  return product.inStock ? base : base + " (在庫なし)";
+}`,
         starterCode: `// TODO: Product 型を定義してください
 
 // TODO: formatProduct 関数を実装してください

--- a/apps/web/src/content/typescript/steps/ts-union-narrowing.ts
+++ b/apps/web/src/content/typescript/steps/ts-union-narrowing.ts
@@ -178,9 +178,24 @@ function getArea(shape: Shape): number {
   return String(value);
 }`,
     expectedKeywords: ['typeof'],
+    conditions: [
+      {
+        id: 'typeof-guard',
+        label: 'typeof で string に絞り込んでいる',
+        requiredKeywords: ['typeof'],
+        explanation: 'typeof value === "string" と書くことで、if ブロック内の value を string として扱えます。',
+      },
+    ],
     explanation: '`typeof value === "string"` で型ガードを適用すると、if ブロック内では value が string 型として扱われ、.toUpperCase() を安全に呼び出せます。',
+    solutionCode: `function processValue(value: string | number): string {
+  if (typeof value === 'string') {
+    return value.toUpperCase();
+  }
+  return String(value);
+}`,
   },
   challengeTask: {
+    primaryPatternId: 'ts-union-narrowing-1',
     patterns: [
       {
         id: 'ts-union-narrowing-1',
@@ -195,17 +210,42 @@ function getArea(shape: Shape): number {
           'switch (res.status) または if (res.status === "success") で分岐できます',
         ],
         expectedKeywords: ['ApiResponse', 'success', 'error', 'handleResponse'],
+        conditions: [
+          {
+            id: 'api-response-union',
+            label: 'ApiResponse 判別共用体を定義している',
+            requiredKeywords: ['ApiResponse', 'success', 'error'],
+            explanation: 'status を共通タグにして success と error の2パターンをユニオン型で表します。',
+          },
+          {
+            id: 'handle-response',
+            label: 'status でレスポンスを分岐している',
+            requiredKeywords: ['handleResponse', 'res.status'],
+            explanation: 'status の値で分岐すると、各ブランチで data/message を安全に参照できます。',
+          },
+          {
+            id: 'return-labels',
+            label: '成功/失敗メッセージを返している',
+            requiredKeywords: ['データ', 'エラー'],
+            explanation: 'success ではデータ、error ではエラーメッセージを文字列にして返します。',
+          },
+        ],
+        solutionCode: `type ApiResponse =
+  | { status: "success"; data: string }
+  | { status: "error"; message: string };
+
+function handleResponse(res: ApiResponse): string {
+  if (res.status === "success") {
+    return "データ: " + res.data;
+  }
+  return "エラー: " + res.message;
+}`,
         starterCode: `// TODO: ApiResponse 型を定義してください
 
 // TODO: handleResponse 関数を実装してください
 function handleResponse(res: ApiResponse): string {
   // TODO: status で分岐して実装
-}
-
-const ok: ApiResponse = { status: "success", data: "ユーザー情報" };
-const ng: ApiResponse = { status: "error", message: "認証エラー" };
-console.log(handleResponse(ok)); // "データ: ユーザー情報"
-console.log(handleResponse(ng)); // "エラー: 認証エラー"`,
+}`,
           mobilePuzzle: {
             type: 'multi',
             codeContext: `____0\n\nfunction handleResponse(res: ApiResponse): string {\n  ____1\n}\n\nconst ok: ApiResponse = { status: "success", data: "ユーザー情報" };\nconst ng: ApiResponse = { status: "error", message: "認証エラー" };\nconsole.log(handleResponse(ok));\nconsole.log(handleResponse(ng));`,

--- a/apps/web/src/content/typescript/steps/ts-utility-types.ts
+++ b/apps/web/src/content/typescript/steps/ts-utility-types.ts
@@ -188,9 +188,25 @@ type StoredUser = Required<Pick<User, "id">> & Partial<Omit<User, "id">>;
 
 type UpdateUser = ____<User>`,
     expectedKeywords: ['Partial'],
+    conditions: [
+      {
+        id: 'use-partial',
+        label: 'Partial<User> を使っている',
+        requiredKeywords: ['Partial', 'User'],
+        explanation: 'User の全プロパティを省略可能にするには Partial<User> を使います。',
+      },
+    ],
     explanation: 'Partial<User>はUserの全プロパティをオプショナル（?付き）にした型を作ります。これでフォーム更新時に一部フィールドだけ渡せるようになります。',
+    solutionCode: `interface User {
+  id: number;
+  name: string;
+  email: string;
+}
+
+type UpdateUser = Partial<User>`,
   },
   challengeTask: {
+    primaryPatternId: 'ts-utility-types-1',
     patterns: [
       {
         id: 'ts-utility-types-1',
@@ -206,6 +222,40 @@ type UpdateUser = ____<User>`,
           '`const { passwordHash: _, ...rest } = user` でスプレッドを使って除外できます',
         ],
         expectedKeywords: ['UserRecord', 'PublicProfile', 'Omit', 'passwordHash', 'toPublicProfile'],
+        conditions: [
+          {
+            id: 'user-record',
+            label: 'UserRecord を定義している',
+            requiredKeywords: ['UserRecord', 'passwordHash', 'role'],
+            explanation: '公開前の元データとして、passwordHash を含む UserRecord を定義します。',
+          },
+          {
+            id: 'public-profile',
+            label: 'Omit で PublicProfile を定義している',
+            requiredKeywords: ['PublicProfile', 'Omit', 'passwordHash'],
+            explanation: 'Omit<UserRecord, "passwordHash"> で機密情報を除いた公開用型を作ります。',
+          },
+          {
+            id: 'to-public-profile',
+            label: 'passwordHash を除いて返している',
+            requiredKeywords: ['toPublicProfile', 'passwordHash', 'return'],
+            explanation: '分割代入と rest 構文で passwordHash を取り除いたオブジェクトを返します。',
+          },
+        ],
+        solutionCode: `interface UserRecord {
+  id: number;
+  name: string;
+  email: string;
+  passwordHash: string;
+  role: "admin" | "user";
+}
+
+type PublicProfile = Omit<UserRecord, "passwordHash">;
+
+function toPublicProfile(user: UserRecord): PublicProfile {
+  const { passwordHash, ...profile } = user;
+  return profile;
+}`,
         starterCode: `// TODO: UserRecord 型を定義してください
 
 // TODO: Omit を使って PublicProfile 型を定義してください


### PR DESCRIPTION
## Summary
- M5-8c対象の typescript + typescript-react 10ステップに primaryPatternId / conditions / solutionCode を反映
- audit指定の応用Practiceラベルを ts-generics / ts-react-props / ts-react-hooks / ts-react-events に追加
- 代表patternのstarterCodeが expectedKeywords を全達成しないことを確認し、ts-union-narrowing のstarterを調整

## Issue
- 新規Issueなし（v6roadmap M5-8c の作業台帳で管理）

## Test
- npm run typecheck
- npm run lint
- npm run test
- npm run build