### PR TITLE
test: M6 E2Eの不足条件表示期待値を更新

### DIFF
--- a/apps/web/e2e/learning.spec.ts
+++ b/apps/web/e2e/learning.spec.ts
@@ -47,7 +47,9 @@ test.describe('S-LEARN 学習フロー（認証済み・complete）', () => {
     await blank.fill('wrong')
     await page.getByRole('button', { name: '判定する' }).click()
 
-    await expect(page.getByText('必要キーワードを満たしていません。')).toBeVisible()
+    await expect(page.getByText('もう少しです。条件を確認してみましょう。')).toBeVisible()
+    await expect(page.getByText('以下の条件を満たせているか確認しましょう:')).toBeVisible()
+    await expect(page.getByText(/現在値から1引いた値を渡している/)).toBeVisible()
     await expect(page.getByText('解説').first()).toBeVisible()
   })
 


### PR DESCRIPTION
## Summary
- learning E2E の Test誤答時期待値をM5-6後の不足条件UIに更新
- 旧文言ではなく、条件確認メッセージ・不足条件ラベル・解説表示を確認するように変更

## Test plan
- E2E_BASE_URL=http://127.0.0.1:5175 npx playwright test apps/web/e2e/auth.setup.ts --project=setup --reporter=list --timeout=60000
- E2E_BASE_URL=http://127.0.0.1:5175 npx playwright test apps/web/e2e/learning.spec.ts --project=chromium --no-deps --reporter=list --timeout=60000
- cmd /c npm run lint