### PR TITLE
feat: M5-8d React実務系のコンテンツ反映

### DIFF
--- a/apps/web/src/content/react-modern/steps/concurrent-features.ts
+++ b/apps/web/src/content/react-modern/steps/concurrent-features.ts
@@ -144,6 +144,8 @@ const SlowList = memo(function SlowList({ text }) {
       hint: '「遅延した値が変わらないときはスキップする」仕組みが必要です。',
       explanation: 'useDeferredValue で遅延した値を memo でラップしたコンポーネントに渡すと、値が変わらない間は再レンダリングをスキップできます。両方の組み合わせで最大効果を発揮します。',
       choices: ['memo', 'useCallback', 'useMemo', 'useRef'],
+      level: 'applied',
+      testedConcept: 'useDeferredValue と memo の組み合わせ',
     },
     {
       id: 'q5',
@@ -152,6 +154,8 @@ const SlowList = memo(function SlowList({ text }) {
       hint: '同名の関数を直接 import できます。',
       explanation: 'react パッケージから startTransition を直接インポートして使えます。useTransition フックが使えない場所（Redux ミドルウェアなど）で役立ちます。',
       choices: ['startTransition（react から直接インポート）', 'setTimeout', 'requestIdleCallback', 'flushSync'],
+      level: 'applied',
+      testedConcept: 'React ツリー外での startTransition 利用',
     },
   ],
   testTask: {
@@ -178,9 +182,51 @@ function SearchPage({ searchItems }) {
   )
 }`,
     expectedKeywords: ['startTransition'],
+    conditions: [
+      {
+        id: 'immediate-query',
+        label: 'setQuery は即時更新している',
+        requiredKeywords: ['setQuery', 'e.target.value'],
+        explanation: '入力欄の値はユーザー操作に直結するため、transition の外で即時更新します。',
+      },
+      {
+        id: 'start-transition',
+        label: 'startTransition を呼び出している',
+        requiredKeywords: ['startTransition'],
+        explanation: '重い更新は startTransition で非緊急更新として扱います。',
+      },
+      {
+        id: 'transition-results',
+        label: 'setResults を transition 内で呼んでいる',
+        requiredKeywords: ['setResults', 'searchItems'],
+        explanation: '検索結果の更新を transition 内へ入れることで入力の応答性を保ちます。',
+      },
+    ],
     explanation: 'useTransition から [isPending, startTransition] を取得し、重い更新を startTransition(() => { ... }) でラップします。',
+    solutionCode: `import { useState, useTransition } from 'react'
+
+function SearchPage({ searchItems }) {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState([])
+  const [isPending, startTransition] = useTransition()
+
+  function handleChange(e) {
+    setQuery(e.target.value)
+    startTransition(() => {
+      setResults(searchItems(e.target.value))
+    })
+  }
+
+  return (
+    <div>
+      <input value={query} onChange={handleChange} />
+      {isPending ? <p>検索中...</p> : <ul>{results.map(r => <li key={r}>{r}</li>)}</ul>}
+    </div>
+  )
+}`,
   },
   challengeTask: {
+    primaryPatternId: 'concurrent-features-1',
     patterns: [
       {
         id: 'concurrent-features-1',
@@ -197,6 +243,53 @@ function SearchPage({ searchItems }) {
           'isPending を使って検索結果のスタイルを動的に変えます',
         ],
         expectedKeywords: ['useTransition', 'startTransition', 'isPending'],
+        conditions: [
+          {
+            id: 'use-transition',
+            label: 'useTransition で isPending/startTransition を取得している',
+            requiredKeywords: ['useTransition', 'isPending', 'startTransition'],
+            explanation: 'pending 表示と非緊急更新のために useTransition を使います。',
+          },
+          {
+            id: 'split-updates',
+            label: '入力更新と結果更新を分離している',
+            requiredKeywords: ['setQuery', 'startTransition', 'setResults'],
+            explanation: 'setQuery は即時、setResults は transition 内で実行します。',
+          },
+          {
+            id: 'pending-style',
+            label: 'isPending で結果欄の表示を変えている',
+            requiredKeywords: ['isPending', 'opacity-50'],
+            explanation: 'transition 中であることを視覚的に示します。',
+          },
+        ],
+        solutionCode: `import { useState, useTransition } from 'react'
+
+const ITEMS = Array.from({ length: 500 }, (_, i) => ({ id: i, name: 'Item ' + i }))
+
+function SearchApp() {
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState(ITEMS)
+  const [isPending, startTransition] = useTransition()
+
+  function handleChange(e) {
+    setQuery(e.target.value)
+    startTransition(() => {
+      setResults(ITEMS.filter((item) => item.name.includes(e.target.value)))
+    })
+  }
+
+  return (
+    <div>
+      <input value={query} onChange={handleChange} placeholder="検索..." />
+      <ul className={isPending ? 'opacity-50' : ''}>
+        {results.map(item => (
+          <li key={item.id}>{item.name}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}`,
         starterCode: `import { useState, useTransition } from 'react'
 
 const ITEMS = Array.from({ length: 500 }, (_, i) => ({ id: i, name: \`Item \${i}\` }))

--- a/apps/web/src/content/react-modern/steps/error-boundary.ts
+++ b/apps/web/src/content/react-modern/steps/error-boundary.ts
@@ -187,9 +187,47 @@ class ErrorBoundary extends React.Component {
   }
 }`,
     expectedKeywords: ['hasError'],
+    conditions: [
+      {
+        id: 'initial-state',
+        label: 'hasError の初期値を false にしている',
+        requiredKeywords: ['hasError', 'false'],
+        explanation: '通常時は子コンポーネントを表示するため、初期 state は hasError: false にします。',
+      },
+      {
+        id: 'derived-state',
+        label: 'エラー時に hasError を true にしている',
+        requiredKeywords: ['getDerivedStateFromError', 'hasError', 'true'],
+        explanation: 'getDerivedStateFromError で hasError: true を返すとフォールバック UI に切り替わります。',
+      },
+      {
+        id: 'fallback-ui',
+        label: 'hasError 時に fallback UI を返している',
+        requiredKeywords: ['this.state.hasError', 'エラーが発生しました'],
+        explanation: 'hasError が true のときは children ではなくエラー表示を返します。',
+      },
+    ],
     explanation: 'constructor で hasError: false の初期 state を設定します。getDerivedStateFromError がエラーを検知すると hasError: true になり、フォールバック UI が表示されます。',
+    solutionCode: `class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <p>エラーが発生しました</p>
+    }
+    return this.props.children
+  }
+}`,
   },
   challengeTask: {
+    primaryPatternId: 'error-boundary-1',
     patterns: [
       {
         id: 'error-boundary-1',
@@ -207,6 +245,62 @@ class ErrorBoundary extends React.Component {
           'handleReset メソッドで state を { hasError: false, error: null } にリセットします',
         ],
         expectedKeywords: ['getDerivedStateFromError', 'componentDidCatch', 'hasError', 'handleReset'],
+        conditions: [
+          {
+            id: 'derived-state-error',
+            label: 'getDerivedStateFromError で error を保存している',
+            requiredKeywords: ['getDerivedStateFromError', 'hasError', 'error'],
+            explanation: 'エラー発生時に hasError と error を state に保存します。',
+          },
+          {
+            id: 'did-catch-log',
+            label: 'componentDidCatch でログ出力している',
+            requiredKeywords: ['componentDidCatch', 'console.error'],
+            explanation: '副作用であるログ送信や出力は componentDidCatch で行います。',
+          },
+          {
+            id: 'reset-state',
+            label: 'handleReset で state をリセットしている',
+            requiredKeywords: ['handleReset', 'setState', 'hasError', 'false'],
+            explanation: '再試行ボタンから hasError と error を初期状態へ戻します。',
+          },
+          {
+            id: 'fallback-reset-button',
+            label: 'fallback UI と再試行ボタンを表示している',
+            requiredKeywords: ['this.state.hasError', 'this.state.error', '再試行'],
+            explanation: 'エラー時は詳細メッセージと回復操作を表示します。',
+          },
+        ],
+        solutionCode: `class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error, info) {
+    console.error(error, info.componentStack)
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div>
+          <p>エラー: {this.state.error?.message}</p>
+          <button onClick={this.handleReset}>再試行</button>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}`,
         starterCode: `class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props)
@@ -219,10 +313,6 @@ class ErrorBoundary extends React.Component {
 
   componentDidCatch(error, info) {
     // TODO: エラーをコンソール出力
-  }
-
-  handleReset = () => {
-    // TODO: state をリセット
   }
 
   render() {

--- a/apps/web/src/content/react-modern/steps/forward-ref.ts
+++ b/apps/web/src/content/react-modern/steps/forward-ref.ts
@@ -198,6 +198,8 @@ inputRef.current?.focus()  // InputHandle の型で補完が効く
       hint: '`useRef<InputHandle>(null)` のように使います。',
       explanation: 'useImperativeHandle で { focus, clear } などを公開する場合、親側は useRef<InputHandle>(null) とすることで inputRef.current.focus() などに型補完が効きます。',
       choices: ['カスタムハンドルのインターフェース型', 'HTMLInputElement', 'null', 'any'],
+      level: 'applied',
+      testedConcept: 'useImperativeHandle の custom handle 型',
     },
   ],
   testTask: {
@@ -219,9 +221,46 @@ function Form() {
   )
 }`,
     expectedKeywords: ['forwardRef'],
+    conditions: [
+      {
+        id: 'use-forward-ref',
+        label: 'forwardRef でラップしている',
+        requiredKeywords: ['forwardRef'],
+        explanation: '子コンポーネントで親からの ref を受け取るには forwardRef が必要です。',
+      },
+      {
+        id: 'pass-ref',
+        label: 'input に ref を渡している',
+        requiredKeywords: ['ref={ref}'],
+        explanation: 'forwardRef の第2引数 ref を内部 input に転送します。',
+      },
+      {
+        id: 'parent-focus',
+        label: '親側から focus を呼んでいる',
+        requiredKeywords: ['inputRef', 'focus'],
+        explanation: '親の ref.current から input の focus を実行できる構造にします。',
+      },
+    ],
     explanation: 'forwardRef でコンポーネントをラップし、第2引数 ref を input 要素の ref prop に渡します。',
+    solutionCode: `import { forwardRef, useRef } from 'react'
+
+const FancyInput = forwardRef(function FancyInput(props, ref) {
+  return <input ref={ref} className="fancy" {...props} />
+})
+
+function Form() {
+  const inputRef = useRef(null)
+
+  return (
+    <>
+      <FancyInput ref={inputRef} />
+      <button onClick={() => inputRef.current.focus()}>フォーカス</button>
+    </>
+  )
+}`,
   },
   challengeTask: {
+    primaryPatternId: 'forward-ref-1',
     patterns: [
       {
         id: 'forward-ref-1',
@@ -238,6 +277,50 @@ function Form() {
           '送信ハンドラの末尾で inputRef.current?.focus() を呼びます',
         ],
         expectedKeywords: ['forwardRef', 'ref', 'focus'],
+        conditions: [
+          {
+            id: 'forward-ref-wrap',
+            label: 'Input を forwardRef でラップしている',
+            requiredKeywords: ['forwardRef', 'function Input'],
+            explanation: 'Input が親から ref を受け取れるように forwardRef で定義します。',
+          },
+          {
+            id: 'input-ref',
+            label: '内部 input に ref を渡している',
+            requiredKeywords: ['ref={ref}'],
+            explanation: '受け取った ref を実際の input 要素に転送します。',
+          },
+          {
+            id: 'focus-after-submit',
+            label: '送信後に親refから focus を呼んでいる',
+            requiredKeywords: ['inputRef.current', 'focus'],
+            explanation: '親コンポーネント側から送信後に入力欄へフォーカスを戻します。',
+          },
+        ],
+        solutionCode: `import { forwardRef, useRef } from 'react'
+
+const Input = forwardRef(function Input(props, ref) {
+  return <input ref={ref} {...props} />
+})
+
+function SearchForm() {
+  const inputRef = useRef(null)
+
+  function handleSubmit(e) {
+    e.preventDefault()
+    const query = e.target.search.value
+    console.log('検索:', query)
+    e.target.reset()
+    inputRef.current?.focus()
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <Input ref={inputRef} name="search" placeholder="検索..." />
+      <button type="submit">検索</button>
+    </form>
+  )
+}`,
         starterCode: `import { forwardRef, useRef } from 'react'
 
 // TODO: forwardRef を使って Input を実装する（ref を input に転送）

--- a/apps/web/src/content/react-modern/steps/portals.ts
+++ b/apps/web/src/content/react-modern/steps/portals.ts
@@ -174,6 +174,8 @@ function PortalWrapper({ children }) {
       hint: 'useEffect のクリーンアップ関数で後片付けします。',
       explanation: 'useEffect 内で document.createElement → document.body.appendChild し、クリーンアップ関数で document.body.removeChild を呼びます。これでメモリリークを防げます。',
       choices: ['作成した DOM 要素を document.body から削除する', '何もしなくてよい（自動クリーンアップされる）', 'createPortal の戻り値に .destroy() を呼ぶ', 'ReactDOM.unmountComponentAtNode を呼ぶ'],
+      level: 'applied',
+      testedConcept: '動的 Portal container の cleanup',
     },
   ],
   testTask: {
@@ -192,9 +194,43 @@ function Modal({ isOpen, onClose }) {
   )
 }`,
     expectedKeywords: ['createPortal'],
+    conditions: [
+      {
+        id: 'use-create-portal',
+        label: 'createPortal を使っている',
+        requiredKeywords: ['createPortal'],
+        explanation: 'Portal 描画には react-dom の createPortal を使います。',
+      },
+      {
+        id: 'body-target',
+        label: '描画先に document.body を指定している',
+        requiredKeywords: ['document.body'],
+        explanation: 'モーダルを body 直下に描画して親DOMの制約を避けます。',
+      },
+      {
+        id: 'closed-null',
+        label: 'isOpen が false のとき null を返している',
+        requiredKeywords: ['isOpen', 'return null'],
+        explanation: '閉じているときは何もレンダリングしません。',
+      },
+    ],
     explanation: 'react-dom から createPortal をインポートし、createPortal(children, document.body) でモーダルを body 直下にレンダリングします。',
+    solutionCode: `import { createPortal } from 'react-dom'
+
+function Modal({ isOpen, onClose }) {
+  if (!isOpen) return null
+
+  return createPortal(
+    <div>
+      <p>モーダルの中身</p>
+      <button onClick={onClose}>閉じる</button>
+    </div>,
+    document.body
+  )
+}`,
   },
   challengeTask: {
+    primaryPatternId: 'portals-1',
     patterns: [
       {
         id: 'portals-1',
@@ -210,6 +246,42 @@ function Modal({ isOpen, onClose }) {
           'createPortal の第2引数は document.body です',
         ],
         expectedKeywords: ['createPortal', 'document.body', 'stopPropagation'],
+        conditions: [
+          {
+            id: 'early-return',
+            label: 'isOpen が false のとき null を返している',
+            requiredKeywords: ['!isOpen', 'return null'],
+            explanation: '閉じている状態では Portal を作らず null を返します。',
+          },
+          {
+            id: 'body-portal',
+            label: 'document.body へ createPortal している',
+            requiredKeywords: ['createPortal', 'document.body'],
+            explanation: 'モーダルを body 直下へ描画します。',
+          },
+          {
+            id: 'stop-propagation',
+            label: 'モーダル内クリックの伝播を止めている',
+            requiredKeywords: ['stopPropagation'],
+            explanation: 'コンテンツ内クリックで overlay の onClose が発火しないようにします。',
+          },
+        ],
+        solutionCode: `import { createPortal } from 'react-dom'
+import { useState } from 'react'
+
+function Modal({ isOpen, onClose, children }) {
+  if (!isOpen) return null
+
+  return createPortal(
+    <div className="overlay" onClick={onClose}>
+      <div className="content" onClick={(e) => e.stopPropagation()}>
+        {children}
+        <button onClick={onClose}>閉じる</button>
+      </div>
+    </div>,
+    document.body
+  )
+}`,
         starterCode: `import { createPortal } from 'react-dom'
 import { useState } from 'react'
 

--- a/apps/web/src/content/react-modern/steps/suspense-lazy.ts
+++ b/apps/web/src/content/react-modern/steps/suspense-lazy.ts
@@ -160,6 +160,8 @@ function App() {
       hint: 'ネットワークエラーが発生したときのフォールバック UI を提供します。',
       explanation: 'ネットワークエラーなどで lazy コンポーネントの読み込みが失敗した場合、Error Boundary がエラーをキャッチしてフォールバック UI を表示します。Suspense と組み合わせて使うのがベストプラクティスです。',
       choices: ['Error Boundary', 'try/catch', 'useErrorHandler', 'onError prop'],
+      level: 'applied',
+      testedConcept: 'lazy 読み込み失敗時の Error Boundary 連携',
     },
   ],
   testTask: {
@@ -176,9 +178,41 @@ function App() {
   )
 }`,
     expectedKeywords: ['lazy'],
+    conditions: [
+      {
+        id: 'use-lazy',
+        label: 'lazy で遅延読み込みしている',
+        requiredKeywords: ['lazy', 'import'],
+        explanation: 'lazy(() => import(...)) でコンポーネントを別チャンクとして読み込みます。',
+      },
+      {
+        id: 'wrap-suspense',
+        label: 'Suspense でラップしている',
+        requiredKeywords: ['Suspense', 'HeavyComponent'],
+        explanation: 'lazy コンポーネントは Suspense の内側でレンダリングします。',
+      },
+      {
+        id: 'fallback-ui',
+        label: 'fallback に読み込み中UIを渡している',
+        requiredKeywords: ['fallback', '読み込み中'],
+        explanation: '読み込み完了まで表示する fallback UI を指定します。',
+      },
+    ],
     explanation: 'React.lazy（または import した lazy）と動的 import() を組み合わせてコンポーネントを遅延読み込みします。Suspense の fallback にローディング UI を渡します。',
+    solutionCode: `import { Suspense, lazy } from 'react'
+
+const HeavyComponent = lazy(() => import('./HeavyComponent'))
+
+function App() {
+  return (
+    <Suspense fallback={<p>読み込み中...</p>}>
+      <HeavyComponent />
+    </Suspense>
+  )
+}`,
   },
   challengeTask: {
+    primaryPatternId: 'suspense-lazy-1',
     patterns: [
       {
         id: 'suspense-lazy-1',
@@ -195,6 +229,44 @@ function App() {
           'Error Boundary は Suspense の外側に配置します',
         ],
         expectedKeywords: ['lazy', 'Suspense', 'fallback', 'import'],
+        conditions: [
+          {
+            id: 'lazy-pages',
+            label: '3ページを lazy import している',
+            requiredKeywords: ['lazy', 'HomePage', 'AboutPage', 'ContactPage', 'import'],
+            explanation: '各ページを lazy(() => import(...)) で個別に遅延読み込みします。',
+          },
+          {
+            id: 'suspense-fallback',
+            label: 'Suspense fallback で Routes を包んでいる',
+            requiredKeywords: ['Suspense', 'fallback', 'Routes'],
+            explanation: 'Routes 全体を Suspense で包み、ページ読み込み中のUIを表示します。',
+          },
+          {
+            id: 'route-elements',
+            label: '各ルートに lazy ページを割り当てている',
+            requiredKeywords: ['Route', 'HomePage', 'AboutPage', 'ContactPage'],
+            explanation: 'Route の element に遅延読み込みしたページコンポーネントを指定します。',
+          },
+        ],
+        solutionCode: `import { Suspense, lazy } from 'react'
+import { Routes, Route } from 'react-router-dom'
+
+const HomePage = lazy(() => import('./pages/HomePage'))
+const AboutPage = lazy(() => import('./pages/AboutPage'))
+const ContactPage = lazy(() => import('./pages/ContactPage'))
+
+function App() {
+  return (
+    <Suspense fallback={<p>読み込み中...</p>}>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/about" element={<AboutPage />} />
+        <Route path="/contact" element={<ContactPage />} />
+      </Routes>
+    </Suspense>
+  )
+}`,
         starterCode: `import { Suspense, lazy } from 'react'
 import { Routes, Route } from 'react-router-dom'
 

--- a/apps/web/src/content/react-modern/steps/use-optimistic.ts
+++ b/apps/web/src/content/react-modern/steps/use-optimistic.ts
@@ -172,11 +172,18 @@ function App({ items, addItem }) {
     },
     {
       id: 'q5',
-      prompt: '`useOptimistic` が対応しているのは React の何番以降？',
-      answer: 'React 19',
-      hint: '比較的新しいフックです。',
-      explanation: 'useOptimistic は React 19 で追加された新しいフックです。Server Actions と組み合わせる場面で特に効果を発揮します。',
-      choices: ['React 19', 'React 18', 'React 17', 'React 16'],
+      prompt: '`useOptimistic(state, updateFn)` の updateFn で守るべきことは？',
+      answer: '現在の state と payload から新しい state を返す純粋関数にする',
+      hint: '副作用や直接変更ではなく、新しい楽観的 state を返します。',
+      explanation: 'updateFn は (currentState, payload) を受け取り、直接 state を変更せずに新しい楽観的 state を返す純粋関数にします。失敗時のロールバックもこの前提で扱いやすくなります。',
+      choices: [
+        '現在の state と payload から新しい state を返す純粋関数にする',
+        'currentState を直接 push して同じ配列を返す',
+        'updateFn の中で fetch を実行する',
+        '必ず React のバージョン番号を返す',
+      ],
+      level: 'applied',
+      testedConcept: 'useOptimistic updateFn とロールバック前提',
     },
   ],
   testTask: {
@@ -208,9 +215,56 @@ function MessageList({ messages, sendMessage }) {
   )
 }`,
     expectedKeywords: ['useOptimistic'],
+    conditions: [
+      {
+        id: 'use-optimistic',
+        label: 'useOptimistic を呼び出している',
+        requiredKeywords: ['useOptimistic'],
+        explanation: '実stateから楽観的stateを作るために useOptimistic を使います。',
+      },
+      {
+        id: 'optimistic-update-fn',
+        label: 'updateFn で送信中メッセージを追加している',
+        requiredKeywords: ['sending: true', 'text: newText'],
+        explanation: 'updateFn は既存stateに sending フラグ付きの一時メッセージを追加します。',
+      },
+      {
+        id: 'call-add-optimistic',
+        label: '送信時に addOptimisticMessage を呼んでいる',
+        requiredKeywords: ['addOptimisticMessage', 'sendMessage'],
+        explanation: 'サーバー送信前に楽観的更新を発火させます。',
+      },
+    ],
     explanation: 'useOptimistic(state, updateFn) でフックを呼び出し、楽観的な状態と更新関数を取得します。',
+    solutionCode: `import { useOptimistic } from 'react'
+
+function MessageList({ messages, sendMessage }) {
+  const [optimisticMessages, addOptimisticMessage] = useOptimistic(
+    messages,
+    (state, newText) => [...state, { id: Date.now(), text: newText, sending: true }]
+  )
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+    const text = e.target.message.value
+    e.target.reset()
+    addOptimisticMessage(text)
+    await sendMessage(text)
+  }
+
+  return (
+    <ul>
+      {optimisticMessages.map((msg) => (
+        <li key={msg.id} style={{ opacity: msg.sending ? 0.5 : 1 }}>
+          {msg.text}
+        </li>
+      ))}
+    </ul>
+  )
+}`,
   },
   challengeTask: {
+    primaryPatternId: 'use-optimistic-1',
     patterns: [
       {
         id: 'use-optimistic-1',
@@ -227,6 +281,52 @@ function MessageList({ messages, sendMessage }) {
           'startTransition 内で addOptimisticLike と await toggleLike を呼びます',
         ],
         expectedKeywords: ['useOptimistic', 'addOptimistic'],
+        conditions: [
+          {
+            id: 'optimistic-state',
+            label: 'useOptimistic で post を楽観的に更新している',
+            requiredKeywords: ['useOptimistic', 'optimisticPost', 'addOptimisticLike'],
+            explanation: 'post から optimisticPost と楽観的更新関数を取得します。',
+          },
+          {
+            id: 'update-likes',
+            label: 'updateFn で likes と liked を更新している',
+            requiredKeywords: ['likes', 'state.likes + 1', 'liked', '!state.liked'],
+            explanation: 'いいね数を増やし、liked を反転した楽観的な post を返します。',
+          },
+          {
+            id: 'transition-submit',
+            label: 'startTransition 内で楽観的更新と送信を行っている',
+            requiredKeywords: ['startTransition', 'addOptimisticLike', 'toggleLike'],
+            explanation: '楽観的更新とサーバー送信を transition の中で実行します。',
+          },
+        ],
+        solutionCode: `import { useOptimistic, useTransition } from 'react'
+
+function LikeButton({ post, toggleLike }) {
+  const [isPending, startTransition] = useTransition()
+  const [optimisticPost, addOptimisticLike] = useOptimistic(
+    post,
+    (state) => ({
+      ...state,
+      likes: state.likes + 1,
+      liked: !state.liked,
+    })
+  )
+
+  function handleClick() {
+    startTransition(async () => {
+      addOptimisticLike()
+      await toggleLike(post.id)
+    })
+  }
+
+  return (
+    <button onClick={handleClick} disabled={isPending}>
+      {optimisticPost.liked ? '❤️' : '🤍'} {optimisticPost.likes}
+    </button>
+  )
+}`,
         starterCode: `import { useOptimistic, useTransition } from 'react'
 
 function LikeButton({ post, toggleLike }) {

--- a/apps/web/src/content/react-patterns/steps/auth-flow.ts
+++ b/apps/web/src/content/react-patterns/steps/auth-flow.ts
@@ -210,6 +210,8 @@ function ProtectedRoute({ children }) {
       hint: 'JavaScript からアクセスできない Cookie の種類です。',
       explanation: 'HttpOnly Cookie は JavaScript の document.cookie からアクセスできないため、XSS でスクリプトが注入されてもトークンを盗めません。localStorage は JavaScript でアクセス可能なため XSS に脆弱です。',
       choices: ['HttpOnly Cookie', 'localStorage', 'sessionStorage', 'メモリ（変数）'],
+      level: 'applied',
+      testedConcept: 'トークン保存場所とXSS耐性',
     },
     {
       id: 'q4',
@@ -240,9 +242,39 @@ function ProtectedRoute({ children }) {
   return <>{children}</>
 }`,
     expectedKeywords: ['isAuthenticated'],
+    conditions: [
+      {
+        id: 'read-auth-state',
+        label: 'isAuthenticated を参照している',
+        requiredKeywords: ['isAuthenticated'],
+        explanation: 'useAuth から認証状態を受け取り、ルート保護の判定に使います。',
+      },
+      {
+        id: 'redirect-login',
+        label: '未認証時に /login へリダイレクトしている',
+        requiredKeywords: ['Navigate', '/login'],
+        explanation: '未認証ならログイン画面へ遷移させます。',
+      },
+      {
+        id: 'render-children',
+        label: '認証済みなら children を返している',
+        requiredKeywords: ['children'],
+        explanation: '認証済みの場合は保護対象の子要素を表示します。',
+      },
+    ],
     explanation: 'isAuthenticated が false のとき <Navigate to="/login" replace /> でリダイレクトします。replace オプションでブラウザ履歴に残さないようにします。',
+    solutionCode: `function ProtectedRoute({ children }) {
+  const { isAuthenticated } = useAuth()
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />
+  }
+
+  return <>{children}</>
+}`,
   },
   challengeTask: {
+    primaryPatternId: 'auth-flow-1',
     patterns: [
       {
         id: 'auth-flow-1',
@@ -260,6 +292,71 @@ function ProtectedRoute({ children }) {
           'useContext が null を返した場合は throw new Error(...) で異常を通知します',
         ],
         expectedKeywords: ['createContext', 'useContext', 'isAuthenticated', 'AuthProvider'],
+        conditions: [
+          {
+            id: 'context-types',
+            label: 'User/AuthContextValue 型と Context を用意している',
+            requiredKeywords: ['User', 'AuthContextValue', 'createContext'],
+            explanation: '認証状態と操作関数の共有形を型として定義し、Context を作ります。',
+          },
+          {
+            id: 'provider-value',
+            label: 'AuthProvider value に認証状態と関数を渡している',
+            requiredKeywords: ['AuthProvider', 'isAuthenticated', 'login', 'logout'],
+            explanation: 'user、isAuthenticated、login、logout を Provider 経由で共有します。',
+          },
+          {
+            id: 'login-logout',
+            label: 'login/logout で user を更新している',
+            requiredKeywords: ['setUser', 'email', 'null'],
+            explanation: 'login でユーザーをセットし、logout で null に戻します。',
+          },
+          {
+            id: 'use-auth-hook',
+            label: 'useAuth hook で null チェックしている',
+            requiredKeywords: ['useContext', 'throw', 'AuthProvider'],
+            explanation: 'Provider 外利用を検出し、正常時は context value を返します。',
+          },
+        ],
+        solutionCode: `import { createContext, useContext, useState } from 'react'
+
+type User = {
+  id: string
+  email: string
+}
+
+type AuthContextValue = {
+  user: User | null
+  isAuthenticated: boolean
+  login: (email: string, password: string) => Promise<void>
+  logout: () => void
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null)
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState<User | null>(null)
+
+  const login = async (email, password) => {
+    setUser({ id: '1', email })
+  }
+
+  const logout = () => {
+    setUser(null)
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, isAuthenticated: !!user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider')
+  return ctx
+}`,
         starterCode: `import { createContext, useContext, useState } from 'react'
 
 // TODO: User 型と AuthContextValue 型を定義

--- a/apps/web/src/content/react-patterns/steps/infinite-scroll.ts
+++ b/apps/web/src/content/react-patterns/steps/infinite-scroll.ts
@@ -193,9 +193,29 @@ useEffect(() => {
   }
 })`,
     expectedKeywords: ['isIntersecting'],
+    conditions: [
+      {
+        id: 'check-intersecting',
+        label: 'entry.isIntersecting を確認している',
+        requiredKeywords: ['isIntersecting'],
+        explanation: 'センチネルが表示領域に入ったかを isIntersecting で判定します。',
+      },
+      {
+        id: 'call-load-more',
+        label: '表示されたら loadMore を呼んでいる',
+        requiredKeywords: ['loadMore'],
+        explanation: 'センチネルが見えたタイミングで追加データを読み込みます。',
+      },
+    ],
     explanation: 'entries[0].isIntersecting が true のとき、センチネル要素がビューポートに入ったことを意味します。このタイミングで loadMore() を呼び出します。',
+    solutionCode: `const observer = new IntersectionObserver((entries) => {
+  if (entries[0].isIntersecting) {
+    loadMore()
+  }
+})`,
   },
   challengeTask: {
+    primaryPatternId: 'infinite-scroll-1',
     patterns: [
       {
         id: 'infinite-scroll-1',
@@ -213,6 +233,80 @@ useEffect(() => {
           'クリーンアップ: return () => observer.disconnect()',
         ],
         expectedKeywords: ['IntersectionObserver', 'isIntersecting', 'sentinelRef', 'hasMore', 'disconnect'],
+        conditions: [
+          {
+            id: 'observer-setup',
+            label: 'IntersectionObserver を作成している',
+            requiredKeywords: ['IntersectionObserver', 'isIntersecting'],
+            explanation: 'センチネルの表示状態を IntersectionObserver で監視します。',
+          },
+          {
+            id: 'load-more-guard',
+            label: 'isIntersecting かつ hasMore のとき loadMore している',
+            requiredKeywords: ['isIntersecting', 'hasMore', 'loadMore'],
+            explanation: '追加データがある場合だけ読み込みを発火させます。',
+          },
+          {
+            id: 'observe-sentinel',
+            label: 'sentinelRef.current を observe している',
+            requiredKeywords: ['sentinelRef.current', 'observe'],
+            explanation: 'リスト末尾のセンチネル要素を監視対象にします。',
+          },
+          {
+            id: 'cleanup',
+            label: 'cleanup で disconnect している',
+            requiredKeywords: ['disconnect'],
+            explanation: 'effect の再実行やアンマウント時に observer を解除します。',
+          },
+          {
+            id: 'sentinel-render',
+            label: 'hasMore 時にセンチネル要素を表示している',
+            requiredKeywords: ['hasMore', 'ref={sentinelRef}'],
+            explanation: '追加ロード可能な間だけセンチネルを表示します。',
+          },
+        ],
+        solutionCode: `function InfiniteList() {
+  const [items, setItems] = useState(generateItems(1, 10))
+  const [hasMore, setHasMore] = useState(true)
+  const [page, setPage] = useState(1)
+  const sentinelRef = useRef(null)
+
+  function generateItems(start, count) {
+    return Array.from({ length: count }, (_, i) => ({
+      id: start + i,
+      name: 'アイテム ' + (start + i),
+    }))
+  }
+
+  const loadMore = () => {
+    const newItems = generateItems(page * 10 + 1, 10)
+    setItems((prev) => [...prev, ...newItems])
+    setPage((p) => p + 1)
+    if (page >= 4) setHasMore(false)
+  }
+
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && hasMore) {
+        loadMore()
+      }
+    })
+    if (sentinelRef.current) observer.observe(sentinelRef.current)
+    return () => observer.disconnect()
+  }, [hasMore, page])
+
+  return (
+    <div style={{ height: '400px', overflowY: 'auto' }}>
+      {items.map((item) => (
+        <div key={item.id} style={{ padding: '12px', borderBottom: '1px solid #eee' }}>
+          {item.name}
+        </div>
+      ))}
+      {hasMore && <div ref={sentinelRef}>読み込み中...</div>}
+      {!hasMore && <p>すべて読み込みました</p>}
+    </div>
+  )
+}`,
         starterCode: `function InfiniteList() {
   const [items, setItems] = useState(generateItems(1, 10))
   const [hasMore, setHasMore] = useState(true)

--- a/apps/web/src/content/react-patterns/steps/pagination.ts
+++ b/apps/web/src/content/react-patterns/steps/pagination.ts
@@ -222,9 +222,27 @@ function ProductList() {
 
 const totalPages = Math.ceil(____ / ITEMS_PER_PAGE)`,
     expectedKeywords: ['totalCount'],
+    conditions: [
+      {
+        id: 'math-ceil',
+        label: 'Math.ceil で切り上げている',
+        requiredKeywords: ['Math.ceil'],
+        explanation: '端数ページを数えるため、総ページ数は Math.ceil で切り上げます。',
+      },
+      {
+        id: 'total-count',
+        label: 'totalCount / ITEMS_PER_PAGE を計算している',
+        requiredKeywords: ['totalCount', 'ITEMS_PER_PAGE'],
+        explanation: '全件数を1ページあたりの件数で割って総ページ数を求めます。',
+      },
+    ],
     explanation: 'Math.ceil(totalCount / ITEMS_PER_PAGE) で端数を切り上げて総ページ数を計算します。',
+    solutionCode: `const ITEMS_PER_PAGE = 10
+
+const totalPages = Math.ceil(totalCount / ITEMS_PER_PAGE)`,
   },
   challengeTask: {
+    primaryPatternId: 'pagination-2',
     patterns: [
       {
         id: 'pagination-1',
@@ -308,14 +326,70 @@ function PaginatedList() {
           'Array.from({ length: totalPages }, (_, i) => i + 1) でページ番号配列を生成します',
         ],
         expectedKeywords: ['useSearchParams', 'searchParams', 'setSearchParams'],
+        conditions: [
+          {
+            id: 'read-page-query',
+            label: 'useSearchParams で page を取得している',
+            requiredKeywords: ['useSearchParams', 'searchParams.get', 'page'],
+            explanation: 'URL の ?page=N から現在ページを読み取ります。',
+          },
+          {
+            id: 'page-calculation',
+            label: 'totalPages / currentItems を計算している',
+            requiredKeywords: ['Math.ceil', 'slice', 'ITEMS_PER_PAGE'],
+            explanation: '現在ページに対応する範囲だけを slice で切り出します。',
+          },
+          {
+            id: 'set-search-params',
+            label: 'setSearchParams でページ変更している',
+            requiredKeywords: ['setSearchParams', 'String(page)'],
+            explanation: 'ボタンクリックでURLの page クエリを更新します。',
+          },
+          {
+            id: 'page-buttons',
+            label: 'ページ番号ボタンを並べている',
+            requiredKeywords: ['Array.from', 'totalPages', 'button'],
+            explanation: '1から totalPages までのページ番号を表示します。',
+          },
+        ],
+        solutionCode: `import { useSearchParams } from 'react-router-dom'
+
+const items = Array.from({ length: 30 }, (_, i) => 'アイテム ' + (i + 1))
+const ITEMS_PER_PAGE = 8
+
+function PaginatedList() {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const currentPage = Number(searchParams.get('page') ?? '1')
+
+  const totalPages = Math.ceil(items.length / ITEMS_PER_PAGE)
+  const startIndex = (currentPage - 1) * ITEMS_PER_PAGE
+  const currentItems = items.slice(startIndex, startIndex + ITEMS_PER_PAGE)
+
+  return (
+    <div>
+      <ul>
+        {currentItems.map((item, i) => (
+          <li key={i}>{item}</li>
+        ))}
+      </ul>
+      <div>
+        {Array.from({ length: totalPages }, (_, i) => i + 1).map((page) => (
+          <button key={page} onClick={() => setSearchParams({ page: String(page) })}>
+            {page}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}`,
         starterCode: `import { useSearchParams } from 'react-router-dom'
 
 const items = Array.from({ length: 30 }, (_, i) => \`アイテム \${i + 1}\`)
 const ITEMS_PER_PAGE = 8
 
 function PaginatedList() {
-  const [searchParams, setSearchParams] = useSearchParams()
-  // TODO: currentPage を searchParams から取得（デフォルト1）
+  // TODO: useSearchParams でURLの page を読み書きする
+  // TODO: currentPage をURLから取得（デフォルト1）
 
   // TODO: totalPages と currentItems を計算
 

--- a/apps/web/src/content/react-patterns/steps/rhf-zod.ts
+++ b/apps/web/src/content/react-patterns/steps/rhf-zod.ts
@@ -194,9 +194,28 @@ useForm({
   password: z.string().min(8, 'パスワードは8文字以上です'),
 })`,
     expectedKeywords: ['email'],
+    conditions: [
+      {
+        id: 'email-schema',
+        label: 'email に z.string().email() を使っている',
+        requiredKeywords: ['email', 'z.string', '.email'],
+        explanation: 'メールアドレスには z.string().email() で形式チェックを付けます。',
+      },
+      {
+        id: 'password-min',
+        label: 'password に8文字以上の制約を付けている',
+        requiredKeywords: ['password', 'min(8'],
+        explanation: 'password は z.string().min(8, ...) で最小文字数を指定します。',
+      },
+    ],
     explanation: 'z.string().email() でメール形式のバリデーションを追加します。引数にエラーメッセージを渡すことができます。',
+    solutionCode: `const loginSchema = z.object({
+  email: z.string().email('有効なメールアドレスを入力してください'),
+  password: z.string().min(8, 'パスワードは8文字以上です'),
+})`,
   },
   challengeTask: {
+    primaryPatternId: 'rhf-zod-1',
     patterns: [
       {
         id: 'rhf-zod-1',
@@ -214,6 +233,70 @@ useForm({
           'errors.email?.message でエラーメッセージにアクセスします',
         ],
         expectedKeywords: ['zodResolver', 'register', 'handleSubmit', 'errors'],
+        conditions: [
+          {
+            id: 'schema-and-type',
+            label: 'Zod schema と z.infer 型を定義している',
+            requiredKeywords: ['z.object', 'email', 'password', 'z.infer'],
+            explanation: 'Zod の schema からフォームデータ型を一元的に生成します。',
+          },
+          {
+            id: 'resolver',
+            label: 'useForm に zodResolver を設定している',
+            requiredKeywords: ['useForm', 'resolver', 'zodResolver'],
+            explanation: 'RHF のバリデーションとして Zod schema を接続します。',
+          },
+          {
+            id: 'register-submit',
+            label: 'register と handleSubmit を使っている',
+            requiredKeywords: ['register', 'handleSubmit'],
+            explanation: '入力フィールド登録と送信処理を React Hook Form に任せます。',
+          },
+          {
+            id: 'error-display',
+            label: 'errors からメッセージを表示している',
+            requiredKeywords: ['errors.email', 'errors.password'],
+            explanation: 'Zod/RHF が返したエラーをフィールドごとに表示します。',
+          },
+        ],
+        solutionCode: `import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+
+const schema = z.object({
+  email: z.string().email('有効なメールアドレスを入力してください'),
+  password: z.string().min(8, 'パスワードは8文字以上です'),
+})
+
+type FormData = z.infer<typeof schema>
+
+function LoginForm() {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+  })
+
+  const onSubmit = (data: FormData) => {
+    console.log('送信:', data)
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <div>
+        <input {...register('email')} placeholder="メールアドレス" />
+        {errors.email && <p>{errors.email.message}</p>}
+      </div>
+      <div>
+        <input {...register('password')} type="password" placeholder="パスワード" />
+        {errors.password && <p>{errors.password.message}</p>}
+      </div>
+      <button type="submit">ログイン</button>
+    </form>
+  )
+}`,
         starterCode: `import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'


### PR DESCRIPTION
## Summary
- M5-8d対象の react-modern + react-patterns 10ステップに primaryPatternId / conditions / solutionCode を反映
- audit指定の応用Practiceラベルを suspense-lazy / concurrent-features / portals / forward-ref / auth-flow に追加し、use-optimistic q5 を updateFn/rollback 観点へ補強
- pagination は audit指定どおり `pagination-2` を代表に固定
- 代表patternのstarterCodeが expectedKeywords を全達成しないことを確認し、error-boundary / pagination のstarterを調整

## Issue
- 新規Issueなし（v6roadmap M5-8d の作業台帳で管理）

## Test
- starter expectedKeywords 全一致ガード: pass
- npm run typecheck
- npm run lint
- npm run test
- npm run build